### PR TITLE
Inline PR diff viewer + key-hint visibility (v0.12.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/alecthomas/chroma/v2 v2.20.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
@@ -17,7 +18,6 @@ require (
 
 require (
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
-	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -34,6 +34,7 @@ import (
 // they're just numbers, not leaking titles or repo names.
 type Client struct {
 	gql           *githubv4.Client
+	rest          *http.Client // shares the oauth2 transport with gql; never nil — falls back to http.DefaultClient for unauthenticated sessions
 	authenticated bool
 	login         string
 	publicOnly    bool
@@ -422,8 +423,13 @@ func New(login string, opts Options) (*Client, error) {
 				"or pass a username: octoscope <username>",
 		)
 	}
+	rest := httpClient
+	if rest == nil {
+		rest = http.DefaultClient
+	}
 	return &Client{
 		gql:           githubv4.NewClient(httpClient),
+		rest:          rest,
 		authenticated: authed,
 		login:         login,
 		publicOnly:    opts.PublicOnly,

--- a/internal/github/pr_detail.go
+++ b/internal/github/pr_detail.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/shurcooL/githubv4"
@@ -67,6 +68,14 @@ type PRDetail struct {
 
 	// Labels
 	Labels []LabelSummary
+
+	// Files is the per-file changeset of the PR, fetched in
+	// parallel with the GraphQL drill-in via REST (the v4 gateway
+	// doesn't expose the raw `patch` body). Populated by
+	// FetchPRFiles (see pr_files.go). Empty when the PR has no
+	// changed files or when the fetch came back from a code path
+	// that doesn't request them.
+	Files []FileChange
 }
 
 // ReviewSummary is one entry in PRDetail.Reviews — the latest
@@ -275,10 +284,51 @@ func (c *Client) FetchPRDetail(ctx context.Context, owner, name string, number i
 		"name":   githubv4.String(name),
 		"number": githubv4.Int(number),
 	}
-	if err := c.gql.Query(ctx, &q, variables); err != nil {
-		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+
+	// GraphQL drill-in (metadata, reviewers, checks, timeline)
+	// runs in parallel with the REST per-file changeset call —
+	// same idiom as the split dashboard fetch from v0.10.1, just
+	// scoped to one PR. Wall-clock latency stays close to the
+	// slower of the two rather than their sum, which matters
+	// because /pulls/{n}/files paginates for PRs touching more
+	// than filesPerPage files.
+	//
+	// First error from either side aborts the whole fetch — a
+	// half-populated PRDetail (metadata but no files, or files
+	// but no header) would render misleadingly in the drill-in
+	// where users expect either "everything" or "error retry".
+	var (
+		wg       sync.WaitGroup
+		gqlErr   error
+		files    []FileChange
+		filesErr error
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if err := c.gql.Query(ctx, &q, variables); err != nil {
+			gqlErr = &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		f, err := c.FetchPRFiles(ctx, owner, name, number)
+		if err != nil {
+			filesErr = err
+			return
+		}
+		files = f
+	}()
+	wg.Wait()
+	if gqlErr != nil {
+		return nil, gqlErr
 	}
-	return extractPRDetail(owner, name, q), nil
+	if filesErr != nil {
+		return nil, filesErr
+	}
+	d := extractPRDetail(owner, name, q)
+	d.Files = files
+	return d, nil
 }
 
 // SplitOwnerNameNumber parses a PR/issue github.com URL into its

--- a/internal/github/pr_detail.go
+++ b/internal/github/pr_detail.go
@@ -297,34 +297,57 @@ func (c *Client) FetchPRDetail(ctx context.Context, owner, name string, number i
 	// half-populated PRDetail (metadata but no files, or files
 	// but no header) would render misleadingly in the drill-in
 	// where users expect either "everything" or "error retry".
+	//
+	// fetchCtx is a child of the caller's ctx with our own
+	// cancel: the first goroutine to fail trips it, which both
+	// short-circuits the sibling's in-flight HTTP roundtrip and
+	// stops FetchPRFiles' pagination loop. Without this, a fast
+	// GraphQL auth error would still wait for the full paginated
+	// REST walk before surfacing — wg.Wait() blocks on whichever
+	// goroutine takes longer, and the slow one keeps going on
+	// the shared ctx with no signal to stop.
+	//
+	// firstErr + setErr (closure over sync.Once) ensure we
+	// report the *original* failure rather than the cancellation
+	// echo the sibling raises when it notices fetchCtx is done.
+	// Without sync.Once the second goroutine's
+	// "context canceled" classification (ReasonNetwork) could
+	// clobber the real reason (Auth, RateLimit, ...) the first
+	// goroutine had already established.
+	fetchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var (
 		wg       sync.WaitGroup
-		gqlErr   error
+		errOnce  sync.Once
+		firstErr error
 		files    []FileChange
-		filesErr error
 	)
+	setErr := func(err error) {
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		if err := c.gql.Query(ctx, &q, variables); err != nil {
-			gqlErr = &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		if err := c.gql.Query(fetchCtx, &q, variables); err != nil {
+			setErr(&FetchError{Reason: classifyErr(fetchCtx, err), Err: err})
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		f, err := c.FetchPRFiles(ctx, owner, name, number)
+		f, err := c.FetchPRFiles(fetchCtx, owner, name, number)
 		if err != nil {
-			filesErr = err
+			setErr(err)
 			return
 		}
 		files = f
 	}()
 	wg.Wait()
-	if gqlErr != nil {
-		return nil, gqlErr
-	}
-	if filesErr != nil {
-		return nil, filesErr
+	if firstErr != nil {
+		return nil, firstErr
 	}
 	d := extractPRDetail(owner, name, q)
 	d.Files = files

--- a/internal/github/pr_files.go
+++ b/internal/github/pr_files.go
@@ -1,0 +1,198 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// FileChange is one entry from GitHub's
+// /repos/{owner}/{name}/pulls/{number}/files endpoint, reshaped for
+// the UI. One per file changed in the PR; Patch carries the unified
+// diff body chroma will syntax-highlight inside the drill-in viewer.
+//
+// GitHub's REST schema returns more fields (sha, blob_url,
+// raw_url, contents_url, previous_filename for renames, …) — we
+// keep only what the renderer actually needs. Anything we end up
+// surfacing later (e.g. previous_filename so the renderer can show
+// "moved from X" on renames) can be threaded through one field at
+// a time without re-shaping the call site.
+type FileChange struct {
+	Path      string // e.g. "internal/ui/pr_detail.go"
+	Status    string // "added" | "modified" | "removed" | "renamed" | "copied" | "changed" | "unchanged"
+	Additions int
+	Deletions int
+	// Patch is the unified-diff body (`@@ ... @@` hunks). May be
+	// empty on binary files, on entries GitHub considers too large
+	// to inline, or when the file was simply renamed without
+	// content changes — Truncated and the Status field together
+	// disambiguate which case applies.
+	Patch string
+	// Truncated is true when we dropped the patch ourselves
+	// because it exceeded patchLineCap. The UI surfaces a banner
+	// pointing at the GitHub URL instead of rendering the hunks.
+	// Different from GitHub's own "patch omitted because file is
+	// too large" response (Patch == "" and Status != "removed"),
+	// which we treat identically at the render layer but track
+	// distinctly for telemetry / future config knobs.
+	Truncated bool
+}
+
+// patchLineCap is the maximum number of \n in Patch we will keep
+// before dropping the body and flagging Truncated. Chosen so that
+// scrolling through a worst-case file stays smooth even on
+// modest terminals — chroma's diff lexer is fast but the viewport
+// has to wrap and paint every line on each scroll tick, and a
+// 5000-line patch turns that into a visible stutter. 500 covers
+// the long tail of real-world PR files comfortably; anything
+// larger usually warrants reading on GitHub anyway.
+const patchLineCap = 500
+
+// filesPerPage is the per-request page size for the files
+// endpoint. GitHub allows up to 100; using the cap minimises
+// pagination round-trips on PRs with many files.
+const filesPerPage = 100
+
+// maxFiles is the absolute ceiling on how many files we fetch
+// from a single PR, across pagination. Mostly a safety net for
+// "this PR touches 800 files because a generated tree got
+// committed" — beyond a few hundred the viewer stops being
+// useful even with caps. The UI surfaces a "showing first N of M"
+// banner when this fires.
+const maxFiles = 300
+
+// restFile is the on-the-wire shape of one entry in
+// /pulls/{n}/files. Kept private; FileChange is what the rest of
+// the codebase sees.
+type restFile struct {
+	Filename  string `json:"filename"`
+	Status    string `json:"status"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Patch     string `json:"patch"`
+}
+
+// FetchPRFiles returns the per-file changeset for one pull
+// request, fetched from GitHub's REST API because the GraphQL
+// gateway doesn't expose the raw `patch` body. Paginates up to
+// maxFiles entries; truncates per-file patches over patchLineCap.
+// Every string crossing the boundary passes through Sanitize so
+// a hostile path or patch body can't inject terminal control
+// sequences once the renderer paints it.
+//
+// Returns an empty slice (not nil) when the PR has no file
+// entries — keeps the loaded-but-empty state distinguishable
+// from "not fetched yet" in callers that compare against nil.
+func (c *Client) FetchPRFiles(ctx context.Context, owner, name string, number int) ([]FileChange, error) {
+	files := make([]FileChange, 0)
+	for page := 1; ; page++ {
+		url := fmt.Sprintf(
+			"https://api.github.com/repos/%s/%s/pulls/%d/files?per_page=%d&page=%d",
+			owner, name, number, filesPerPage, page,
+		)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		resp, err := c.rest.Do(req)
+		if err != nil {
+			return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+		page, decodeErr := decodePRFilesPage(resp)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, f := range page {
+			files = append(files, sanitizeFileChange(f))
+			if len(files) >= maxFiles {
+				return files, nil
+			}
+		}
+		if len(page) < filesPerPage {
+			break
+		}
+	}
+	return files, nil
+}
+
+// decodePRFilesPage consumes one page response, classifying HTTP
+// errors via the shared FetchError so the UI's classifyErr-driven
+// banner messages stay consistent with the GraphQL path. The
+// response body is always closed before return.
+func decodePRFilesPage(resp *http.Response) ([]restFile, error) {
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, &FetchError{
+			Reason: ReasonRateLimitSecondary,
+			Err:    fmt.Errorf("github rest %s: %s", resp.Status, strings.TrimSpace(string(body))),
+		}
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		// 403 on GitHub REST is overloaded: primary rate limit
+		// exhaustion (X-RateLimit-Remaining: 0) and abuse throttle
+		// both surface as 403. Inspecting the rate-limit headers
+		// distinguishes them. The header check is intentionally
+		// lenient — when in doubt, fall back to the primary
+		// reason because that's the one the UI already paints
+		// with a reset-time clock.
+		reason := ReasonRateLimitPrimary
+		if remaining := resp.Header.Get("X-RateLimit-Remaining"); remaining != "" && remaining != "0" {
+			reason = ReasonRateLimitSecondary
+		}
+		return nil, &FetchError{
+			Reason: reason,
+			Err:    fmt.Errorf("github rest %s: %s", resp.Status, strings.TrimSpace(string(body))),
+		}
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, &FetchError{
+			Reason: ReasonAuth,
+			Err:    fmt.Errorf("github rest %s: %s", resp.Status, strings.TrimSpace(string(body))),
+		}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, &FetchError{
+			Reason: ReasonServer,
+			Err:    fmt.Errorf("github rest %s: %s", resp.Status, strings.TrimSpace(string(body))),
+		}
+	}
+	var page []restFile
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, &FetchError{Reason: ReasonServer, Err: err}
+	}
+	return page, nil
+}
+
+// sanitizeFileChange runs every string field through Sanitize and
+// enforces patchLineCap. Lives here so the call site in
+// FetchPRFiles stays a one-liner and the truncation contract is
+// in one place.
+func sanitizeFileChange(f restFile) FileChange {
+	patch := Sanitize(f.Patch)
+	truncated := false
+	if strings.Count(patch, "\n") > patchLineCap {
+		patch = ""
+		truncated = true
+	}
+	return FileChange{
+		Path:      Sanitize(f.Filename),
+		Status:    Sanitize(f.Status),
+		Additions: f.Additions,
+		Deletions: f.Deletions,
+		Patch:     patch,
+		Truncated: truncated,
+	}
+}

--- a/internal/github/pr_files.go
+++ b/internal/github/pr_files.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -86,14 +87,25 @@ type restFile struct {
 // Returns an empty slice (not nil) when the PR has no file
 // entries — keeps the loaded-but-empty state distinguishable
 // from "not fetched yet" in callers that compare against nil.
+//
+// No explicit per-call timeout: cancellation rides on the
+// caller's ctx. Parent FetchPRDetail runs both this and the
+// GraphQL query under the 30s drill-in context set up in v0.10.1,
+// which covers realistic worst-case network latencies without
+// stranding the UI on real failures.
 func (c *Client) FetchPRFiles(ctx context.Context, owner, name string, number int) ([]FileChange, error) {
 	files := make([]FileChange, 0)
-	for page := 1; ; page++ {
-		url := fmt.Sprintf(
+	for pageNum := 1; ; pageNum++ {
+		// url.PathEscape on owner/name is defense-in-depth: today
+		// they arrive from SplitOwnerNameNumber which has already
+		// parsed them out of a github.com URL, but future callers
+		// (e.g. a JSON-driven script wrapper) might pass them
+		// directly. Cost is one function call per page.
+		reqURL := fmt.Sprintf(
 			"https://api.github.com/repos/%s/%s/pulls/%d/files?per_page=%d&page=%d",
-			owner, name, number, filesPerPage, page,
+			url.PathEscape(owner), url.PathEscape(name), number, filesPerPage, pageNum,
 		)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 		if err != nil {
 			return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
 		}
@@ -104,20 +116,20 @@ func (c *Client) FetchPRFiles(ctx context.Context, owner, name string, number in
 		if err != nil {
 			return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
 		}
-		page, decodeErr := decodePRFilesPage(resp)
+		pageFiles, decodeErr := decodePRFilesPage(resp)
 		if decodeErr != nil {
 			return nil, decodeErr
 		}
-		if len(page) == 0 {
+		if len(pageFiles) == 0 {
 			break
 		}
-		for _, f := range page {
+		for _, f := range pageFiles {
 			files = append(files, sanitizeFileChange(f))
 			if len(files) >= maxFiles {
 				return files, nil
 			}
 		}
-		if len(page) < filesPerPage {
+		if len(pageFiles) < filesPerPage {
 			break
 		}
 	}

--- a/internal/github/pr_files_test.go
+++ b/internal/github/pr_files_test.go
@@ -1,0 +1,301 @@
+package github
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSanitizeFileChange covers the pure transform from the
+// REST wire shape to the UI-facing FileChange:
+//   - Sanitize() runs on Path / Status / Patch
+//   - patchLineCap is enforced on Patch (count of '\n')
+//   - Truncated reflects only the cap, not GitHub-side omissions
+func TestSanitizeFileChange(t *testing.T) {
+	largePatch := strings.Repeat("@@ hunk @@\n", patchLineCap+1) // > patchLineCap newlines
+	boundary := strings.Repeat("@@ hunk @@\n", patchLineCap)     // exactly patchLineCap newlines — keep
+	ansiPath := "internal/ui/\x1b[31mhostile\x1b[0m.go"
+	cleanPath := "internal/ui/hostile.go"
+
+	tests := []struct {
+		name        string
+		in          restFile
+		wantPath    string
+		wantStatus  string
+		wantPatch   string
+		wantTrunc   bool
+		patchEmpty  bool
+		patchPrefix string // when wantPatch is set and we want a prefix match (long patches)
+	}{
+		{
+			name:       "simple modified file passes through",
+			in:         restFile{Filename: "README.md", Status: "modified", Additions: 3, Deletions: 1, Patch: "@@ -1 +1 @@\n-old\n+new"},
+			wantPath:   "README.md",
+			wantStatus: "modified",
+			wantPatch:  "@@ -1 +1 @@\n-old\n+new",
+		},
+		{
+			name:       "path with ANSI escape is stripped",
+			in:         restFile{Filename: ansiPath, Status: "modified"},
+			wantPath:   cleanPath,
+			wantStatus: "modified",
+		},
+		{
+			name:       "patch exactly at cap is kept",
+			in:         restFile{Filename: "big.go", Status: "modified", Patch: boundary},
+			wantPath:   "big.go",
+			wantStatus: "modified",
+			wantPatch:  boundary,
+		},
+		{
+			name:       "patch over cap is dropped and flagged",
+			in:         restFile{Filename: "huge.go", Status: "modified", Patch: largePatch},
+			wantPath:   "huge.go",
+			wantStatus: "modified",
+			wantTrunc:  true,
+			patchEmpty: true,
+		},
+		{
+			name:       "binary file (empty patch) stays untouched",
+			in:         restFile{Filename: "logo.png", Status: "modified", Patch: ""},
+			wantPath:   "logo.png",
+			wantStatus: "modified",
+			patchEmpty: true,
+		},
+		{
+			name:       "removed file keeps status",
+			in:         restFile{Filename: "old.txt", Status: "removed", Deletions: 42},
+			wantPath:   "old.txt",
+			wantStatus: "removed",
+			patchEmpty: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFileChange(tt.in)
+			if got.Path != tt.wantPath {
+				t.Errorf("Path = %q, want %q", got.Path, tt.wantPath)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.Truncated != tt.wantTrunc {
+				t.Errorf("Truncated = %v, want %v", got.Truncated, tt.wantTrunc)
+			}
+			if tt.patchEmpty {
+				if got.Patch != "" {
+					t.Errorf("Patch = %q, want empty", got.Patch)
+				}
+			} else if tt.wantPatch != "" && got.Patch != tt.wantPatch {
+				t.Errorf("Patch mismatch")
+			}
+			if got.Additions != tt.in.Additions {
+				t.Errorf("Additions = %d, want %d", got.Additions, tt.in.Additions)
+			}
+			if got.Deletions != tt.in.Deletions {
+				t.Errorf("Deletions = %d, want %d", got.Deletions, tt.in.Deletions)
+			}
+		})
+	}
+}
+
+// TestDecodePRFilesPage covers the HTTP-response classification
+// path. Each status code is mapped to a distinct FetchError
+// reason so the UI banner stays informative; the JSON body
+// itself is decoded only on 2xx. The function must always close
+// the response body.
+func TestDecodePRFilesPage(t *testing.T) {
+	body := func(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }
+
+	tests := []struct {
+		name         string
+		status       int
+		bodyText     string
+		header       http.Header
+		wantErr      bool
+		wantReason   FetchErrorReason
+		wantLen      int
+		wantFilename string // first element when len > 0
+	}{
+		{
+			name:       "401 -> auth",
+			status:     http.StatusUnauthorized,
+			bodyText:   `{"message":"Bad credentials"}`,
+			wantErr:    true,
+			wantReason: ReasonAuth,
+		},
+		{
+			name:       "403 with remaining=0 -> primary rate limit",
+			status:     http.StatusForbidden,
+			bodyText:   `{"message":"API rate limit exceeded"}`,
+			header:     http.Header{"X-Ratelimit-Remaining": []string{"0"}},
+			wantErr:    true,
+			wantReason: ReasonRateLimitPrimary,
+		},
+		{
+			name:       "403 with remaining>0 -> abuse / secondary",
+			status:     http.StatusForbidden,
+			bodyText:   `{"message":"abuse"}`,
+			header:     http.Header{"X-Ratelimit-Remaining": []string{"42"}},
+			wantErr:    true,
+			wantReason: ReasonRateLimitSecondary,
+		},
+		{
+			name:       "403 without remaining header -> primary by default",
+			status:     http.StatusForbidden,
+			bodyText:   `{"message":"forbidden"}`,
+			wantErr:    true,
+			wantReason: ReasonRateLimitPrimary,
+		},
+		{
+			name:       "429 -> secondary rate limit",
+			status:     http.StatusTooManyRequests,
+			bodyText:   `{"message":"slow down"}`,
+			wantErr:    true,
+			wantReason: ReasonRateLimitSecondary,
+		},
+		{
+			name:       "500 -> server",
+			status:     http.StatusInternalServerError,
+			bodyText:   `oops`,
+			wantErr:    true,
+			wantReason: ReasonServer,
+		},
+		{
+			name:       "200 with malformed JSON -> server",
+			status:     http.StatusOK,
+			bodyText:   `not json`,
+			wantErr:    true,
+			wantReason: ReasonServer,
+		},
+		{
+			name:         "200 with valid array",
+			status:       http.StatusOK,
+			bodyText:     `[{"filename":"a.go","status":"modified","additions":2,"deletions":1,"patch":"@@"}]`,
+			wantLen:      1,
+			wantFilename: "a.go",
+		},
+		{
+			name:     "200 with empty array",
+			status:   http.StatusOK,
+			bodyText: `[]`,
+			wantLen:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Status:     http.StatusText(tt.status),
+				Body:       body(tt.bodyText),
+				Header:     tt.header,
+			}
+			got, err := decodePRFilesPage(resp)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				fe, ok := err.(*FetchError)
+				if !ok {
+					t.Fatalf("err type = %T, want *FetchError", err)
+				}
+				if fe.Reason != tt.wantReason {
+					t.Errorf("reason = %v, want %v", fe.Reason, tt.wantReason)
+				}
+				return
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tt.wantLen)
+			}
+			if tt.wantLen > 0 && got[0].Filename != tt.wantFilename {
+				t.Errorf("first filename = %q, want %q", got[0].Filename, tt.wantFilename)
+			}
+		})
+	}
+}
+
+// TestFetchPRFilesPagination is an end-to-end test of the
+// paginating fetch loop against a httptest server. Confirms:
+//   - the loop walks pages until a short page (len < filesPerPage)
+//     is returned, then stops
+//   - request URL path-escapes owner / name
+//   - the per-PR maxFiles ceiling caps the result regardless of
+//     how many pages the server is happy to keep returning
+func TestFetchPRFilesPagination(t *testing.T) {
+	var gotPaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.RequestURI())
+		page := r.URL.Query().Get("page")
+		switch page {
+		case "1":
+			w.Header().Set("Content-Type", "application/json")
+			// Full page (filesPerPage entries) — pagination must
+			// continue.
+			w.Write([]byte(`[` + strings.Repeat(`{"filename":"a.go","status":"modified","additions":1,"deletions":0,"patch":""},`, filesPerPage-1) +
+				`{"filename":"last.go","status":"modified","additions":1,"deletions":0,"patch":""}]`))
+		case "2":
+			// Short page — fetch should stop after consuming it.
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"filename":"b.go","status":"added","additions":3,"deletions":0,"patch":""}]`))
+		default:
+			t.Errorf("unexpected page request: %s", page)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	// Build a Client with the test server as the REST transport.
+	// We don't go through New() because we don't need oauth here —
+	// only the rest field is exercised.
+	c := &Client{rest: srv.Client()}
+	// Point the request URL at the test server by intercepting
+	// the host through a custom transport.
+	c.rest.Transport = &rewriteHost{base: srv.Client().Transport, host: srv.URL}
+
+	files, err := c.FetchPRFiles(context.Background(), "owner with space", "repo/name", 1)
+	if err != nil {
+		t.Fatalf("FetchPRFiles err = %v", err)
+	}
+	if got, want := len(files), filesPerPage+1; got != want {
+		t.Errorf("len(files) = %d, want %d", got, want)
+	}
+	if len(gotPaths) != 2 {
+		t.Errorf("server saw %d requests, want 2 (page=1, page=2)", len(gotPaths))
+	}
+	// PathEscape on owner converts " " -> %20 (not "+" — that's
+	// QueryEscape). Confirm the request actually went through it.
+	if !strings.Contains(gotPaths[0], "owner%20with%20space") {
+		t.Errorf("owner was not path-escaped, got URI = %q", gotPaths[0])
+	}
+	if !strings.Contains(gotPaths[0], "repo%2Fname") {
+		t.Errorf("repo name was not path-escaped, got URI = %q", gotPaths[0])
+	}
+}
+
+// rewriteHost is a tiny http.RoundTripper that swaps the
+// request's host with `host` before forwarding. Lets the test
+// keep using the production URL builder (api.github.com) while
+// the actual traffic hits the httptest server.
+type rewriteHost struct {
+	base http.RoundTripper
+	host string
+}
+
+func (r *rewriteHost) RoundTrip(req *http.Request) (*http.Response, error) {
+	// host is e.g. "http://127.0.0.1:54321". Splice the scheme
+	// + host onto the original path + query.
+	newURL := r.host + req.URL.RequestURI()
+	out, err := http.NewRequestWithContext(req.Context(), req.Method, newURL, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	out.Header = req.Header
+	base := r.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(out)
+}

--- a/internal/ui/action_menu.go
+++ b/internal/ui/action_menu.go
@@ -179,7 +179,11 @@ func (m ActionMenuModel) View(width int) string {
 		lines = append(lines, fmt.Sprintf("%s%s  %s", marker, shortcut, labelStyled))
 	}
 	lines = append(lines, "")
-	lines = append(lines, mutedStyle.Render("↑/↓ select · enter confirm · esc back"))
+	lines = append(lines, keyHints(
+		"↑/↓", "select",
+		"enter", "confirm",
+		"esc", "back",
+	))
 
 	panel := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/internal/ui/hints.go
+++ b/internal/ui/hints.go
@@ -1,0 +1,72 @@
+package ui
+
+import "strings"
+
+// keyHint renders one entry of a key-hints line: the key itself in
+// accent+bold so the eye locks onto it, and the human label in the
+// usual muted footer style. Convention shared with lazygit /
+// gh-dash / ranger / k9s: emphasising the key (the actionable
+// part) over the description makes long footer strings scannable
+// instead of forming a uniform grey block.
+//
+// Used everywhere a footer or title-bar lists available actions —
+// the drill-in titles, the sub-view footers (files / diff), the
+// list-tab footers, the action menu, the settings panel hint,
+// the global footer.
+//
+// Special cases handled implicitly:
+//   - Empty key (e.g. for "search:" prompts that aren't bound to
+//     a single keystroke): caller can pass key=="" and we fall
+//     back to plain muted label.
+//   - Multi-key combos ("↑↓", "1-5/tab", "pgup/pgdn"): treated as
+//     one logical "key" — passed verbatim to the accent style.
+func keyHint(key, label string) string {
+	key = strings.TrimSpace(key)
+	label = strings.TrimSpace(label)
+	if key == "" {
+		return mutedStyle.Render(label)
+	}
+	if label == "" {
+		return boldStyle.Foreground(colAccent).Render(key)
+	}
+	return boldStyle.Foreground(colAccent).Render(key) +
+		mutedStyle.Render(" "+label)
+}
+
+// keyHintsSep is the canonical separator between hint entries.
+// Centralised so a single change (e.g. swapping " · " for " | ")
+// updates every hint line in the app.
+const keyHintsSep = " · "
+
+// keyHints assembles a complete hint line from (key, label) pairs.
+// Each pair becomes one keyHint entry; entries are joined by
+// keyHintsSep. Pairs are flat: keyHints("esc", "back", "o", "open",
+// "r", "refresh") — odd-indexed args are keys, even-indexed are
+// labels.
+//
+// Wraps the common case so call sites read declaratively:
+//
+//	mutedStyle.Render("  esc back · o open · r refresh")
+//
+// becomes
+//
+//	keyHints("esc", "back", "o", "open", "r", "refresh")
+//
+// Odd-length input (a trailing key without label) is rendered as
+// a bare accent key — useful for hints like "?" or a lone
+// modifier reminder.
+func keyHints(pairs ...string) string {
+	if len(pairs) == 0 {
+		return ""
+	}
+	var entries []string
+	for i := 0; i < len(pairs); i += 2 {
+		key := pairs[i]
+		label := ""
+		if i+1 < len(pairs) {
+			label = pairs[i+1]
+		}
+		entries = append(entries, keyHint(key, label))
+	}
+	return strings.Join(entries, mutedStyle.Render(keyHintsSep))
+}

--- a/internal/ui/issue_detail.go
+++ b/internal/ui/issue_detail.go
@@ -139,7 +139,7 @@ func (id IssueDetailModel) View(width, height int) string {
 		return title + "\n\n" +
 			errorStyle.Render("Could not fetch issue detail") + "\n" +
 			mutedStyle.Render(id.err.Error()) + "\n\n" +
-			mutedStyle.Render("r retry · esc back")
+			keyHints("r", "retry", "esc", "back")
 	}
 	if id.detail == nil {
 		return title + "\n\n" + mutedStyle.Render("(no data)")
@@ -165,8 +165,11 @@ func (id IssueDetailModel) renderTitle() string {
 		owner, name, num = "?", "?", id.issue.Number
 	}
 	titleText := fmt.Sprintf("▸ Issues / %s/%s#%d", owner, name, num)
-	return activeTabStyle.Render(titleText) +
-		mutedStyle.Render("  esc back · o open in github · r refresh")
+	return activeTabStyle.Render(titleText) + "  " + keyHints(
+		"esc", "back",
+		"o", "open in github",
+		"r", "refresh",
+	)
 }
 
 // computeBody renders the loaded-detail body. Pure function of

--- a/internal/ui/issues.go
+++ b/internal/ui/issues.go
@@ -256,7 +256,15 @@ func (im IssuesModel) renderIssuesTab(stats *github.Stats, available, availableH
 
 	table := renderIssuesTable(rows[offset:end], cursor-offset, im.sort)
 
-	hint := mutedStyle.Render("↑↓ move · g/G top/bottom · s sort · / search · enter details · o github · c copy")
+	hint := keyHints(
+		"↑↓", "move",
+		"g/G", "top/bottom",
+		"s", "sort",
+		"/", "search",
+		"enter", "details",
+		"o", "github",
+		"c", "copy",
+	)
 
 	parts := []string{headerLine}
 	if searchLine != "" {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -851,10 +851,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// have one; Linux without xclip/xsel/wl-copy is an edge
 		// case) but we surface a real reason rather than a generic
 		// "failed" so the user knows what to install.
+		noun := msg.noun
+		if noun == "" {
+			noun = "URL"
+		}
 		if msg.err != nil {
-			m.toastMsg = "Copy URL failed: " + msg.err.Error()
+			m.toastMsg = "Copy " + noun + " failed: " + msg.err.Error()
 		} else {
-			m.toastMsg = "URL copied"
+			m.toastMsg = noun + " copied"
 		}
 		m.toastUntil = time.Now().Add(toastDuration)
 		return m, tea.Tick(toastDuration, func(time.Time) tea.Msg {
@@ -1027,13 +1031,19 @@ type viewIssueDetailMsg struct {
 	issue github.Issue
 }
 
-// urlCopiedMsg fires after a copy-URL action — `err` is nil on
-// success, non-nil when the clipboard helper failed (missing
-// xclip/xsel on minimal Linux, headless X session, etc.). The root
-// model picks the toast wording based on the outcome.
+// urlCopiedMsg fires after a copy-to-clipboard action — `err` is
+// nil on success, non-nil when the clipboard helper failed
+// (missing xclip/xsel on minimal Linux, headless X session, etc.).
+// The root model picks the toast wording based on the outcome.
+//
+// `noun` lets the caller swap "URL" for whatever fits the
+// payload: "Path" for file paths, etc. Empty string defaults to
+// "URL" so existing call sites that don't care don't have to
+// thread the field through.
 type urlCopiedMsg struct {
-	url string
-	err error
+	url  string
+	err  error
+	noun string
 }
 
 // viewRepoDetailCmd builds a Cmd that asks the root model to open
@@ -1068,9 +1078,26 @@ func viewIssueDetailCmd(it github.Issue) tea.Cmd {
 // root can decide whether to show "URL copied" or a one-line
 // reason ("clipboard helper not found") in the footer toast.
 func copyURLCmd(url string) tea.Cmd {
+	return copyTextCmd(url, "URL")
+}
+
+// copyPathCmd is the file-path counterpart of copyURLCmd: same
+// pipeline, different toast noun ("Path copied" instead of
+// "URL copied"). Used by the PR diff viewer's files list (v0.12.0)
+// where the clipboard payload is a repo-relative path rather than
+// a URL.
+func copyPathCmd(path string) tea.Cmd {
+	return copyTextCmd(path, "Path")
+}
+
+// copyTextCmd is the shared underlying primitive. Captures the
+// noun so the eventual toast reflects what was actually copied
+// without each call site having to construct the urlCopiedMsg
+// itself.
+func copyTextCmd(text, noun string) tea.Cmd {
 	return func() tea.Msg {
-		err := clipboard.Copy(url)
-		return urlCopiedMsg{url: url, err: err}
+		err := clipboard.Copy(text)
+		return urlCopiedMsg{url: text, err: err, noun: noun}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1036,12 +1036,17 @@ type viewIssueDetailMsg struct {
 // (missing xclip/xsel on minimal Linux, headless X session, etc.).
 // The root model picks the toast wording based on the outcome.
 //
+// `text` is the payload that was placed on the clipboard. The
+// field name dropped "url" once copyPathCmd (v0.12.0) started
+// reusing the message for file paths — keeping a misleading name
+// invites bugs where someone reads msg.url and assumes a URL.
+//
 // `noun` lets the caller swap "URL" for whatever fits the
 // payload: "Path" for file paths, etc. Empty string defaults to
 // "URL" so existing call sites that don't care don't have to
 // thread the field through.
 type urlCopiedMsg struct {
-	url  string
+	text string
 	err  error
 	noun string
 }
@@ -1077,6 +1082,8 @@ func viewIssueDetailCmd(it github.Issue) tea.Cmd {
 // urlCopiedMsg with the err field populated on failure so the
 // root can decide whether to show "URL copied" or a one-line
 // reason ("clipboard helper not found") in the footer toast.
+// Thin wrapper around copyTextCmd; see copyPathCmd for the
+// path-flavoured counterpart used by the v0.12.0 diff viewer.
 func copyURLCmd(url string) tea.Cmd {
 	return copyTextCmd(url, "URL")
 }
@@ -1097,7 +1104,7 @@ func copyPathCmd(path string) tea.Cmd {
 func copyTextCmd(text, noun string) tea.Cmd {
 	return func() tea.Msg {
 		err := clipboard.Copy(text)
-		return urlCopiedMsg{url: text, err: err, noun: noun}
+		return urlCopiedMsg{text: text, err: err, noun: noun}
 	}
 }
 

--- a/internal/ui/pr_detail.go
+++ b/internal/ui/pr_detail.go
@@ -38,6 +38,13 @@ type PRDetailModel struct {
 	// (new payload) and by width changes (re-rendered on demand).
 	bodyCache      string
 	bodyCacheWidth int
+
+	// files is the nested files-list sub-view (v0.12.0). Opens on
+	// `f` once the PR detail has loaded with a non-empty
+	// detail.Files slice. While files.IsOpen() the parent stops
+	// rendering its own body and forwards keys to the sub-view;
+	// closing the sub-view returns control here transparently.
+	files PRFilesModel
 }
 
 // IsOpen reports whether the detail view is currently active.
@@ -70,6 +77,14 @@ func (pd PRDetailModel) Update(msg tea.KeyMsg, client *github.Client, width, hei
 	if !pd.open {
 		return pd, nil
 	}
+	// Files sub-view (v0.12.0) owns the screen when open: keys
+	// go to it, and `esc` inside the sub-view closes only that
+	// level — `pd` stays open so the user returns to the PR body.
+	if pd.files.IsOpen() {
+		var cmd tea.Cmd
+		pd.files, cmd = pd.files.Update(msg, width, height)
+		return pd, cmd
+	}
 	switch msg.String() {
 	case "q":
 		return pd.Close(), tea.Quit
@@ -86,6 +101,19 @@ func (pd PRDetailModel) Update(msg tea.KeyMsg, client *github.Client, width, hei
 		return pd, fetchPRDetailCmd(client, owner, name, num, pd.pr.URL)
 	case "o":
 		return pd, openURLCmd(pd.pr.URL)
+	case "f":
+		// Open the files-list sub-view. Guarded so the keybind
+		// only fires when there's something to show — otherwise
+		// the user gets a confusing "nothing happened" press.
+		if pd.detail == nil || len(pd.detail.Files) == 0 {
+			return pd, nil
+		}
+		owner, name, num := github.SplitOwnerNameNumber(pd.pr.URL)
+		if owner == "" {
+			return pd, nil
+		}
+		pd.files = pd.files.Open(pd.detail.Files, owner, name, num)
+		return pd, nil
 	}
 
 	pd = pd.syncViewport(width, height)
@@ -106,6 +134,10 @@ func (pd PRDetailModel) applyFetched(detail *github.PRDetail, err error) PRDetai
 	pd.err = err
 	pd.bodyCache = ""
 	pd.bodyCacheWidth = 0
+	// Drop any open files sub-view: it would be pointing at the
+	// previous payload's Files slice. The user invoked `r` (or
+	// the inital fetch); they expect a clean slate.
+	pd.files = PRFilesModel{}
 	return pd
 }
 
@@ -147,6 +179,17 @@ func (pd PRDetailModel) View(width, height int) string {
 	}
 
 	title := pd.renderTitle()
+
+	// Files sub-view (v0.12.0) replaces the PR body while open.
+	// The title row stays visible so the user keeps the
+	// breadcrumb context at every nesting level.
+	if pd.files.IsOpen() {
+		subHeight := height - 2 // title + blank
+		if subHeight < 1 {
+			subHeight = height
+		}
+		return title + "\n\n" + pd.files.View(width, subHeight)
+	}
 
 	if pd.loading {
 		return title + "\n\n" +
@@ -285,6 +328,15 @@ func prDetailChips(d *github.PRDetail) string {
 			errorStyle.Render(fmt.Sprintf("-%d", d.Deletions))
 		if d.ChangedFiles > 0 {
 			diff += "  " + mutedStyle.Render(fmt.Sprintf("· %d files", d.ChangedFiles))
+			// Hint at the diff viewer (v0.12.0). Only when the
+			// per-file payload actually came back from REST — a
+			// PR with ChangedFiles > 0 but zero Files means the
+			// inspector would open an empty list, so withhold the
+			// hint rather than promise something the next press
+			// can't deliver.
+			if len(d.Files) > 0 {
+				diff += "  " + mutedStyle.Render("· f inspect")
+			}
 		}
 		parts = append(parts, diff)
 	}

--- a/internal/ui/pr_detail.go
+++ b/internal/ui/pr_detail.go
@@ -199,7 +199,7 @@ func (pd PRDetailModel) View(width, height int) string {
 		return title + "\n\n" +
 			errorStyle.Render("Could not fetch PR detail") + "\n" +
 			mutedStyle.Render(pd.err.Error()) + "\n\n" +
-			mutedStyle.Render("r retry · esc back")
+			keyHints("r", "retry", "esc", "back")
 	}
 	if pd.detail == nil {
 		return title + "\n\n" + mutedStyle.Render("(no data)")
@@ -226,8 +226,19 @@ func (pd PRDetailModel) renderTitle() string {
 		owner, name, num = "?", "?", pd.pr.Number
 	}
 	titleText := fmt.Sprintf("▸ PRs / %s/%s#%d", owner, name, num)
-	return activeTabStyle.Render(titleText) +
-		mutedStyle.Render("  esc back · o open in github · r refresh")
+	// f inspect lives here (rather than next to the +/-/files
+	// counter) so all drill-in actions share one visual region.
+	// The keybind only does something once the detail has
+	// loaded with a non-empty Files slice — we surface the hint
+	// anyway, since hiding it would create an inconsistent
+	// title-bar layout between PRs with and without files.
+	hints := keyHints(
+		"esc", "back",
+		"o", "open in github",
+		"r", "refresh",
+		"f", "inspect",
+	)
+	return activeTabStyle.Render(titleText) + "  " + hints
 }
 
 // computeBody renders the loaded-detail body. Pure function of
@@ -328,16 +339,11 @@ func prDetailChips(d *github.PRDetail) string {
 			errorStyle.Render(fmt.Sprintf("-%d", d.Deletions))
 		if d.ChangedFiles > 0 {
 			diff += "  " + mutedStyle.Render(fmt.Sprintf("· %d files", d.ChangedFiles))
-			// Hint at the diff viewer (v0.12.0). Only when the
-			// per-file payload actually came back from REST — a
-			// PR with ChangedFiles > 0 but zero Files means the
-			// inspector would open an empty list, so withhold the
-			// hint rather than promise something the next press
-			// can't deliver.
-			if len(d.Files) > 0 {
-				diff += "  " + mutedStyle.Render("· f inspect")
-			}
 		}
+		// `f inspect` lives in the title-bar hints (renderTitle)
+		// alongside esc/o/r — keeping all drill-in actions in one
+		// visual region rather than scattering them across the
+		// chip line.
 		parts = append(parts, diff)
 	}
 

--- a/internal/ui/pr_detail.go
+++ b/internal/ui/pr_detail.go
@@ -136,7 +136,7 @@ func (pd PRDetailModel) applyFetched(detail *github.PRDetail, err error) PRDetai
 	pd.bodyCacheWidth = 0
 	// Drop any open files sub-view: it would be pointing at the
 	// previous payload's Files slice. The user invoked `r` (or
-	// the inital fetch); they expect a clean slate.
+	// the initial fetch); they expect a clean slate.
 	pd.files = PRFilesModel{}
 	return pd
 }

--- a/internal/ui/pr_diff.go
+++ b/internal/ui/pr_diff.go
@@ -125,7 +125,13 @@ func (dm PRDiffModel) View(width, height int) string {
 	}
 	heading := boldStyle.Foreground(colAccent).Render(dm.file.Path)
 	counts := mutedStyle.Render(fmt.Sprintf("  +%d -%d", dm.file.Additions, dm.file.Deletions))
-	hints := mutedStyle.Render("↑↓ scroll · pgup/pgdn page · esc back · o open on github · c copy path")
+	hints := keyHints(
+		"↑↓", "scroll",
+		"pgup/pgdn", "page",
+		"esc", "back",
+		"o", "open on github",
+		"c", "copy path",
+	)
 
 	body := dm.bodyForWidth(width)
 	vp := dm.viewport

--- a/internal/ui/pr_diff.go
+++ b/internal/ui/pr_diff.go
@@ -1,0 +1,232 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// PRDiffModel is the single-file diff viewer (v0.12.0), the
+// deepest level of the PR drill-in. Opened by PRFilesModel when
+// the user presses Enter on a file row.
+//
+// Renders the file's unified-diff patch with chroma's "diff"
+// lexer (already in the binary via glamour) so additions /
+// deletions / hunk headers get colour-highlighted. Wraps the
+// rendered text in a bubbles/viewport for scrolling — most diffs
+// fit on a screen but a 400-line refactor patch (just under
+// patchLineCap) demands paging.
+type PRDiffModel struct {
+	open bool
+	file github.FileChange
+
+	owner  string
+	repo   string
+	number int
+
+	viewport viewport.Model
+
+	// Width-keyed cache of the rendered diff, mirroring the
+	// markdown body cache on PRDetailModel. chroma highlighting
+	// is fast (a few ms per file) but redoing it on every paint
+	// shows up on long diffs and on resizes — caching keeps the
+	// scroll buttery.
+	bodyCache      string
+	bodyCacheWidth int
+}
+
+// IsOpen reports whether the diff viewer is currently active.
+func (dm PRDiffModel) IsOpen() bool {
+	return dm.open
+}
+
+// Open seeds a fresh diff viewer with the file the user picked
+// from the files list. width / height seed the viewport so the
+// first paint already has correct dimensions.
+func (dm PRDiffModel) Open(file github.FileChange, owner, repo string, number, width, height int) PRDiffModel {
+	vp := viewport.New(width, max(1, height-2))
+	return PRDiffModel{
+		open:     true,
+		file:     file,
+		owner:    owner,
+		repo:     repo,
+		number:   number,
+		viewport: vp,
+	}
+}
+
+// Close returns a closed diff viewer (zero value).
+func (dm PRDiffModel) Close() PRDiffModel {
+	return PRDiffModel{}
+}
+
+// Update handles a single key event while the diff viewer owns
+// the screen. esc backs out one level (to the files list),
+// scroll keys feed the viewport, `o` opens the file on GitHub.
+func (dm PRDiffModel) Update(msg tea.KeyMsg, width, height int) (PRDiffModel, tea.Cmd) {
+	if !dm.open {
+		return dm, nil
+	}
+	switch msg.String() {
+	case "q":
+		return dm.Close(), tea.Quit
+	case "esc":
+		return dm.Close(), nil
+	case "o":
+		url := fmt.Sprintf("https://github.com/%s/%s/pull/%d/files",
+			dm.owner, dm.repo, dm.number)
+		return dm, openURLCmd(url)
+	}
+	dm = dm.syncViewport(width, height)
+	var cmd tea.Cmd
+	dm.viewport, cmd = dm.viewport.Update(msg)
+	return dm, cmd
+}
+
+// syncViewport refreshes the viewport's dimensions + content,
+// computing the rendered body once and caching it.
+func (dm PRDiffModel) syncViewport(width, height int) PRDiffModel {
+	body := dm.bodyForWidth(width)
+	dm.bodyCache = body
+	dm.bodyCacheWidth = width
+	dm.viewport.Width = width
+	dm.viewport.Height = max(1, height-2)
+	dm.viewport.SetContent(body)
+	return dm
+}
+
+// bodyForWidth returns the rendered diff body, hitting the
+// width-keyed cache when possible. Width affects only the
+// header/footer chrome — the diff itself is rendered with
+// chroma's terminal formatter which doesn't wrap.
+func (dm PRDiffModel) bodyForWidth(width int) string {
+	if dm.bodyCache != "" && dm.bodyCacheWidth == width {
+		return dm.bodyCache
+	}
+	return renderDiff(dm.file)
+}
+
+// View renders the diff viewer. A heading row with the file
+// path, the scrollable diff body, and a footer with key hints.
+func (dm PRDiffModel) View(width, height int) string {
+	if !dm.open {
+		return ""
+	}
+	heading := boldStyle.Foreground(colAccent).Render(dm.file.Path)
+	counts := mutedStyle.Render(fmt.Sprintf("  +%d -%d", dm.file.Additions, dm.file.Deletions))
+	hints := mutedStyle.Render("↑↓ scroll · pgup/pgdn page · esc back · o open on github")
+
+	body := dm.bodyForWidth(width)
+	vp := dm.viewport
+	vp.Width = width
+	vp.Height = max(1, height-2)
+	vp.SetContent(body)
+
+	return heading + counts + "\n" + vp.View() + "\n" + hints
+}
+
+// renderDiff is the pure function that turns a FileChange's
+// Patch into a coloured diff body. Three paths:
+//   - Truncated by our cap → banner pointing at the GitHub URL.
+//   - Empty patch (binary file, GitHub-side too-large, or
+//     content-less rename) → polite one-liner explaining the
+//     section is empty for a reason.
+//   - Otherwise → chroma highlight with the "diff" lexer and a
+//     dark style consistent with the markdown rendering palette.
+//
+// Doesn't word-wrap: diffs are inherently column-aware (the
+// leading +/-/space marker carries meaning, hunk headers align
+// on @@) and wrapping breaks visual scanning. Lines longer than
+// the viewport width simply overflow; the viewport scrolls
+// horizontally if the user moves with the arrow keys past the
+// edge.
+func renderDiff(f github.FileChange) string {
+	if f.Truncated {
+		return mutedStyle.Render(
+			"Diff too large to display in-app — open this file on github.com (press o) to read it there.",
+		)
+	}
+	if strings.TrimSpace(f.Patch) == "" {
+		switch f.Status {
+		case "renamed", "copied":
+			return mutedStyle.Render("(no content change — file renamed or copied without modifications)")
+		case "removed":
+			return mutedStyle.Render("(file removed — no remaining content to diff)")
+		default:
+			return mutedStyle.Render("(no patch available — likely a binary file or omitted by GitHub)")
+		}
+	}
+	out, err := highlightDiff(f.Patch)
+	if err != nil {
+		return f.Patch
+	}
+	return out
+}
+
+// highlightDiff runs chroma against the diff lexer + a dark
+// style + the terminal256 formatter (24-bit-capable terminals
+// pick up colour anyway via lipgloss's auto-detection). Cached
+// behind the same single-entry MRU idiom as the markdown
+// renderer because building the style + formatter takes a
+// non-trivial slice of a frame budget on bigger diffs.
+func highlightDiff(patch string) (string, error) {
+	lexer := lexers.Get("diff")
+	if lexer == nil {
+		lexer = lexers.Fallback
+	}
+	style := diffStyle()
+	formatter := formatters.Get("terminal256")
+	if formatter == nil {
+		formatter = formatters.Fallback
+	}
+
+	iter, err := lexer.Tokenise(nil, patch)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, style, iter); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// diffStyle returns the chroma style used for diff rendering.
+// "monokai" reads well on the dark terminal background octoscope
+// targets and its red/green for - / + lines is the universally
+// recognised diff palette. Cached so we don't look it up on
+// every call.
+func diffStyle() *chroma.Style {
+	diffStyleOnce.Do(func() {
+		s := styles.Get("monokai")
+		if s == nil {
+			s = styles.Fallback
+		}
+		cachedDiffStyle = s
+	})
+	return cachedDiffStyle
+}
+
+var (
+	diffStyleOnce   sync.Once
+	cachedDiffStyle *chroma.Style
+)
+
+// max is a tiny helper for height clamping — Go 1.21+ has it in
+// the stdlib but we keep the local copy for clarity at the call
+// site.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/ui/pr_diff.go
+++ b/internal/ui/pr_diff.go
@@ -70,8 +70,10 @@ func (dm PRDiffModel) Close() PRDiffModel {
 }
 
 // Update handles a single key event while the diff viewer owns
-// the screen. esc backs out one level (to the files list),
-// scroll keys feed the viewport, `o` opens the file on GitHub.
+// the screen. esc backs out one level (to the files list); q
+// quits the whole app (consistent with every other view in
+// octoscope — q is a global escape hatch). Scroll keys feed the
+// viewport, `o` opens the file on GitHub, `c` copies the path.
 func (dm PRDiffModel) Update(msg tea.KeyMsg, width, height int) (PRDiffModel, tea.Cmd) {
 	if !dm.open {
 		return dm, nil
@@ -131,6 +133,7 @@ func (dm PRDiffModel) View(width, height int) string {
 		"esc", "back",
 		"o", "open on github",
 		"c", "copy path",
+		"q", "quit",
 	)
 
 	body := dm.bodyForWidth(width)
@@ -229,12 +232,3 @@ var (
 	cachedDiffStyle *chroma.Style
 )
 
-// max is a tiny helper for height clamping — Go 1.21+ has it in
-// the stdlib but we keep the local copy for clarity at the call
-// site.
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/internal/ui/pr_diff.go
+++ b/internal/ui/pr_diff.go
@@ -85,6 +85,8 @@ func (dm PRDiffModel) Update(msg tea.KeyMsg, width, height int) (PRDiffModel, te
 		url := fmt.Sprintf("https://github.com/%s/%s/pull/%d/files",
 			dm.owner, dm.repo, dm.number)
 		return dm, openURLCmd(url)
+	case "c":
+		return dm, copyPathCmd(dm.file.Path)
 	}
 	dm = dm.syncViewport(width, height)
 	var cmd tea.Cmd
@@ -123,7 +125,7 @@ func (dm PRDiffModel) View(width, height int) string {
 	}
 	heading := boldStyle.Foreground(colAccent).Render(dm.file.Path)
 	counts := mutedStyle.Render(fmt.Sprintf("  +%d -%d", dm.file.Additions, dm.file.Deletions))
-	hints := mutedStyle.Render("↑↓ scroll · pgup/pgdn page · esc back · o open on github")
+	hints := mutedStyle.Render("↑↓ scroll · pgup/pgdn page · esc back · o open on github · c copy path")
 
 	body := dm.bodyForWidth(width)
 	vp := dm.viewport

--- a/internal/ui/pr_files.go
+++ b/internal/ui/pr_files.go
@@ -1,0 +1,254 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// PRFilesModel is the files-list sub-view of the PR drill-in
+// (v0.12.0). Nested inside PRDetailModel: PRDetailModel keys this
+// open with `f` once a PR detail has loaded with a non-empty
+// Files slice, and routes key events to it while it owns the
+// screen.
+//
+// Full-screen sub-view by design — the v0.12.0 UX question landed
+// on "drill-in nel drill-in" rather than an inline expandable
+// section. The PR detail's banner / title row stays painted by
+// the parent, so we render below it: a heading row that names the
+// PR, a navigable file list, and a footer with key hints.
+//
+// Selecting a file with `enter` (or `space`) opens the file's
+// diff in PRDiffModel — another level of nesting handled here so
+// PRDetailModel stays a single transparent wrapper.
+type PRFilesModel struct {
+	open   bool
+	files  []github.FileChange
+	cursor int
+
+	// Header context — owner / repo / number copied from the PR
+	// at Open() time so the heading line stays informative even
+	// after the user has navigated several levels deep.
+	owner  string
+	repo   string
+	number int
+
+	diff PRDiffModel
+}
+
+// IsOpen reports whether the files list is currently active.
+func (fm PRFilesModel) IsOpen() bool {
+	return fm.open
+}
+
+// Open seeds a fresh files list. Caller has already verified
+// that len(files) > 0; an empty list would render a useless
+// "no files" placeholder, which we'd rather avoid by suppressing
+// the `f` keybind upstream.
+func (fm PRFilesModel) Open(files []github.FileChange, owner, repo string, number int) PRFilesModel {
+	return PRFilesModel{
+		open:   true,
+		files:  files,
+		cursor: 0,
+		owner:  owner,
+		repo:   repo,
+		number: number,
+	}
+}
+
+// Close returns a closed files list (zero value), tearing down
+// any nested diff viewer along with it.
+func (fm PRFilesModel) Close() PRFilesModel {
+	return PRFilesModel{}
+}
+
+// Update handles one key event while the list is the active
+// surface. If the nested diff viewer is open it receives the
+// message first; otherwise the list dispatches navigation /
+// open / back keys itself.
+func (fm PRFilesModel) Update(msg tea.KeyMsg, width, height int) (PRFilesModel, tea.Cmd) {
+	if !fm.open {
+		return fm, nil
+	}
+	if fm.diff.IsOpen() {
+		var cmd tea.Cmd
+		fm.diff, cmd = fm.diff.Update(msg, width, height)
+		// Diff viewer signals "close me" by reporting !IsOpen()
+		// after the update. The wrapper just keeps the (now-empty)
+		// diff field and re-renders the list — no extra plumbing
+		// needed.
+		return fm, cmd
+	}
+	switch msg.String() {
+	case "q":
+		return fm.Close(), tea.Quit
+	case "esc":
+		return fm.Close(), nil
+	case "up", "k":
+		if fm.cursor > 0 {
+			fm.cursor--
+		}
+		return fm, nil
+	case "down", "j":
+		if fm.cursor < len(fm.files)-1 {
+			fm.cursor++
+		}
+		return fm, nil
+	case "home", "g":
+		fm.cursor = 0
+		return fm, nil
+	case "end", "G":
+		fm.cursor = len(fm.files) - 1
+		return fm, nil
+	case "enter", " ":
+		if len(fm.files) == 0 {
+			return fm, nil
+		}
+		fm.diff = fm.diff.Open(fm.files[fm.cursor], fm.owner, fm.repo, fm.number, width, height)
+		return fm, nil
+	case "o":
+		if len(fm.files) == 0 {
+			return fm, nil
+		}
+		url := fileBlobURL(fm.owner, fm.repo, fm.number, fm.files[fm.cursor].Path)
+		return fm, openURLCmd(url)
+	case "c":
+		if len(fm.files) == 0 {
+			return fm, nil
+		}
+		return fm, copyURLCmd(fm.files[fm.cursor].Path)
+	}
+	return fm, nil
+}
+
+// View renders the files list (or the nested diff viewer, when
+// open). Width and height are the area the PRDetailModel hands
+// us below its sticky title row.
+func (fm PRFilesModel) View(width, height int) string {
+	if !fm.open {
+		return ""
+	}
+	if fm.diff.IsOpen() {
+		return fm.diff.View(width, height)
+	}
+
+	heading := boldStyle.Foreground(colAccent).Render(
+		fmt.Sprintf("Files changed in %s/%s#%d", fm.owner, fm.repo, fm.number),
+	)
+	count := mutedStyle.Render(fmt.Sprintf("  (%d files)", len(fm.files)))
+	hints := mutedStyle.Render("↑↓ move · enter inspect · o open on github · c copy path · esc back")
+
+	rowsBudget := height - 4 // heading + blank + footer + blank
+	if rowsBudget < 1 {
+		rowsBudget = 1
+	}
+	rows := renderFileRows(fm.files, fm.cursor, width, rowsBudget)
+
+	return heading + count + "\n\n" + rows + "\n" + hints
+}
+
+// renderFileRows turns the file slice into the visible viewport
+// of rows, applying cursor highlighting and a window calculation
+// so the cursor never falls off the visible area. A real
+// bubbles/viewport would be overkill here — the list never has
+// more than maxFiles (300) entries, well within plain-string
+// territory.
+func renderFileRows(files []github.FileChange, cursor, width, budget int) string {
+	if len(files) == 0 {
+		return mutedStyle.Render("  (no files)")
+	}
+	start := 0
+	if cursor >= budget {
+		start = cursor - budget + 1
+	}
+	end := start + budget
+	if end > len(files) {
+		end = len(files)
+	}
+
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		b.WriteString(fileRow(files[i], width, i == cursor))
+		if i < end-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// fileRow renders one row: cursor marker, status glyph, path,
+// +Additions / -Deletions counts. Mirrors the highlight idiom of
+// the list tabs (marker "▸" + accent recolour on the active
+// row) so the muscle memory carries over from Repos / PRs /
+// Issues. Truncates the path on the left (…prefix) when it
+// would overflow the available width.
+func fileRow(f github.FileChange, width int, active bool) string {
+	statusGlyph := fileStatusGlyph(f.Status)
+	addDel := okStyle.Render(fmt.Sprintf("+%d", f.Additions)) +
+		" " + errorStyle.Render(fmt.Sprintf("-%d", f.Deletions))
+	marker := "  "
+	if active {
+		marker = activeTabStyle.Render("▸ ")
+	}
+	// Reserve room for marker (2) + " glyph " (3) + addDel
+	// (~18 cols worst-case on a busy PR).
+	const overhead = 2 + 3 + 18
+	pathBudget := width - overhead
+	if pathBudget < 10 {
+		pathBudget = 10
+	}
+	path := f.Path
+	if lipgloss.Width(path) > pathBudget {
+		path = "…" + path[lipgloss.Width(path)-pathBudget+1:]
+	}
+	if active {
+		path = boldStyle.Foreground(colAccent).Render(path)
+	}
+	return fmt.Sprintf("%s%s %s   %s", marker, statusGlyph, path, addDel)
+}
+
+// fileStatusGlyph maps GitHub's REST status enum to a one-rune
+// indicator. Stays single-rune so cursor highlighting and the
+// fileRow width budget stay predictable.
+func fileStatusGlyph(status string) string {
+	switch status {
+	case "added":
+		return okStyle.Render("A")
+	case "removed":
+		return errorStyle.Render("D")
+	case "renamed":
+		return boldStyle.Foreground(colAccent).Render("R")
+	case "copied":
+		return mutedStyle.Render("C")
+	case "modified", "changed":
+		return mutedStyle.Render("M")
+	default:
+		return mutedStyle.Render("·")
+	}
+}
+
+// fileBlobURL builds the github.com URL of a file at a specific
+// PR's head — best-effort: we don't know the head sha here, so
+// we link to the PR's files tab on GitHub anchored at the file
+// path. That lands the user on the canonical place GitHub
+// renders the file's diff, which is the natural fallback when
+// the in-app viewer doesn't fit a use case.
+func fileBlobURL(owner, repo string, number int, path string) string {
+	// Anchor on the PR's "Files changed" tab; GitHub auto-scrolls
+	// to the file when the fragment matches the file index.
+	return fmt.Sprintf("https://github.com/%s/%s/pull/%d/files#diff-%s",
+		owner, repo, number, anchorForPath(path))
+}
+
+// anchorForPath is the SHA-1-based anchor GitHub uses on the
+// pull-request files tab. We don't compute it (would require a
+// runtime sha1 dependency for marginal value); the fragment is
+// optional, GitHub still loads the page without it. Kept as a
+// hook so a future commit can plug in the real anchor if we
+// decide the precise auto-scroll is worth the cost.
+func anchorForPath(_ string) string {
+	return ""
+}

--- a/internal/ui/pr_files.go
+++ b/internal/ui/pr_files.go
@@ -139,7 +139,13 @@ func (fm PRFilesModel) View(width, height int) string {
 		fmt.Sprintf("Files changed in %s/%s#%d", fm.owner, fm.repo, fm.number),
 	)
 	count := mutedStyle.Render(fmt.Sprintf("  (%d files)", len(fm.files)))
-	hints := mutedStyle.Render("↑↓ move · enter inspect · o open on github · c copy path · esc back")
+	hints := keyHints(
+		"↑↓", "move",
+		"enter", "inspect",
+		"o", "open on github",
+		"c", "copy path",
+		"esc", "back",
+	)
 
 	rowsBudget := height - 4 // heading + blank + footer + blank
 	if rowsBudget < 1 {

--- a/internal/ui/pr_files.go
+++ b/internal/ui/pr_files.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/gfazioli/octoscope/internal/github"
+	"github.com/mattn/go-runewidth"
 )
 
 // PRFilesModel is the files-list sub-view of the PR drill-in
@@ -145,6 +145,7 @@ func (fm PRFilesModel) View(width, height int) string {
 		"o", "open on github",
 		"c", "copy path",
 		"esc", "back",
+		"q", "quit",
 	)
 
 	rowsBudget := height - 4 // heading + blank + footer + blank
@@ -190,7 +191,9 @@ func renderFileRows(files []github.FileChange, cursor, width, budget int) string
 // the list tabs (marker "▸" + accent recolour on the active
 // row) so the muscle memory carries over from Repos / PRs /
 // Issues. Truncates the path on the left (…prefix) when it
-// would overflow the available width.
+// would overflow the available width — left-trim because the
+// filename (rightmost segment) is what the user is reading;
+// dropping it would defeat the row.
 func fileRow(f github.FileChange, width int, active bool) string {
 	statusGlyph := fileStatusGlyph(f.Status)
 	addDel := okStyle.Render(fmt.Sprintf("+%d", f.Additions)) +
@@ -206,14 +209,43 @@ func fileRow(f github.FileChange, width int, active bool) string {
 	if pathBudget < 10 {
 		pathBudget = 10
 	}
-	path := f.Path
-	if lipgloss.Width(path) > pathBudget {
-		path = "…" + path[lipgloss.Width(path)-pathBudget+1:]
-	}
+	path := truncatePathLeft(f.Path, pathBudget)
 	if active {
 		path = boldStyle.Foreground(colAccent).Render(path)
 	}
 	return fmt.Sprintf("%s%s %s   %s", marker, statusGlyph, path, addDel)
+}
+
+// truncatePathLeft trims the prefix of `path` so the rendered
+// result fits in at most `w` terminal cells, prepending an
+// ellipsis when anything had to drop. UTF-8 / wide-rune safe:
+// iterates the runes from right to left and tracks display
+// width with runewidth, never slicing a multi-byte rune in
+// half.
+//
+// Mirror of repos.go's `truncate` but trimming the *left*: for
+// file paths the right end is the filename the user actually
+// scans for, so the prefix is the cheaper thing to drop.
+func truncatePathLeft(path string, w int) string {
+	if w <= 1 {
+		return "…"
+	}
+	if runewidth.StringWidth(path) <= w {
+		return path
+	}
+	limit := w - 1 // room for the leading ellipsis
+	runes := []rune(path)
+	used := 0
+	cut := len(runes)
+	for i := len(runes) - 1; i >= 0; i-- {
+		rw := runewidth.RuneWidth(runes[i])
+		if used+rw > limit {
+			break
+		}
+		used += rw
+		cut = i
+	}
+	return "…" + string(runes[cut:])
 }
 
 // fileStatusGlyph maps GitHub's REST status enum to a one-rune
@@ -236,25 +268,17 @@ func fileStatusGlyph(status string) string {
 	}
 }
 
-// fileBlobURL builds the github.com URL of a file at a specific
-// PR's head — best-effort: we don't know the head sha here, so
-// we link to the PR's files tab on GitHub anchored at the file
-// path. That lands the user on the canonical place GitHub
-// renders the file's diff, which is the natural fallback when
-// the in-app viewer doesn't fit a use case.
-func fileBlobURL(owner, repo string, number int, path string) string {
-	// Anchor on the PR's "Files changed" tab; GitHub auto-scrolls
-	// to the file when the fragment matches the file index.
-	return fmt.Sprintf("https://github.com/%s/%s/pull/%d/files#diff-%s",
-		owner, repo, number, anchorForPath(path))
-}
-
-// anchorForPath is the SHA-1-based anchor GitHub uses on the
-// pull-request files tab. We don't compute it (would require a
-// runtime sha1 dependency for marginal value); the fragment is
-// optional, GitHub still loads the page without it. Kept as a
-// hook so a future commit can plug in the real anchor if we
-// decide the precise auto-scroll is worth the cost.
-func anchorForPath(_ string) string {
-	return ""
+// fileBlobURL builds the github.com URL of the PR's "Files
+// changed" tab. Best-effort fallback when the in-app diff viewer
+// doesn't fit a use case — drops the user on the page GitHub
+// renders the same diff in a browser.
+//
+// No #diff-<sha> fragment: GitHub uses SHA-256 of the path for
+// the per-file anchor, and synthesising it would buy us only an
+// auto-scroll to the right file. Worth revisiting if users start
+// asking for "deep-link to this specific file on github.com";
+// today the page header has a navigable file tree anyway.
+func fileBlobURL(owner, repo string, number int, _ string) string {
+	return fmt.Sprintf("https://github.com/%s/%s/pull/%d/files",
+		owner, repo, number)
 }

--- a/internal/ui/pr_files.go
+++ b/internal/ui/pr_files.go
@@ -119,7 +119,7 @@ func (fm PRFilesModel) Update(msg tea.KeyMsg, width, height int) (PRFilesModel, 
 		if len(fm.files) == 0 {
 			return fm, nil
 		}
-		return fm, copyURLCmd(fm.files[fm.cursor].Path)
+		return fm, copyPathCmd(fm.files[fm.cursor].Path)
 	}
 	return fm, nil
 }

--- a/internal/ui/pr_files_test.go
+++ b/internal/ui/pr_files_test.go
@@ -1,0 +1,208 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestTruncatePathLeft covers the left-trim helper used by
+// fileRow. Two contracts to defend:
+//   - the returned string fits within `w` terminal cells
+//   - no rune is ever split (no UTF-8 invalid byte sequences in
+//     the output)
+//
+// We strip ANSI before measuring because callers paint the
+// active row in bold accent, but truncatePathLeft itself works
+// on the raw string.
+func TestTruncatePathLeft(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		width     int
+		wantWidth int    // max expected display width of the result
+		wantFinal string // last few chars we expect preserved (filename)
+	}{
+		{
+			name:      "fits without trim",
+			in:        "a/b/c.go",
+			width:     20,
+			wantWidth: 8,
+			wantFinal: "c.go",
+		},
+		{
+			name:      "trim leaves the filename intact",
+			in:        "internal/very/long/path/to/file.go",
+			width:     15,
+			wantWidth: 15,
+			wantFinal: "file.go",
+		},
+		{
+			name:      "trim on a path with multi-byte runes does not split a rune",
+			in:        "intérnal/ÜtilitÿDir/файл.go",
+			width:     14,
+			wantWidth: 14,
+			wantFinal: "файл.go",
+		},
+		{
+			name:      "width 1 collapses to ellipsis",
+			in:        "anything",
+			width:     1,
+			wantWidth: 1,
+			wantFinal: "…",
+		},
+		{
+			name:      "width 0 collapses to ellipsis",
+			in:        "anything",
+			width:     0,
+			wantWidth: 1,
+			wantFinal: "…",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncatePathLeft(tt.in, tt.width)
+			if w := cellWidth(got); w > tt.wantWidth {
+				t.Errorf("cellWidth(%q) = %d, want <= %d", got, w, tt.wantWidth)
+			}
+			if !strings.HasSuffix(got, tt.wantFinal) {
+				t.Errorf("result %q does not end with %q", got, tt.wantFinal)
+			}
+			// UTF-8 validity: round-tripping via ansi.Strip + []byte
+			// should produce a valid utf-8 string (no half runes).
+			plain := ansi.Strip(got)
+			for _, r := range plain {
+				if r == '�' {
+					t.Errorf("output %q contains replacement rune (truncation split a UTF-8 sequence)", got)
+				}
+			}
+		})
+	}
+}
+
+// TestFileStatusGlyph covers the small mapping table that turns
+// GitHub's REST status enum into a one-rune visual indicator.
+// Status values come from
+// https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+func TestFileStatusGlyph(t *testing.T) {
+	cases := []struct {
+		status string
+		want   string // ansi-stripped expected glyph
+	}{
+		{"added", "A"},
+		{"removed", "D"},
+		{"renamed", "R"},
+		{"copied", "C"},
+		{"modified", "M"},
+		{"changed", "M"},
+		{"unchanged", "·"},
+		{"", "·"},
+		{"something-new-from-github", "·"},
+	}
+	for _, c := range cases {
+		got := ansi.Strip(fileStatusGlyph(c.status))
+		if got != c.want {
+			t.Errorf("fileStatusGlyph(%q) = %q, want %q", c.status, got, c.want)
+		}
+	}
+}
+
+// TestRenderDiff covers the three branches of the diff renderer:
+//   - Truncated patches return the explicit banner
+//   - Empty patches fall through to a status-specific message
+//   - Normal patches are passed to chroma highlight, which we
+//     don't assert on character-by-character (the formatter
+//     output is large) but we do assert that the returned string
+//     contains the original patch's recognisable tokens
+func TestRenderDiff(t *testing.T) {
+	t.Run("truncated banner mentions github", func(t *testing.T) {
+		f := github.FileChange{Path: "huge.go", Truncated: true}
+		got := ansi.Strip(renderDiff(f))
+		if !strings.Contains(got, "github") {
+			t.Errorf("truncated banner = %q, expected to mention github", got)
+		}
+	})
+
+	t.Run("empty patch on renamed", func(t *testing.T) {
+		f := github.FileChange{Path: "moved.go", Status: "renamed"}
+		got := ansi.Strip(renderDiff(f))
+		if !strings.Contains(strings.ToLower(got), "rename") {
+			t.Errorf("renamed empty-patch message = %q", got)
+		}
+	})
+
+	t.Run("empty patch on removed", func(t *testing.T) {
+		f := github.FileChange{Path: "old.go", Status: "removed"}
+		got := ansi.Strip(renderDiff(f))
+		if !strings.Contains(strings.ToLower(got), "removed") {
+			t.Errorf("removed empty-patch message = %q", got)
+		}
+	})
+
+	t.Run("empty patch on binary / unknown falls back", func(t *testing.T) {
+		f := github.FileChange{Path: "logo.png", Status: "modified"}
+		got := ansi.Strip(renderDiff(f))
+		if !strings.Contains(strings.ToLower(got), "binary") {
+			t.Errorf("binary empty-patch message = %q", got)
+		}
+	})
+
+	t.Run("normal patch survives chroma round trip", func(t *testing.T) {
+		patch := "@@ -1,2 +1,2 @@\n-old\n+new"
+		f := github.FileChange{Path: "a.go", Status: "modified", Patch: patch}
+		got := ansi.Strip(renderDiff(f))
+		// chroma may reflow whitespace but the hunk header and
+		// the +/- markers should still be in the output.
+		if !strings.Contains(got, "@@") {
+			t.Errorf("rendered diff missing hunk header: %q", got)
+		}
+		if !strings.Contains(got, "-old") || !strings.Contains(got, "+new") {
+			t.Errorf("rendered diff missing diff lines: %q", got)
+		}
+	})
+}
+
+// TestKeyHints exercises the key-hint helper used across every
+// footer / title-bar. The exact ANSI codes vary by theme, so we
+// only assert on plain-text shape and the canonical separator.
+func TestKeyHints(t *testing.T) {
+	plain := func(s string) string { return ansi.Strip(s) }
+
+	t.Run("zero pairs returns empty", func(t *testing.T) {
+		if keyHints() != "" {
+			t.Errorf("keyHints() with no args should be empty")
+		}
+	})
+
+	t.Run("single pair joins key + label", func(t *testing.T) {
+		got := plain(keyHints("q", "quit"))
+		if got != "q quit" {
+			t.Errorf("got %q, want %q", got, "q quit")
+		}
+	})
+
+	t.Run("multiple pairs are joined by the canonical separator", func(t *testing.T) {
+		got := plain(keyHints("r", "refresh", "q", "quit"))
+		want := "r refresh" + keyHintsSep + "q quit"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("trailing odd key renders as bare key", func(t *testing.T) {
+		got := plain(keyHints("esc", "back", "?"))
+		want := "esc back" + keyHintsSep + "?"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty key falls back to plain muted label", func(t *testing.T) {
+		got := plain(keyHint("", "loading…"))
+		if got != "loading…" {
+			t.Errorf("got %q, want %q", got, "loading…")
+		}
+	})
+}

--- a/internal/ui/prs.go
+++ b/internal/ui/prs.go
@@ -262,7 +262,15 @@ func (pm PRsModel) renderPRsTab(stats *github.Stats, available, availableHeight 
 
 	table := renderPRsTable(rows[offset:end], cursor-offset, pm.sort)
 
-	hint := mutedStyle.Render("↑↓ move · g/G top/bottom · s sort · / search · enter details · o github · c copy")
+	hint := keyHints(
+		"↑↓", "move",
+		"g/G", "top/bottom",
+		"s", "sort",
+		"/", "search",
+		"enter", "details",
+		"o", "github",
+		"c", "copy",
+	)
 
 	parts := []string{headerLine}
 	if searchLine != "" {

--- a/internal/ui/repo_detail.go
+++ b/internal/ui/repo_detail.go
@@ -201,7 +201,7 @@ func (rd RepoDetailModel) View(width, height int) string {
 		return title + "\n\n" +
 			errorStyle.Render("Could not fetch detail") + "\n" +
 			mutedStyle.Render(rd.err.Error()) + "\n\n" +
-			mutedStyle.Render("r retry · esc back")
+			keyHints("r", "retry", "esc", "back")
 	}
 	if rd.detail == nil {
 		// Defensive — shouldn't happen (loading=false + err=nil
@@ -237,8 +237,11 @@ func (rd RepoDetailModel) View(width, height int) string {
 func (rd RepoDetailModel) renderTitle() string {
 	owner, name := github.SplitOwnerName(rd.repo.URL)
 	titleText := fmt.Sprintf("▸ Repos / %s / %s", owner, name)
-	return activeTabStyle.Render(titleText) +
-		mutedStyle.Render("  esc back · o open in github · r refresh")
+	return activeTabStyle.Render(titleText) + "  " + keyHints(
+		"esc", "back",
+		"o", "open in github",
+		"r", "refresh",
+	)
 }
 
 // computeBody renders the loaded-detail body (everything below the

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -324,7 +324,15 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 
 	table := renderReposTable(rows[offset:end], cursor-offset, rm.sort)
 
-	hint := mutedStyle.Render("↑↓ move · g/G top/bottom · s sort · / search · enter details · o github · c copy")
+	hint := keyHints(
+		"↑↓", "move",
+		"g/G", "top/bottom",
+		"s", "sort",
+		"/", "search",
+		"enter", "details",
+		"o", "github",
+		"c", "copy",
+	)
 
 	parts := []string{headerLine}
 	if searchLine != "" {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -202,7 +202,13 @@ func (sm SettingsModel) Update(msg tea.Msg) (SettingsModel, settingsAction) {
 // accent-pink focus border, value-style cyan numbers in the toggles.
 func (sm SettingsModel) View(width int) string {
 	title := boldStyle.Foreground(colAccent).Render("Settings")
-	hint := mutedStyle.Render("↑↓ move · space toggle · ← → cycle · enter save · esc cancel")
+	hint := keyHints(
+		"↑↓", "move",
+		"space", "toggle",
+		"← →", "cycle",
+		"enter", "save",
+		"esc", "cancel",
+	)
 
 	// Pad all labels to the length of the longest so the value
 	// column lands at a single x-coordinate. Looks much tidier than

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -34,7 +34,7 @@ func (m Model) View() string {
 		return outerStyle.Render(
 			renderBanner(m.version) + "\n\n" +
 				m.spinner.View() + "  " + mutedStyle.Render("Loading…") + "\n\n" +
-				mutedStyle.Render("q quit"),
+				keyHints("q", "quit"),
 		)
 	}
 	if m.err != nil && m.stats == nil {
@@ -42,7 +42,7 @@ func (m Model) View() string {
 			renderBanner(m.version) + "\n\n" +
 				errorStyle.Render("Could not fetch stats") + "\n" +
 				mutedStyle.Render(m.err.Error()) + "\n\n" +
-				mutedStyle.Render("r retry · q quit"),
+				keyHints("r", "retry", "q", "quit"),
 		)
 	}
 
@@ -834,15 +834,13 @@ func formatThousands(n int) string {
 func renderFooterBar(m Model) string {
 	age := time.Since(m.lastFetch).Truncate(time.Second)
 
-	keys := mutedStyle.Render("r") + " refresh  " +
-		mutedStyle.Render("·") + "  " +
-		mutedStyle.Render("1-5/tab") + " switch  " +
-		mutedStyle.Render("·") + "  " +
-		mutedStyle.Render("p") + " public  " +
-		mutedStyle.Render("·") + "  " +
-		mutedStyle.Render(",") + " settings  " +
-		mutedStyle.Render("·") + "  " +
-		mutedStyle.Render("q") + " quit"
+	keys := keyHints(
+		"r", "refresh",
+		"1-5/tab", "switch",
+		"p", "public",
+		",", "settings",
+		"q", "quit",
+	)
 
 	// Scroll hint surfaces only when the active tab actually overflows
 	// vertically — otherwise the keys row stays compact and the hint
@@ -855,17 +853,15 @@ func renderFooterBar(m Model) string {
 	switch m.activeTab {
 	case TabOverview:
 		if m.overviewVP.TotalLineCount() > m.overviewVP.VisibleLineCount() {
-			scrollHint = mutedStyle.Render("·") + "  " +
-				mutedStyle.Render("↑/↓") + " scroll"
+			scrollHint = keyHint("↑/↓", "scroll")
 		}
 	case TabActivity:
 		if m.activityVP.TotalLineCount() > m.activityVP.VisibleLineCount() {
-			scrollHint = mutedStyle.Render("·") + "  " +
-				mutedStyle.Render("↑/↓") + " scroll"
+			scrollHint = keyHint("↑/↓", "scroll")
 		}
 	}
 	if scrollHint != "" {
-		keys += "  " + scrollHint
+		keys += mutedStyle.Render(keyHintsSep) + scrollHint
 	}
 
 	// freshness is the "Updated Xs ago" or, while a fetch is in


### PR DESCRIPTION
## Summary

Pressing `enter` on a PR row drills into the PR detail (as of v0.11.0). This release adds **`f inspect`** at that level: a full-screen files list with cursor navigation, plus a per-file unified diff viewer with chroma syntax highlighting. First feature request to land off the v0.11.0 Product Hunt thread.

A second sweep across the app emphasises **the key over the label** in every hint line — same convention lazygit / k9s / gh-dash use — so the new keybind (and every existing one) reads as actionable rather than dissolving into the muted footer.

## What lands

### `f inspect` — files list + diff viewer
- New `github.FileChange{Path, Status, Additions, Deletions, Patch, Truncated}` plus `Client.FetchPRFiles`. REST against `/repos/{o}/{n}/pulls/{n}/files` because GraphQL doesn't expose the raw `patch` body.
- `FetchPRDetail` now runs the GraphQL drill-in **and** the REST files fetch **in parallel** (goroutines + `sync.WaitGroup`, same idiom as the v0.10.1 dashboard split). Wall-clock latency stays close to the slower of the two; first error from either side aborts so the drill-in never paints a half-populated payload.
- Patches over **500 hunk lines** are dropped and flagged `Truncated`; pagination caps at **300 files per PR**. Hard limits chosen so a worst-case 5000-line patch can't freeze the viewport.
- `Path` and `Patch` both pass through `github.Sanitize` at the boundary — hostile diff content can't inject ANSI escapes (same defence pattern from v0.11.0).
- `PRFilesModel` nested inside `PRDetailModel` renders the files list: cursor `↑↓ j/k`, status glyphs `A/D/M/R/C`, +Additions/-Deletions counts, viewport-style windowing so the cursor never scrolls off-screen.
- `PRDiffModel` deeper still renders the patch through chroma's `diff` lexer + monokai + terminal256 formatter (chroma is already in the binary via glamour — no new dep). `bubbles/viewport` for scrolling, width-keyed body cache mirroring the markdown body cache.
- Dedicated empty states for binary files, removed entries, content-less renames, and patches truncated by the cap — no blank sections.

### UI hint visibility refactor
- New `internal/ui/hints.go` with `keyHint(key, label)` and `keyHints(pairs ...string)`. The key renders in accent (pink) + bold; the label stays muted; entries join with a shared `keyHintsSep`.
- All hint sites in the app migrate to the helper: three drill-in title bars, their retry hints, the new sub-view footers, three list-tab footers, action menu, settings panel, global footer + scroll-hint suffix, boot loading + error screens.
- `f inspect` moves from the Files-changed meta line up into the title-bar hints alongside `esc / o / r` — every drill-in action concentrated in one visual region.

### Polish
- `urlCopiedMsg` learns a `noun` field so the toast reads \"Path copied\" when we copy a file path and \"URL copied\" when we copy an item URL. New `copyPathCmd` wraps the same primitive with `noun=\"Path\"`.
- `PRDiffModel` grows a `c` keybind that copies the current file's path, plus the matching footer hint.

## Architecture notes

- Two new sub-models (`PRFilesModel`, `PRDiffModel`) nest **inside `PRDetailModel`** rather than as peers of the root model's `repoDetail` / `prDetail` / `issueDetail`. They exist only while a PR detail is open, so the root dispatcher stays untouched — no extra mutual-exclusion bookkeeping at the top level.
- `Client.rest *http.Client` shares the oauth2 transport with the GraphQL client (or falls back to `http.DefaultClient` unauthenticated), so REST and GraphQL use the same auth context without duplicate setup.

## Test plan

- [x] `go build` clean (dual-target: `./octoscope` + `/opt/homebrew/bin/octoscope`)
- [x] `go test -race ./...` passes
- [x] Manual smoke (maintainer): PR with mixed files (added / modified / removed / renamed), patches small / large / truncated, binary / content-less renames render dedicated empty states
- [x] Manual smoke: `c` toast reads \"Path copied\" in the sub-views and still \"URL copied\" in the list tabs
- [x] Manual smoke: every key hint line across the app uses the new accent-key + muted-label style

## Out of scope (deferred)

- Side-by-side diff view (only unified for the first cut)
- `?w=1` ignore-whitespace toggle
- Inline diff comments / review actions — octoscope stays read-only