### PR TITLE
Repos tab gets serious: CI status column + pinned repos + smoke harness (v0.13.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           cache: true
       - name: Build
         run: go build -v ./...
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           cache: true
       - name: Test (race)
         run: go test -race ./...
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           cache: true
       - name: gofmt
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+# CI workflow. Runs on every push and pull-request against main to
+# catch the obvious regressions before they reach a tag.
+#
+# Three jobs: build (compile-only sanity), test (race-checked unit
+# suite), and lint (gofmt + go vet). Each runs on the same Ubuntu
+# runner with caching keyed on go.sum so successive runs are fast.
+#
+# The vhs-driven smoke tapes (tapes/*.tape) are NOT invoked here —
+# they require a real GITHUB_TOKEN with the same scopes a user
+# would have, and the asset generation step is intentionally
+# human-in-the-loop. CI's job is "did this commit break the
+# build?", not "did the rendered output drift?".
+
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Build
+        run: go build -v ./...
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Test (race)
+        run: go test -race ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: gofmt
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "files need formatting:"
+            gofmt -l .
+            exit 1
+          fi
+      - name: go vet
+        run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # Goreleaser output (added in v0.2+)
 /dist/
 
+# vhs rendered output (tapes/*.tape are committed; tapes/out/ is
+# regenerable via `make tapes` and never lands in git).
+/tapes/out/
+
 # Go test coverage
 coverage.out
 coverage.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+.PHONY: build install test race tapes tape tapes-clean fmt vet help
+
+# Dual-target build — what the maintainer runs after every Go edit.
+# `./octoscope` is the iterate-and-test binary; the brew-installed
+# binary at /opt/homebrew/bin/octoscope is what `octoscope` from
+# anywhere picks up. Forgetting one half causes "I don't see my
+# change" loops, so the canonical build target keeps both in sync.
+build:
+	go build -o ./octoscope .
+	go build -o /opt/homebrew/bin/octoscope .
+
+install:
+	go install .
+
+# Race-checked unit suite. Same command we run in CI so local
+# results match what the workflow will report.
+test:
+	go test ./...
+
+race:
+	go test -race ./...
+
+fmt:
+	gofmt -w .
+
+vet:
+	go vet ./...
+
+# tapes/ — vhs-driven smoke session + asset generator.
+# Renders every .tape into tapes/out/*.gif and *.png. Requires
+# `vhs` on $PATH (`brew install vhs`) and a valid $GITHUB_TOKEN so
+# octoscope's real fetch path actually returns data; the tapes are
+# not mocked.
+TAPES_DIR := tapes
+TAPES_OUT := $(TAPES_DIR)/out
+
+tapes: tapes-clean
+	@command -v vhs >/dev/null 2>&1 || { \
+		echo "vhs not installed — run 'brew install vhs' first."; \
+		exit 1; \
+	}
+	@mkdir -p $(TAPES_OUT)
+	@for tape in $(TAPES_DIR)/*.tape; do \
+		echo "→ rendering $$tape"; \
+		(cd $(TAPES_DIR) && vhs $$(basename $$tape)); \
+	done
+	@echo "✓ tapes rendered into $(TAPES_OUT)"
+
+# Render a single tape: `make tape NAME=overview`.
+tape:
+	@if [ -z "$(NAME)" ]; then \
+		echo "usage: make tape NAME=<tape-base-name>"; \
+		exit 2; \
+	fi
+	@command -v vhs >/dev/null 2>&1 || { \
+		echo "vhs not installed — run 'brew install vhs' first."; \
+		exit 1; \
+	}
+	@mkdir -p $(TAPES_OUT)
+	(cd $(TAPES_DIR) && vhs $(NAME).tape)
+
+tapes-clean:
+	@rm -rf $(TAPES_OUT)
+
+help:
+	@echo "Targets:"
+	@echo "  build       — dual-target build (./octoscope + /opt/homebrew/bin/octoscope)"
+	@echo "  install     — go install"
+	@echo "  test        — go test ./..."
+	@echo "  race        — go test -race ./..."
+	@echo "  fmt         — gofmt -w ."
+	@echo "  vet         — go vet ./..."
+	@echo "  tapes       — render every tapes/*.tape via vhs (needs \$$GITHUB_TOKEN)"
+	@echo "  tape NAME=x — render tapes/x.tape only"
+	@echo "  tapes-clean — wipe tapes/out/"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,26 @@
 .PHONY: build install test race tapes tape tapes-clean fmt vet help
 
 # Dual-target build — what the maintainer runs after every Go edit.
-# `./octoscope` is the iterate-and-test binary; the brew-installed
-# binary at /opt/homebrew/bin/octoscope is what `octoscope` from
-# anywhere picks up. Forgetting one half causes "I don't see my
-# change" loops, so the canonical build target keeps both in sync.
+# `./octoscope` is the iterate-and-test binary; the binary under
+# $(BINDIR) is what `octoscope` from anywhere picks up (a brew
+# install on macOS lands it at /opt/homebrew/bin/, hence the
+# default). Override BINDIR on the command line — or unset it — on
+# systems with a different install path:
+#
+#   make build BINDIR=/usr/local/bin           # Intel macOS / Linux
+#   make build BINDIR=                          # skip second target
+#
+# The second build is skipped silently when BINDIR is empty or
+# when the directory doesn't exist, so the target is portable
+# instead of macOS-brew-only.
+BINDIR ?= /opt/homebrew/bin
+
 build:
 	go build -o ./octoscope .
-	go build -o /opt/homebrew/bin/octoscope .
+	@if [ -n "$(BINDIR)" ] && [ -d "$(BINDIR)" ]; then \
+		echo "→ also building into $(BINDIR)/octoscope"; \
+		go build -o $(BINDIR)/octoscope .; \
+	fi
 
 install:
 	go install .
@@ -64,7 +77,7 @@ tapes-clean:
 
 help:
 	@echo "Targets:"
-	@echo "  build       — dual-target build (./octoscope + /opt/homebrew/bin/octoscope)"
+	@echo "  build       — dual-target build (./octoscope + \$$BINDIR/octoscope when set)"
 	@echo "  install     — go install"
 	@echo "  test        — go test ./..."
 	@echo "  race        — go test -race ./..."

--- a/README.md
+++ b/README.md
@@ -58,9 +58,13 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
 - **Overview** — the five stat sections below, the traditional dashboard
   landing.
 - **Repos** — every owned, non-fork repository in one sortable, searchable
-  list. Columns: name, primary language, stars, forks, open issues, open
-  PRs, last push. Press `s` to cycle sort, `/` to filter by substring, the
-  viewport scrolls so even a 100-repo account stays navigable.
+  list. Columns: **CI status** (a coloured dot — green / red / yellow / dim
+  — sourced from the default-branch status-check rollup), name, primary
+  language, stars, forks, open issues, open PRs, last push. Press `s` to
+  cycle sort (CI is in the cycle and surfaces failures first), `/` to
+  filter by substring, `P` on a row to pin a repo to a sticky section at
+  the top — the viewport scrolls so even a 100-repo account stays
+  navigable.
 - **PRs** — every open pull request you've authored, across every repo.
   Number, title, repo, state (draft / ready / conflicts) and last-update
   time. Same sort & search idioms as Repos.
@@ -336,6 +340,15 @@ theme = "octoscope"
 # Hex ("#FF0080") or ANSI 256 ("201"). Leave unset to keep the
 # theme's default accent.
 # accent_color = "#FF0080"
+
+# Repositories pinned to the top of the Repos tab. Each entry is
+# "owner/name"; order is preserved exactly as listed here. Press
+# P on any repo row to add / remove it — the file is rewritten
+# atomically. Malformed entries are dropped silently at load.
+# pinned_repos = [
+#   "gfazioli/octoscope",
+#   "gfazioli/Mantine-Hint",
+# ]
 ```
 
 Pass `--config PATH` to read a different file (handy for trying out
@@ -383,7 +396,8 @@ Key bindings while running:
 | `o` | Open the selected repo / PR / issue in your browser (or, inside the PR diff viewer, the PR's Files-changed tab on github.com) |
 | `c` | Copy the selected row's URL (or, inside the PR diff viewer / files list, the current file's path) to your system clipboard |
 | `f` | Inside the PR drill-in: inspect the changed files (full-screen list → Enter opens each file's diff with syntax highlighting) |
-| `o` / `d` / `c` | Inside the action menu: Open in GitHub · View details · Copy URL |
+| `P` | On a Repos row: toggle pin/unpin (pinned repos stick to the top of the Repos tab, ordering preserved across refreshes; writes back to config) |
+| `o` / `d` / `c` / `P` | Inside the action menu on Repos: Open in GitHub · View details · Copy URL · Pin/Unpin |
 | `esc` | Close the action menu / detail view, or clear the current filter |
 | `r` | Refresh now (or refetch the current detail view when open) |
 | `p` | Toggle public-only mode (saves to config) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -914,7 +914,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.12.0</span>
+                <span class="version-tag" id="version-pill">0.13.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1052,6 +1052,11 @@
                     <div class="feature-label">Drill in</div>
                     <h3>One keystroke deeper</h3>
                     <p>Press <code class="inline">enter</code> on any row of <strong style="color: var(--text);">Repos</strong> / <strong style="color: var(--text);">PRs</strong> / <strong style="color: var(--text);">Issues</strong> for a rich detail view: descriptions in markdown, reviewers, checks, comments, linked PRs and timelines. Inside a PR, press <code class="inline">f</code> to inspect the changed files and Enter on any of them to read its unified diff syntax-highlighted inline &mdash; never leave the terminal. One targeted query per item, no rate-limit pressure.</p>
+                </div>
+                <div class="feature wide">
+                    <div class="feature-label">Repos tab gets serious</div>
+                    <h3>CI status &middot; pinned repos</h3>
+                    <p>New in v0.13.0. The Repos tab now leads with a <strong style="color: var(--text);">CI status dot</strong> on every row &mdash; green / red / yellow / dim &mdash; sourced from the default branch's status-check rollup, with a "by CI" sort that surfaces failing repos first. Press <code class="inline">P</code> on a row to <strong style="color: var(--text);">pin</strong> it: pinned repos stick to a section at the top of the list (order preserved across refreshes), and the choice is written back to <code class="inline">~/.config/octoscope/config.toml</code> automatically. Hand-edit the file to lock the ordering you want; press <code class="inline">P</code> again to unpin.</p>
                 </div>
                 <div class="feature wide">
                     <div class="feature-label">Configurable</div>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -56,6 +57,16 @@ type Config struct {
 	// "#FF0080", ANSI 256 numbers like "201"). Empty disables the
 	// override. The other palette slots stay on the named theme.
 	AccentColor string `toml:"accent_color"`
+
+	// PinnedRepos is the list of "owner/name" identifiers that the
+	// Repos tab will surface in a dedicated section above the rest
+	// of the list, in the order written here. v0.13.0+ feature.
+	// Each entry must look exactly like "owner/name" — anything
+	// else is silently dropped at load time (with a warning the
+	// caller can surface), so a typo in the file can't crash the
+	// app on boot. Duplicates are de-duplicated keeping the first
+	// occurrence so the file's intent is preserved.
+	PinnedRepos []string `toml:"pinned_repos"`
 }
 
 // Defaults returns the values octoscope uses when no config file
@@ -67,7 +78,46 @@ func Defaults() Config {
 		Compact:         false,
 		Theme:           "octoscope",
 		AccentColor:     "",
+		PinnedRepos:     nil,
 	}
+}
+
+// SanitizePinnedRepos returns a fresh slice with empty entries
+// dropped, "owner/name" shape enforced, and duplicates removed
+// (first occurrence wins so the file's ordering survives). Used
+// at Load time and as a defensive pre-Save scrub so a bad in-
+// memory list never reaches disk.
+//
+// Anything that doesn't match a single "/" with non-empty owner
+// and non-empty name is silently dropped — callers can compare
+// len(in) vs len(out) to detect "the file had typos worth
+// telling the user about".
+func SanitizePinnedRepos(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			continue
+		}
+		parts := strings.Split(s, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		key := strings.ToLower(s)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // DefaultPath returns the file octoscope looks for absent
@@ -114,11 +164,12 @@ func Load(path string) (Config, error) {
 	// duration field; we can't tag time.Duration directly because
 	// BurntSushi/toml doesn't know it.
 	var raw struct {
-		RefreshInterval string `toml:"refresh_interval"`
-		PublicOnly      *bool  `toml:"public_only"`
-		Compact         *bool  `toml:"compact"`
-		Theme           string `toml:"theme"`
-		AccentColor     string `toml:"accent_color"`
+		RefreshInterval string   `toml:"refresh_interval"`
+		PublicOnly      *bool    `toml:"public_only"`
+		Compact         *bool    `toml:"compact"`
+		Theme           string   `toml:"theme"`
+		AccentColor     string   `toml:"accent_color"`
+		PinnedRepos     []string `toml:"pinned_repos"`
 	}
 	if _, err := toml.DecodeFile(path, &raw); err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
@@ -144,6 +195,7 @@ func Load(path string) (Config, error) {
 	if raw.AccentColor != "" {
 		cfg.AccentColor = raw.AccentColor
 	}
+	cfg.PinnedRepos = SanitizePinnedRepos(raw.PinnedRepos)
 
 	return cfg, nil
 }
@@ -174,6 +226,23 @@ func Save(path string, cfg Config) error {
 		accentLine = fmt.Sprintf("\n# Override the active theme's accent colour. Hex (\"#FF0080\")\n# or ANSI 256 (\"201\"). Leave unset to use the theme's default.\naccent_color = %q\n", cfg.AccentColor)
 	}
 
+	// Same idea for pinned_repos: only emit the section when the
+	// list is non-empty so a freshly-saved file stays minimal.
+	// Defensive sanitisation here too — a caller that bypassed
+	// the in-memory normaliser can't sneak garbage onto disk.
+	pinnedLine := ""
+	if pins := SanitizePinnedRepos(cfg.PinnedRepos); len(pins) > 0 {
+		var b strings.Builder
+		b.WriteString("\n# Repositories pinned to the top of the Repos tab.\n")
+		b.WriteString("# Order here is preserved; press P on a row to toggle.\n")
+		b.WriteString("pinned_repos = [\n")
+		for _, p := range pins {
+			fmt.Fprintf(&b, "  %q,\n", p)
+		}
+		b.WriteString("]\n")
+		pinnedLine = b.String()
+	}
+
 	body := fmt.Sprintf(`# octoscope configuration
 # Auto-saved by octoscope. Edit by hand or via the in-app settings
 # panel (press ',' while running).
@@ -190,7 +259,7 @@ compact = %t
 # Visual theme. Built-in: octoscope (default), high-contrast,
 # terminal, monochrome, stranger-things, phosphor, amber.
 theme = %q
-%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, accentLine)
+%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, accentLine, pinnedLine)
 
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestSanitizePinnedRepos pins the contract: drop empties, drop
+// malformed entries, de-duplicate case-insensitively, preserve
+// first-occurrence order, return nil for an all-empty input.
+func TestSanitizePinnedRepos(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "nil in, nil out",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "all valid passes through",
+			in:   []string{"gfazioli/octoscope", "charmbracelet/glamour"},
+			want: []string{"gfazioli/octoscope", "charmbracelet/glamour"},
+		},
+		{
+			name: "empty and whitespace entries dropped",
+			in:   []string{"", "  ", "gfazioli/octoscope"},
+			want: []string{"gfazioli/octoscope"},
+		},
+		{
+			name: "malformed dropped — missing owner",
+			in:   []string{"/octoscope", "gfazioli/octoscope"},
+			want: []string{"gfazioli/octoscope"},
+		},
+		{
+			name: "malformed dropped — missing name",
+			in:   []string{"gfazioli/", "gfazioli/octoscope"},
+			want: []string{"gfazioli/octoscope"},
+		},
+		{
+			name: "malformed dropped — too many segments",
+			in:   []string{"gfazioli/octoscope/x", "gfazioli/octoscope"},
+			want: []string{"gfazioli/octoscope"},
+		},
+		{
+			name: "duplicates dropped, case-insensitive, first wins",
+			in:   []string{"gfazioli/Octoscope", "GFAZIOLI/octoscope"},
+			want: []string{"gfazioli/Octoscope"},
+		},
+		{
+			name: "all entries invalid → nil",
+			in:   []string{"", "/", "no-slash", "a/b/c"},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizePinnedRepos(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadPinnedRepos covers the end-to-end TOML parse + sanitize
+// path: a config file with mixed valid / malformed pinned_repos
+// produces a clean slice on the Config.
+func TestLoadPinnedRepos(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := []byte(`
+refresh_interval = "30s"
+pinned_repos = [
+  "gfazioli/octoscope",
+  "",
+  "no-slash",
+  "GFAZIOLI/OCTOSCOPE",
+  "charmbracelet/glamour",
+]
+`)
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"gfazioli/octoscope", "charmbracelet/glamour"}
+	if !reflect.DeepEqual(cfg.PinnedRepos, want) {
+		t.Errorf("pinned = %#v, want %#v", cfg.PinnedRepos, want)
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -213,12 +213,12 @@ type RateLimit struct {
 type FetchErrorReason int
 
 const (
-	ReasonUnknown              FetchErrorReason = iota
-	ReasonRateLimitPrimary                      // 5000/h GraphQL budget exhausted
-	ReasonRateLimitSecondary                    // short-term abuse throttle
-	ReasonAuth                                  // 401/403 from token rejection
-	ReasonNetwork                               // DNS, TCP, TLS, context timeout
-	ReasonServer                                // 5xx or GraphQL-level error
+	ReasonUnknown            FetchErrorReason = iota
+	ReasonRateLimitPrimary                    // 5000/h GraphQL budget exhausted
+	ReasonRateLimitSecondary                  // short-term abuse throttle
+	ReasonAuth                                // 401/403 from token rejection
+	ReasonNetwork                             // DNS, TCP, TLS, context timeout
+	ReasonServer                              // 5xx or GraphQL-level error
 )
 
 // FetchError wraps the original error with a classified reason. Kept
@@ -270,9 +270,9 @@ type Stats struct {
 	TotalStarsWithForks int
 
 	// Activity (lifetime counts unless noted)
-	PRsTotal                 int
-	PRsMerged                int
-	IssuesAuthored           int
+	PRsTotal       int
+	PRsMerged      int
+	IssuesAuthored int
 	// OpenPRsAuthored is the count of currently-open pull requests
 	// the user authored, anywhere on GitHub (including repos they
 	// don't own). Distinct from Stats.OpenPRs in the Operational
@@ -590,7 +590,14 @@ type repoFields struct {
 	Repositories struct {
 		TotalCount githubv4.Int
 		Nodes      []struct {
-			Name            githubv4.String
+			Name githubv4.String
+			// NameWithOwner is the merge key against repoCIFields
+			// in extractStats — bare Name isn't unique when
+			// ownerAffiliations expands across personal + orgs
+			// (an org may legitimately own a repo called the
+			// same as a personal one). NameWithOwner is the
+			// canonical "owner/name" string GitHub guarantees.
+			NameWithOwner   githubv4.String
 			URL             githubv4.String `graphql:"url"`
 			IsPrivate       githubv4.Boolean
 			PushedAt        githubv4.DateTime
@@ -625,12 +632,14 @@ type repoFields struct {
 // repository nodes blew GitHub's gateway complexity ceiling and
 // 502'd on busy accounts — exactly the same failure mode that
 // drove the v0.10.1 split. Each node carries only the bare
-// minimum (name + rollup state) so this query stays cheap; the
-// merge happens by name in extractStats.
+// minimum (nameWithOwner + rollup state) so this query stays
+// cheap; the merge happens by NameWithOwner in extractStats so
+// org-level repos don't collide with personal repos that share
+// a bare name.
 type repoCIFields struct {
 	Repositories struct {
 		Nodes []struct {
-			Name             githubv4.String
+			NameWithOwner    githubv4.String
 			DefaultBranchRef struct {
 				Target struct {
 					Commit struct {
@@ -668,10 +677,10 @@ type repoCIFields struct {
 // (followers, PRs, issues) are unaffected.
 func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	var (
-		profile    profileFields
-		repos      repoFields
-		repoCI     repoCIFields
-		rlP, rlR, rlC rateLimitFields
+		profile          profileFields
+		repos            repoFields
+		repoCI           repoCIFields
+		rlP, rlR, rlC    rateLimitFields
 		errP, errR, errC error
 	)
 
@@ -885,16 +894,20 @@ func classifyErr(ctx context.Context, err error) FetchErrorReason {
 // the data merge happens in one place rather than scattered
 // across the call sites.
 func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *Stats {
-	// Build the CI lookup once — owner is implicit (the same
-	// scope as repoFields, so we can match on bare name) and
-	// nodes are bounded by the repositories(first: 100) cap.
-	ciByName := make(map[string]string, len(ci.Repositories.Nodes))
+	// Build the CI lookup once, keyed on the canonical
+	// "owner/name" string. Bare Name isn't unique inside
+	// ownerAffiliations: OWNER once orgs are in the picture (an
+	// org may own a repo called the same as a personal one) —
+	// using NameWithOwner as the key keeps the merge correct in
+	// every account shape. Nodes are bounded by the
+	// repositories(first: 100) cap, so the map stays small.
+	ciByNameWithOwner := make(map[string]string, len(ci.Repositories.Nodes))
 	for _, n := range ci.Repositories.Nodes {
-		name := string(n.Name)
-		if name == "" {
+		key := string(n.NameWithOwner)
+		if key == "" {
 			continue
 		}
-		ciByName[name] = string(n.DefaultBranchRef.Target.Commit.StatusCheckRollup.State)
+		ciByNameWithOwner[key] = string(n.DefaultBranchRef.Target.Commit.StatusCheckRollup.State)
 	}
 	// Sanitize at the boundary — every GitHub-sourced string
 	// flowing into Stats passes through Sanitize so the UI layer
@@ -997,7 +1010,7 @@ func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *S
 			OpenPRs:         int(repo.PullRequests.TotalCount),
 			PushedAt:        repo.PushedAt.Time,
 			IsPrivate:       bool(repo.IsPrivate),
-			CIState:         Sanitize(ciByName[string(repo.Name)]),
+			CIState:         Sanitize(ciByNameWithOwner[string(repo.NameWithOwner)]),
 		})
 
 		for _, e := range repo.Languages.Edges {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -615,15 +615,22 @@ type repoFields struct {
 					}
 				}
 			} `graphql:"languages(first: 10, orderBy: {field: SIZE, direction: DESC})"`
-			// CI rollup — one extra nested object per repo, no
-			// fan-out across N queries. Added in v0.13.0 for the
-			// Repos-tab CI status column. Carefully kept as a
-			// single scalar (state); we don't pull contexts here
-			// because the per-context detail already lives on the
-			// PR drill-in via the existing prDetailQuery, and
-			// pulling it for 100 repos × N contexts would blow
-			// the complexity budget the v0.10.1 split was
-			// designed to respect.
+		}
+	} `graphql:"repositories(first: 100, ownerAffiliations: OWNER, isFork: false)"`
+}
+
+// repoCIFields is the third parallel query introduced in v0.13.0
+// to power the Repos-tab CI status column. Kept separate from
+// repoFields because pulling statusCheckRollup inline on the main
+// repository nodes blew GitHub's gateway complexity ceiling and
+// 502'd on busy accounts — exactly the same failure mode that
+// drove the v0.10.1 split. Each node carries only the bare
+// minimum (name + rollup state) so this query stays cheap; the
+// merge happens by name in extractStats.
+type repoCIFields struct {
+	Repositories struct {
+		Nodes []struct {
+			Name             githubv4.String
 			DefaultBranchRef struct {
 				Target struct {
 					Commit struct {
@@ -661,14 +668,15 @@ type repoFields struct {
 // (followers, PRs, issues) are unaffected.
 func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	var (
-		profile profileFields
-		repos   repoFields
-		rlP, rlR rateLimitFields
-		errP, errR error
+		profile    profileFields
+		repos      repoFields
+		repoCI     repoCIFields
+		rlP, rlR, rlC rateLimitFields
+		errP, errR, errC error
 	)
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()
@@ -714,9 +722,35 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		}
 	}()
 
+	// Third parallel query — CI rollup state per repo, kept on a
+	// minimal payload (name + statusCheckRollup.state) so it stays
+	// well under the complexity ceiling. Pulling the same field
+	// inline on repoFields 502'd the gateway on busy accounts.
+	go func() {
+		defer wg.Done()
+		if c.login == "" {
+			var q struct {
+				Viewer    repoCIFields
+				RateLimit rateLimitFields
+			}
+			errC = c.gql.Query(ctx, &q, nil)
+			repoCI = q.Viewer
+			rlC = q.RateLimit
+		} else {
+			var q struct {
+				User      repoCIFields `graphql:"user(login: $login)"`
+				RateLimit rateLimitFields
+			}
+			vars := map[string]interface{}{"login": githubv4.String(c.login)}
+			errC = c.gql.Query(ctx, &q, vars)
+			repoCI = q.User
+			rlC = q.RateLimit
+		}
+	}()
+
 	wg.Wait()
 
-	// Surface the first error — both queries serve the same
+	// Surface the first error — all three queries serve the same
 	// dashboard, so a partial result would be misleading. The
 	// classifier sees the actual error so the footer message
 	// stays accurate (rate-limit / auth / network / 5xx).
@@ -726,9 +760,12 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	if errR != nil {
 		return nil, &FetchError{Reason: classifyErr(ctx, errR), Err: errR}
 	}
+	if errC != nil {
+		return nil, &FetchError{Reason: classifyErr(ctx, errC), Err: errC}
+	}
 
-	stats := c.extractStats(profile, repos)
-	stats.RateLimit = mergeRateLimit(rlP, rlR)
+	stats := c.extractStats(profile, repos, repoCI)
+	stats.RateLimit = mergeRateLimit3(rlP, rlR, rlC)
 	return stats, nil
 }
 
@@ -747,6 +784,36 @@ func mergeRateLimit(a, b rateLimitFields) *RateLimit {
 		pick = b
 	}
 	cost := int(a.Cost) + int(b.Cost)
+	return &RateLimit{
+		Cost:      cost,
+		Limit:     int(pick.Limit),
+		Remaining: int(pick.Remaining),
+		ResetAt:   pick.ResetAt.Time,
+	}
+}
+
+// mergeRateLimit3 is the 3-way variant introduced in v0.13.0
+// when the parallel fetch grew a third query (repoCIFields).
+// Same "most pessimistic remaining wins, costs sum" semantics
+// as mergeRateLimit. Lives next to its 2-way counterpart so
+// future callers can pick whichever arity fits.
+func mergeRateLimit3(a, b, c rateLimitFields) *RateLimit {
+	pick := a
+	candidates := []rateLimitFields{b, c}
+	for _, cand := range candidates {
+		if int(cand.Limit) > 0 && int(cand.Remaining) < int(pick.Remaining) {
+			pick = cand
+		}
+	}
+	if int(pick.Limit) == 0 {
+		for _, cand := range candidates {
+			if int(cand.Limit) > 0 {
+				pick = cand
+				break
+			}
+		}
+	}
+	cost := int(a.Cost) + int(b.Cost) + int(c.Cost)
 	return &RateLimit{
 		Cost:      cost,
 		Limit:     int(pick.Limit),
@@ -810,13 +877,25 @@ func classifyErr(ctx context.Context, err error) FetchErrorReason {
 }
 
 // extractStats flattens the two GraphQL response halves
-// (profileFields + repoFields) into the UI-facing Stats struct,
-// aggregating per-repo totals and deduping languages. Pure
+// (profileFields + repoFields + repoCIFields) into the UI-facing
+// Stats struct, aggregating per-repo totals, deduping languages
+// and merging the parallel CI rollup payload by repo name. Pure
 // function aside from the client-level Authenticated/IsViewer
 // flags. Lives downstream of FetchStats's parallel goroutines so
 // the data merge happens in one place rather than scattered
 // across the call sites.
-func (c *Client) extractStats(p profileFields, r repoFields) *Stats {
+func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *Stats {
+	// Build the CI lookup once — owner is implicit (the same
+	// scope as repoFields, so we can match on bare name) and
+	// nodes are bounded by the repositories(first: 100) cap.
+	ciByName := make(map[string]string, len(ci.Repositories.Nodes))
+	for _, n := range ci.Repositories.Nodes {
+		name := string(n.Name)
+		if name == "" {
+			continue
+		}
+		ciByName[name] = string(n.DefaultBranchRef.Target.Commit.StatusCheckRollup.State)
+	}
 	// Sanitize at the boundary — every GitHub-sourced string
 	// flowing into Stats passes through Sanitize so the UI layer
 	// downstream renders without worrying about embedded
@@ -918,7 +997,7 @@ func (c *Client) extractStats(p profileFields, r repoFields) *Stats {
 			OpenPRs:         int(repo.PullRequests.TotalCount),
 			PushedAt:        repo.PushedAt.Time,
 			IsPrivate:       bool(repo.IsPrivate),
-			CIState:         Sanitize(string(repo.DefaultBranchRef.Target.Commit.StatusCheckRollup.State)),
+			CIState:         Sanitize(ciByName[string(repo.Name)]),
 		})
 
 		for _, e := range repo.Languages.Edges {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -155,6 +155,16 @@ type Repo struct {
 	OpenPRs         int
 	PushedAt        time.Time
 	IsPrivate       bool
+
+	// CIState is the status-check rollup state of the latest
+	// commit on the default branch, sourced from
+	// `defaultBranchRef.target.statusCheckRollup.state`. Empty
+	// string means "no rollup" (no default branch, no workflow
+	// run on the head commit, fork that never ran CI). The UI
+	// renders it as a coloured dot in the Repos tab. Enum
+	// values from GitHub: SUCCESS, FAILURE, ERROR, PENDING,
+	// EXPECTED.
+	CIState string
 }
 
 // PullRequest is one open PR authored by the user, feeding the PRs
@@ -605,6 +615,24 @@ type repoFields struct {
 					}
 				}
 			} `graphql:"languages(first: 10, orderBy: {field: SIZE, direction: DESC})"`
+			// CI rollup — one extra nested object per repo, no
+			// fan-out across N queries. Added in v0.13.0 for the
+			// Repos-tab CI status column. Carefully kept as a
+			// single scalar (state); we don't pull contexts here
+			// because the per-context detail already lives on the
+			// PR drill-in via the existing prDetailQuery, and
+			// pulling it for 100 repos × N contexts would blow
+			// the complexity budget the v0.10.1 split was
+			// designed to respect.
+			DefaultBranchRef struct {
+				Target struct {
+					Commit struct {
+						StatusCheckRollup struct {
+							State githubv4.StatusState
+						}
+					} `graphql:"... on Commit"`
+				}
+			}
 		}
 	} `graphql:"repositories(first: 100, ownerAffiliations: OWNER, isFork: false)"`
 }
@@ -890,6 +918,7 @@ func (c *Client) extractStats(p profileFields, r repoFields) *Stats {
 			OpenPRs:         int(repo.PullRequests.TotalCount),
 			PushedAt:        repo.PushedAt.Time,
 			IsPrivate:       bool(repo.IsPrivate),
+			CIState:         Sanitize(string(repo.DefaultBranchRef.Target.Commit.StatusCheckRollup.State)),
 		})
 
 		for _, e := range repo.Languages.Edges {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -806,29 +806,40 @@ func mergeRateLimit(a, b rateLimitFields) *RateLimit {
 // Same "most pessimistic remaining wins, costs sum" semantics
 // as mergeRateLimit. Lives next to its 2-way counterpart so
 // future callers can pick whichever arity fits.
+//
+// Iterates all three envelopes in one pass and only ever
+// considers candidates with Limit>0. The previous
+// initialise-with-`a`-then-loop shape produced a wrong pick
+// when `a.Limit==0`: pick.Remaining started at 0, and the
+// strict `< pick.Remaining` comparison meant no candidate
+// could ever beat it, so the fallback path took the first
+// non-zero-Limit envelope rather than the smallest
+// Remaining one.
 func mergeRateLimit3(a, b, c rateLimitFields) *RateLimit {
-	pick := a
-	candidates := []rateLimitFields{b, c}
-	for _, cand := range candidates {
-		if int(cand.Limit) > 0 && int(cand.Remaining) < int(pick.Remaining) {
-			pick = cand
-		}
-	}
-	if int(pick.Limit) == 0 {
-		for _, cand := range candidates {
-			if int(cand.Limit) > 0 {
-				pick = cand
-				break
-			}
-		}
-	}
 	cost := int(a.Cost) + int(b.Cost) + int(c.Cost)
-	return &RateLimit{
-		Cost:      cost,
-		Limit:     int(pick.Limit),
-		Remaining: int(pick.Remaining),
-		ResetAt:   pick.ResetAt.Time,
+
+	// pick is the most pessimistic envelope seen so far. nil
+	// means we haven't seen any valid one yet (Limit==0 on all
+	// three is an "every query returned an empty rateLimit"
+	// state — rare but possible on heavily-cached responses).
+	var pick *rateLimitFields
+	for _, cand := range []rateLimitFields{a, b, c} {
+		cand := cand
+		if int(cand.Limit) == 0 {
+			continue
+		}
+		if pick == nil || int(cand.Remaining) < int(pick.Remaining) {
+			pick = &cand
+		}
 	}
+
+	out := &RateLimit{Cost: cost}
+	if pick != nil {
+		out.Limit = int(pick.Limit)
+		out.Remaining = int(pick.Remaining)
+		out.ResetAt = pick.ResetAt.Time
+	}
+	return out
 }
 
 // rateLimitFields mirrors GitHub's top-level rateLimit envelope. Kept

--- a/internal/github/detail.go
+++ b/internal/github/detail.go
@@ -42,13 +42,13 @@ type RepoDetail struct {
 	OpenPRs    int
 
 	// One-line metadata for the header chip row
-	License             string // "" when unlicensed
-	PrimaryLanguage     string
+	License              string // "" when unlicensed
+	PrimaryLanguage      string
 	PrimaryLanguageColor string
 
 	// Body sections — each may be empty / nil
-	LatestRelease     *Release
-	Languages         []Language
+	LatestRelease *Release
+	Languages     []Language
 
 	// Default-branch commit metrics. HasDefaultBranch is false on
 	// empty repos (no pushes yet); Commits and CommitsYearAuthored

--- a/internal/github/issue_detail.go
+++ b/internal/github/issue_detail.go
@@ -122,7 +122,7 @@ type issueDetailQuery struct {
 					// fragment's struct. Switching on Typename is
 					// the only correct discriminator.
 					Typename githubv4.String `graphql:"__typename"`
-					Comment struct {
+					Comment  struct {
 						Author    struct{ Login githubv4.String }
 						CreatedAt githubv4.DateTime
 					} `graphql:"... on IssueComment"`
@@ -147,8 +147,8 @@ type issueDetailQuery struct {
 						CreatedAt githubv4.DateTime
 					} `graphql:"... on ReopenedEvent"`
 					CrossReferenced struct {
-						Actor     struct{ Login githubv4.String }
-						Source    struct {
+						Actor  struct{ Login githubv4.String }
+						Source struct {
 							PullRequest struct {
 								Number githubv4.Int
 								Title  githubv4.String

--- a/internal/github/pr_detail.go
+++ b/internal/github/pr_detail.go
@@ -21,18 +21,18 @@ import (
 // sections rather than rendering "(none)" placeholders.
 type PRDetail struct {
 	// Identity
-	Owner          string // "gfazioli"
-	RepoName       string // "octoscope"
-	NameWithOwner  string // "gfazioli/octoscope"
-	Number         int
-	URL            string
+	Owner         string // "gfazioli"
+	RepoName      string // "octoscope"
+	NameWithOwner string // "gfazioli/octoscope"
+	Number        int
+	URL           string
 
 	// Headline
-	Title       string
-	Body        string
-	State       string // "OPEN" | "CLOSED" | "MERGED"
-	IsDraft     bool
-	Mergeable   string // "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
+	Title     string
+	Body      string
+	State     string // "OPEN" | "CLOSED" | "MERGED"
+	IsDraft   bool
+	Mergeable string // "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
 
 	// Branches
 	BaseRefName string // target (where the PR merges into)
@@ -52,14 +52,14 @@ type PRDetail struct {
 	// Two separate slices because the data shapes diverge: a
 	// requested reviewer has only a name, a submitted review has
 	// state + when.
-	RequestedReviewers []string         // login or team slug
-	Reviews            []ReviewSummary  // most recent state per reviewer
+	RequestedReviewers []string        // login or team slug
+	Reviews            []ReviewSummary // most recent state per reviewer
 
 	// Checks (CI / status). Empty when the PR's head commit hasn't
 	// triggered any rollup yet. State is the overall rollup
 	// ("SUCCESS" / "FAILURE" / "PENDING" / "ERROR" / "EXPECTED").
-	ChecksState     string
-	ChecksContexts  []CheckSummary
+	ChecksState    string
+	ChecksContexts []CheckSummary
 
 	// Timeline — most recent ~10 events relevant to a PR's life.
 	// Events outside the curated set (label changes, milestones,
@@ -216,7 +216,7 @@ type prDetailQuery struct {
 			TimelineItems struct {
 				Nodes []struct {
 					Typename githubv4.String `graphql:"__typename"`
-					Review struct {
+					Review   struct {
 						Author      struct{ Login githubv4.String }
 						State       githubv4.PullRequestReviewState
 						SubmittedAt githubv4.DateTime
@@ -226,8 +226,8 @@ type prDetailQuery struct {
 						CreatedAt githubv4.DateTime
 					} `graphql:"... on IssueComment"`
 					Assigned struct {
-						Actor     struct{ Login githubv4.String }
-						Assignee  struct {
+						Actor    struct{ Login githubv4.String }
+						Assignee struct {
 							User struct{ Login githubv4.String } `graphql:"... on User"`
 						}
 						CreatedAt githubv4.DateTime

--- a/internal/github/ratelimit_test.go
+++ b/internal/github/ratelimit_test.go
@@ -1,0 +1,94 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// Tests pin the contract of the rate-limit mergers introduced
+// for the parallel-fetch design (v0.10.1 for the 2-way, v0.13.0
+// for the 3-way). Most-pessimistic Remaining wins among
+// envelopes that actually carry a Limit; envelopes with Limit==0
+// (empty / cached-response) are ignored so they can't drag the
+// reported budget to zero.
+
+func envelope(limit, remaining, cost int) rateLimitFields {
+	return rateLimitFields{
+		Limit:     githubv4.Int(limit),
+		Remaining: githubv4.Int(remaining),
+		Cost:      githubv4.Int(cost),
+		ResetAt:   githubv4.DateTime{Time: time.Unix(int64(remaining), 0)}, // arbitrary distinct timestamp
+	}
+}
+
+func TestMergeRateLimit3(t *testing.T) {
+	tests := []struct {
+		name          string
+		a, b, c       rateLimitFields
+		wantLimit     int
+		wantRemaining int
+		wantCost      int
+	}{
+		{
+			name:          "all valid — smallest Remaining wins",
+			a:             envelope(5000, 4800, 1),
+			b:             envelope(5000, 4500, 2),
+			c:             envelope(5000, 4700, 1),
+			wantLimit:     5000,
+			wantRemaining: 4500,
+			wantCost:      4,
+		},
+		{
+			name:          "a is empty — pick still finds the smallest among b/c",
+			a:             envelope(0, 0, 0),
+			b:             envelope(5000, 4500, 2),
+			c:             envelope(5000, 4200, 1),
+			wantLimit:     5000,
+			wantRemaining: 4200, // regression: previously the empty `a` would win and report 0
+			wantCost:      3,
+		},
+		{
+			name:          "a and b empty — c provides the answer",
+			a:             envelope(0, 0, 0),
+			b:             envelope(0, 0, 0),
+			c:             envelope(5000, 4800, 1),
+			wantLimit:     5000,
+			wantRemaining: 4800,
+			wantCost:      1,
+		},
+		{
+			name:          "all empty — Limit/Remaining stay zero, cost still sums",
+			a:             envelope(0, 0, 0),
+			b:             envelope(0, 0, 0),
+			c:             envelope(0, 0, 0),
+			wantLimit:     0,
+			wantRemaining: 0,
+			wantCost:      0,
+		},
+		{
+			name:          "cost sums regardless of which envelope wins",
+			a:             envelope(5000, 4900, 3),
+			b:             envelope(5000, 4800, 5),
+			c:             envelope(5000, 4950, 2),
+			wantLimit:     5000,
+			wantRemaining: 4800,
+			wantCost:      10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeRateLimit3(tt.a, tt.b, tt.c)
+			if got.Limit != tt.wantLimit {
+				t.Errorf("Limit = %d, want %d", got.Limit, tt.wantLimit)
+			}
+			if got.Remaining != tt.wantRemaining {
+				t.Errorf("Remaining = %d, want %d", got.Remaining, tt.wantRemaining)
+			}
+			if got.Cost != tt.wantCost {
+				t.Errorf("Cost = %d, want %d", got.Cost, tt.wantCost)
+			}
+		})
+	}
+}

--- a/internal/github/sanitize.go
+++ b/internal/github/sanitize.go
@@ -23,12 +23,12 @@ import (
 // typed.
 //
 // Two-stage strip:
-//   1. ansi.Strip removes well-formed CSI / OSC / SGR
-//      sequences (covers the common attack shapes).
-//   2. The byte-level filter removes any remaining C0 control
-//      characters (0x00–0x1F) plus DEL (0x7F), keeping only
-//      newline and tab. C1 controls inside multi-byte UTF-8
-//      sequences are already covered by the ansi pass.
+//  1. ansi.Strip removes well-formed CSI / OSC / SGR
+//     sequences (covers the common attack shapes).
+//  2. The byte-level filter removes any remaining C0 control
+//     characters (0x00–0x1F) plus DEL (0x7F), keeping only
+//     newline and tab. C1 controls inside multi-byte UTF-8
+//     sequences are already covered by the ansi pass.
 //
 // Idempotent — sanitising an already-sanitised string returns
 // the same string. Safe to call defensively at the render

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -319,4 +319,3 @@ func longestStreak(days []github.ContributionDay) int {
 	}
 	return best
 }
-

--- a/internal/ui/markdown.go
+++ b/internal/ui/markdown.go
@@ -37,10 +37,10 @@ func renderDetailDescription(body string, width int) string {
 // or otherwise hijacks the terminal once we paint it.
 //
 // Two-stage strip:
-//   1. ansi.Strip removes well-formed CSI / OSC / SGR sequences.
-//   2. The byte-level filter removes any remaining C0 control
-//      characters (0x00–0x1F) except tab and newline, plus DEL
-//      (0x7F). C1 controls are already covered by the ansi pass.
+//  1. ansi.Strip removes well-formed CSI / OSC / SGR sequences.
+//  2. The byte-level filter removes any remaining C0 control
+//     characters (0x00–0x1F) except tab and newline, plus DEL
+//     (0x7F). C1 controls are already covered by the ansi pass.
 //
 // Result is safe to feed to glamour or to lipgloss directly.
 // Idempotent — sanitizing an already-sanitized string returns

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -92,6 +92,14 @@ type Model struct {
 	// theme so launch-time and runtime sources stay in sync.
 	accentColor string
 
+	// pinned is the live list of "owner/name" pinned repositories
+	// for the Repos tab (v0.13.0). Mutable via P on a row or via
+	// the action menu; on every change we write back to config so
+	// the next launch picks the same set up. The slice is treated
+	// as ordered — first entry renders first in the pinned
+	// section — to preserve the user's intent.
+	pinned []string
+
 	// settings holds the in-app settings form's transient state
 	// (focused row, edit buffer, staged toggles). The panel is open
 	// iff settings.IsOpen().
@@ -330,6 +338,12 @@ type Options struct {
 	// AccentColor optionally overrides the active theme's Accent slot
 	// only. Empty = no override.
 	AccentColor string
+
+	// PinnedRepos is the persisted list of "owner/name" identifiers
+	// that the Repos tab renders in a sticky section at the top.
+	// Already sanitised (see config.SanitizePinnedRepos) by the
+	// caller — NewModel trusts the slice as-is.
+	PinnedRepos []string
 }
 
 // NewModel returns a Model ready for tea.NewProgram. The first fetch
@@ -361,6 +375,7 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 		configPath:  opts.ConfigPath,
 		theme:       themeName,
 		accentColor: opts.AccentColor,
+		pinned:      append([]string(nil), opts.PinnedRepos...),
 		version:     version,
 		spinner:     sp,
 		pulseMap:    make(map[string]time.Time),
@@ -474,7 +489,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch {
 			case m.activeTab == TabRepos && m.repos.IsInputMode():
 				var cmd tea.Cmd
-				m.repos, cmd = m.repos.Update(msg, eff)
+				m.repos, cmd = m.repos.Update(msg, eff, m.pinned)
 				return m, cmd
 			case m.activeTab == TabPRs && m.prs.IsInputMode():
 				var cmd tea.Cmd
@@ -516,11 +531,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			)
 			switch m.activeTab {
 			case TabRepos:
-				if r, ok := m.repos.selectedRepo(s); ok {
+				if r, ok := m.repos.selectedRepo(s, m.pinned); ok {
 					title = "Actions for " + r.Name
+					pinLabel := "Pin"
+					pinNext := true
+					if isPinned(r.URL, m.pinned) {
+						pinLabel = "Unpin"
+						pinNext = false
+					}
 					actions = []Action{
 						{Label: "Open in GitHub", Shortcut: 'o', Cmd: openURLCmd(r.URL)},
 						{Label: "View details", Shortcut: 'd', Cmd: viewRepoDetailCmd(r)},
+						{Label: pinLabel, Shortcut: 'P', Cmd: togglePinCmd(r.URL, pinNext)},
 						{Label: "Copy URL", Shortcut: 'c', Cmd: copyURLCmd(r.URL)},
 					}
 				}
@@ -618,7 +640,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch m.activeTab {
 			case TabRepos:
 				var cmd tea.Cmd
-				m.repos, cmd = m.repos.Update(msg, eff)
+				m.repos, cmd = m.repos.Update(msg, eff, m.pinned)
 				return m, cmd
 			case TabPRs:
 				var cmd tea.Cmd
@@ -844,6 +866,54 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.issueDetail = m.issueDetail.applyFetched(msg.detail, msg.err)
 		return m, nil
+
+	case pinToggledMsg:
+		// Mutate the canonical pinned list, then persist back to
+		// the config file if one was given at launch. Toast feedback
+		// so the user knows the press registered even when the
+		// row's visual position doesn't move (e.g. unpinning a
+		// row that was already last in the pinned section).
+		owner, name := github.SplitOwnerName(msg.url)
+		if owner == "" || name == "" {
+			// Defensive: the only way to land here with an
+			// unparseable URL is a bug in the producer. Swallow
+			// without changing state.
+			return m, nil
+		}
+		key := owner + "/" + name
+		nextPinned := togglePinList(m.pinned, key, msg.pin)
+		// No-op when the requested state already matches — avoid
+		// pointless disk writes and a misleading toast.
+		if pinnedEqual(m.pinned, nextPinned) {
+			return m, nil
+		}
+		m.pinned = nextPinned
+
+		// Best-effort writeback. A config-less launch (no path)
+		// keeps the pin in-memory only — same trade-off the
+		// settings panel makes for other keys. Silent on failure
+		// because the toast already speaks for the user-visible
+		// change; surfacing a write error here would step on it.
+		if m.configPath != "" {
+			cfgOnDisk, _ := config.Load(m.configPath)
+			cfgOnDisk.PinnedRepos = m.pinned
+			cfgOnDisk.RefreshInterval = m.interval
+			cfgOnDisk.PublicOnly = m.client.PublicOnly()
+			cfgOnDisk.Compact = m.compact
+			cfgOnDisk.Theme = m.theme
+			cfgOnDisk.AccentColor = m.accentColor
+			_ = config.Save(m.configPath, cfgOnDisk)
+		}
+
+		if msg.pin {
+			m.toastMsg = key + " pinned"
+		} else {
+			m.toastMsg = key + " unpinned"
+		}
+		m.toastUntil = time.Now().Add(toastDuration)
+		return m, tea.Tick(toastDuration, func(time.Time) tea.Msg {
+			return clockTickMsg(time.Now())
+		})
 
 	case urlCopiedMsg:
 		// Set the toast based on the outcome. The clipboard helper

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -177,8 +177,8 @@ type Model struct {
 	// footer freshness for `toastDuration` after an event. Used today
 	// for "URL copied" and the "View details — coming soon" stub;
 	// any future inline notification can pipe through here too.
-	toastMsg     string
-	toastUntil   time.Time
+	toastMsg   string
+	toastUntil time.Time
 }
 
 // toastDuration is how long a transient footer toast stays visible
@@ -891,23 +891,42 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Best-effort writeback. A config-less launch (no path)
 		// keeps the pin in-memory only — same trade-off the
-		// settings panel makes for other keys. Silent on failure
-		// because the toast already speaks for the user-visible
-		// change; surfacing a write error here would step on it.
+		// settings panel makes for other keys.
+		//
+		// IMPORTANT: we re-Load the file before saving so the
+		// writeback preserves keys we don't touch here (e.g.
+		// keys the user added by hand that the in-memory Model
+		// doesn't track). If that Load fails — malformed TOML,
+		// permissions changed mid-session, file removed — we
+		// MUST NOT proceed to Save, because Save would otherwise
+		// overwrite the on-disk file with config.Defaults()
+		// plus our in-memory state, silently nuking the user's
+		// hand-edits. Surface the failure as a toast and keep
+		// the pin in memory only.
+		saveErr := ""
 		if m.configPath != "" {
-			cfgOnDisk, _ := config.Load(m.configPath)
-			cfgOnDisk.PinnedRepos = m.pinned
-			cfgOnDisk.RefreshInterval = m.interval
-			cfgOnDisk.PublicOnly = m.client.PublicOnly()
-			cfgOnDisk.Compact = m.compact
-			cfgOnDisk.Theme = m.theme
-			cfgOnDisk.AccentColor = m.accentColor
-			_ = config.Save(m.configPath, cfgOnDisk)
+			cfgOnDisk, loadErr := config.Load(m.configPath)
+			if loadErr != nil {
+				saveErr = "config unreadable, pin kept in memory only"
+			} else {
+				cfgOnDisk.PinnedRepos = m.pinned
+				cfgOnDisk.RefreshInterval = m.interval
+				cfgOnDisk.PublicOnly = m.client.PublicOnly()
+				cfgOnDisk.Compact = m.compact
+				cfgOnDisk.Theme = m.theme
+				cfgOnDisk.AccentColor = m.accentColor
+				if err := config.Save(m.configPath, cfgOnDisk); err != nil {
+					saveErr = "config write failed: " + err.Error()
+				}
+			}
 		}
 
-		if msg.pin {
+		switch {
+		case saveErr != "":
+			m.toastMsg = saveErr
+		case msg.pin:
 			m.toastMsg = key + " pinned"
-		} else {
+		default:
 			m.toastMsg = key + " unpinned"
 		}
 		m.toastUntil = time.Now().Add(toastDuration)
@@ -1177,4 +1196,3 @@ func copyTextCmd(text, noun string) tea.Cmd {
 		return urlCopiedMsg{text: text, err: err, noun: noun}
 	}
 }
-

--- a/internal/ui/pr_diff.go
+++ b/internal/ui/pr_diff.go
@@ -235,4 +235,3 @@ var (
 	diffStyleOnce   sync.Once
 	cachedDiffStyle *chroma.Style
 )
-

--- a/internal/ui/prs.go
+++ b/internal/ui/prs.go
@@ -308,7 +308,7 @@ func (pm PRsModel) renderHeaderLine(visible, total, offset, end int) string {
 func renderPRsTable(prs []github.PullRequest, cursorRow int, sortMode PRsSort) string {
 	const (
 		cursorW  = 2
-		numberW  = 6  // "#12345"
+		numberW  = 6 // "#12345"
 		titleW   = 40
 		repoW    = 24
 		stateW   = 10

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -24,6 +24,7 @@ const (
 	ReposSortStars
 	ReposSortForks
 	ReposSortName
+	ReposSortCI // v0.13.0 — surface failing CI first
 )
 
 // reposSortLabels is the human-readable name for each sort mode,
@@ -33,16 +34,19 @@ var reposSortLabels = [...]string{
 	ReposSortStars:  "★ stars",
 	ReposSortForks:  "⑂ forks",
 	ReposSortName:   "name",
+	ReposSortCI:     "CI",
 }
 
 // reposSortChevron is the arrow glyph drawn next to the sorted
 // column header: ↓ for descending sorts (the default for all three
-// metric columns) and ↑ for the ascending name sort.
+// metric columns) and ↑ for the ascending name sort. CI sorts
+// failures-first, so the chevron points up to the "worst" rows.
 var reposSortChevron = [...]string{
 	ReposSortPushed: "↓",
 	ReposSortStars:  "↓",
 	ReposSortForks:  "↓",
 	ReposSortName:   "↑",
+	ReposSortCI:     "↑",
 }
 
 // ReposModel is the Repos-tab sub-state: cursor position, sort mode,
@@ -65,17 +69,23 @@ func (rm ReposModel) IsInputMode() bool {
 }
 
 // selectedRepo returns the repo at the current cursor position
-// inside the sorted-and-filtered view, plus a bool indicating
-// whether the selection is valid. Callers (action menu, drill-in)
-// rely on this so they don't have to re-implement the sort+filter
-// pipeline. Returns ok=false on empty stats, empty filtered set, or
-// out-of-range cursor (the view-level cursor clamp also covers this
-// but we double-check here so callers can rely on a clean Repo).
-func (rm ReposModel) selectedRepo(stats *github.Stats) (github.Repo, bool) {
+// inside the sorted-filtered-partitioned view, plus a bool
+// indicating whether the selection is valid. Callers (action
+// menu, drill-in) rely on this so they don't have to re-
+// implement the sort+filter+pin pipeline. Returns ok=false on
+// empty stats, empty filtered set, or out-of-range cursor (the
+// view-level cursor clamp also covers this but we double-check
+// here so callers can rely on a clean Repo).
+//
+// `pinned` is the ordered list of "owner/name" entries that
+// render in the sticky top section. An empty pinned slice
+// degenerates the partition into a single section — same
+// behaviour as before v0.13.0.
+func (rm ReposModel) selectedRepo(stats *github.Stats, pinned []string) (github.Repo, bool) {
 	if stats == nil {
 		return github.Repo{}, false
 	}
-	rows := sortRepos(filterRepos(stats.Repositories, rm.query), rm.sort)
+	rows := visibleRepos(stats.Repositories, rm.query, rm.sort, pinned)
 	if len(rows) == 0 {
 		return github.Repo{}, false
 	}
@@ -89,10 +99,152 @@ func (rm ReposModel) selectedRepo(stats *github.Stats) (github.Repo, bool) {
 	return rows[idx], true
 }
 
+// visibleRepos is the canonical pipeline that produces the flat
+// ordered slice the view paints and the cursor walks: filter →
+// sort → partition (pinned on top in config order, rest after
+// in the chosen sort).
+//
+// Exposed as a helper instead of inlined so selectedRepo,
+// Update bounds, and renderReposTab share the exact same
+// ordering — drifting their pipelines would make the cursor
+// point at a different row than the highlighted one. Pure
+// function of its inputs.
+func visibleRepos(repos []github.Repo, query string, mode ReposSort, pinned []string) []github.Repo {
+	filtered := filterRepos(repos, query)
+	pinnedRows, rest := partitionByPinned(filtered, pinned)
+	rest = sortRepos(rest, mode)
+	out := make([]github.Repo, 0, len(pinnedRows)+len(rest))
+	out = append(out, pinnedRows...)
+	out = append(out, rest...)
+	return out
+}
+
+// partitionByPinned splits `repos` into (pinned, rest):
+//   - pinned: repos whose "owner/name" matches an entry in
+//     `pins`, ordered by the position of the match in `pins`
+//     so the user's listing intent in config is preserved
+//   - rest: everything else, in input order
+//
+// Comparison is case-insensitive on "owner/name". Repos whose
+// URL doesn't parse cleanly into owner/name fall through to
+// rest — they cannot be pinned.
+func partitionByPinned(repos []github.Repo, pins []string) (pinned, rest []github.Repo) {
+	if len(pins) == 0 {
+		return nil, repos
+	}
+	// rank[lowercased "owner/name"] = position in pins, used to
+	// re-order the pinned slice to match the file's listing.
+	rank := make(map[string]int, len(pins))
+	for i, p := range pins {
+		rank[strings.ToLower(p)] = i
+	}
+	type ranked struct {
+		repo github.Repo
+		rank int
+	}
+	var ordered []ranked
+	rest = make([]github.Repo, 0, len(repos))
+	for _, r := range repos {
+		owner, name := github.SplitOwnerName(r.URL)
+		if owner == "" || name == "" {
+			rest = append(rest, r)
+			continue
+		}
+		if pos, ok := rank[strings.ToLower(owner+"/"+name)]; ok {
+			ordered = append(ordered, ranked{repo: r, rank: pos})
+			continue
+		}
+		rest = append(rest, r)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].rank < ordered[j].rank })
+	pinned = make([]github.Repo, len(ordered))
+	for i, e := range ordered {
+		pinned[i] = e.repo
+	}
+	return pinned, rest
+}
+
+// togglePinList returns a fresh slice with `key` either added to
+// the end (when `add` is true and it isn't already present) or
+// removed (when `add` is false). Case-insensitive match. Input
+// slice is not mutated.
+//
+// Adds to the end on purpose: pinning a new repo from the TUI
+// puts it at the bottom of the pinned section, which feels right
+// (most-recent intent floats to the most-recent slot). Users who
+// want a different order can hand-edit the config file —
+// pinned_repos is preserved by the saver.
+func togglePinList(in []string, key string, add bool) []string {
+	out := make([]string, 0, len(in)+1)
+	keyLower := strings.ToLower(key)
+	found := false
+	for _, p := range in {
+		if strings.ToLower(p) == keyLower {
+			found = true
+			if !add {
+				continue
+			}
+			out = append(out, p) // preserve original case
+			continue
+		}
+		out = append(out, p)
+	}
+	if add && !found {
+		out = append(out, key)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// pinnedEqual reports whether two pinned slices contain the same
+// entries in the same order (case-insensitive). Used to decide
+// whether a pinToggledMsg actually changed anything before
+// running a disk writeback.
+func pinnedEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !strings.EqualFold(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isPinned reports whether the given repo URL matches one of
+// the pinned "owner/name" identifiers. Case-insensitive. Used
+// by the action-menu label ("Pin" vs "Unpin") and the row
+// glyph in the Repos tab.
+func isPinned(url string, pins []string) bool {
+	if len(pins) == 0 {
+		return false
+	}
+	owner, name := github.SplitOwnerName(url)
+	if owner == "" || name == "" {
+		return false
+	}
+	key := strings.ToLower(owner + "/" + name)
+	for _, p := range pins {
+		if strings.ToLower(p) == key {
+			return true
+		}
+	}
+	return false
+}
+
 // Update handles key events routed from the root model when the
 // Repos tab is active. Returns the updated sub-model and any command
 // the root should batch into its own result.
-func (rm ReposModel) Update(msg tea.Msg, stats *github.Stats) (ReposModel, tea.Cmd) {
+//
+// `pinned` is the live list of pinned "owner/name" identifiers so
+// the cursor walks the same partitioned ordering the view paints.
+// Without threading it through, the cursor pointing at row N would
+// resolve to a different repo than the highlighted one once any
+// repo got pinned.
+func (rm ReposModel) Update(msg tea.Msg, stats *github.Stats, pinned []string) (ReposModel, tea.Cmd) {
 	km, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return rm, nil
@@ -102,13 +254,14 @@ func (rm ReposModel) Update(msg tea.Msg, stats *github.Stats) (ReposModel, tea.C
 		return rm.updateSearch(km), nil
 	}
 
-	// Filtered-then-sorted row count drives cursor bounds. Computing it
-	// here (rather than passing pre-filtered data in) keeps Update a
-	// pure function of the ReposModel + raw stats.
-	n := 0
+	// Row count drives cursor bounds. Built from the same pipeline
+	// the renderer uses (visibleRepos) so Update + View can never
+	// disagree on which repo lives at index N.
+	var rows []github.Repo
 	if stats != nil {
-		n = len(filterRepos(stats.Repositories, rm.query))
+		rows = visibleRepos(stats.Repositories, rm.query, rm.sort, pinned)
 	}
+	n := len(rows)
 
 	switch km.String() {
 	case "up", "k":
@@ -136,26 +289,33 @@ func (rm ReposModel) Update(msg tea.Msg, stats *github.Stats) (ReposModel, tea.C
 		// because the TUI convention is "Enter = drill-in" (lazygit,
 		// k9s, ranger). Browser access stays one keystroke away
 		// via `o`.
-		if stats == nil || n == 0 || rm.cursor >= n {
+		if n == 0 || rm.cursor >= n {
 			return rm, nil
 		}
-		rows := sortRepos(filterRepos(stats.Repositories, rm.query), rm.sort)
 		return rm, viewRepoDetailCmd(rows[rm.cursor])
 	case "o":
 		// Direct shortcut to open the row in the browser — what
 		// `Enter` did pre-v0.11.0.
-		if stats == nil || n == 0 || rm.cursor >= n {
+		if n == 0 || rm.cursor >= n {
 			return rm, nil
 		}
-		rows := sortRepos(filterRepos(stats.Repositories, rm.query), rm.sort)
 		return rm, openURLCmd(rows[rm.cursor].URL)
 	case "c":
 		// Direct shortcut to copy the row's URL.
-		if stats == nil || n == 0 || rm.cursor >= n {
+		if n == 0 || rm.cursor >= n {
 			return rm, nil
 		}
-		rows := sortRepos(filterRepos(stats.Repositories, rm.query), rm.sort)
 		return rm, copyURLCmd(rows[rm.cursor].URL)
+	case "P":
+		// Toggle pin/unpin (v0.13.0). Capital P so it doesn't
+		// collide with lowercase `p` (public-only) at the root
+		// level. The actual list mutation + config writeback
+		// happens in the root model's pinToggledMsg handler; this
+		// sub-model only emits the request.
+		if n == 0 || rm.cursor >= n {
+			return rm, nil
+		}
+		return rm, togglePinCmd(rows[rm.cursor].URL, !isPinned(rows[rm.cursor].URL, pinned))
 	case "esc":
 		// Outside search mode, Esc clears the current filter if any.
 		// When no filter is set, Esc is a no-op so the user doesn't
@@ -234,6 +394,11 @@ func sortRepos(repos []github.Repo, mode ReposSort) []github.Repo {
 			}
 		case ReposSortName:
 			return strings.ToLower(a.Name) < strings.ToLower(b.Name)
+		case ReposSortCI:
+			ar, br := ciSortRank(a.CIState), ciSortRank(b.CIState)
+			if ar != br {
+				return ar < br // failures (low rank) first
+			}
 		default: // ReposSortPushed
 			if !a.PushedAt.Equal(b.PushedAt) {
 				return a.PushedAt.After(b.PushedAt)
@@ -246,17 +411,37 @@ func sortRepos(repos []github.Repo, mode ReposSort) []github.Repo {
 	return out
 }
 
+// togglePinCmd asks the root model to flip a repo's pinned state.
+// `pin == true` means "add to the pinned list"; false means
+// "remove". The root handles writeback to disk and toast feedback.
+func togglePinCmd(url string, pin bool) tea.Cmd {
+	return func() tea.Msg {
+		return pinToggledMsg{url: url, pin: pin}
+	}
+}
+
+// pinToggledMsg is fired from the Repos tab (and the action menu)
+// asking the root model to update the pinned list. Carries the
+// repo URL because the root holds the canonical pinned slice and
+// runs the config writeback in one place.
+type pinToggledMsg struct {
+	url string
+	pin bool
+}
+
 // renderReposTab draws the header line, a windowed slice of the
 // sorted-and-filtered rows (within the vertical budget passed in by
 // the root view), and a short legend. availableHeight==0 means the
 // caller doesn't know the terminal height yet; render everything
 // and let the terminal scroll as a fallback.
-func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHeight int) string {
+func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHeight int, pinned []string) string {
 	if stats == nil || len(stats.Repositories) == 0 {
 		return mutedStyle.Render("(no repositories to show yet — waiting for first refresh)")
 	}
 
-	rows := sortRepos(filterRepos(stats.Repositories, rm.query), rm.sort)
+	rows := visibleRepos(stats.Repositories, rm.query, rm.sort, pinned)
+	pinnedCount, _ := partitionByPinned(filterRepos(stats.Repositories, rm.query), pinned)
+	pinCount := len(pinnedCount)
 
 	// Clamp the cursor in case the repo count shrank across a refresh
 	// (private repo flipped public, repo deleted, filter narrowed the
@@ -322,7 +507,7 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 			mutedStyle.Render("   (esc to clear)")
 	}
 
-	table := renderReposTable(rows[offset:end], cursor-offset, rm.sort)
+	table := renderReposTable(rows[offset:end], cursor-offset, rm.sort, pinCount-offset)
 
 	hint := keyHints(
 		"↑↓", "move",
@@ -332,6 +517,7 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 		"enter", "details",
 		"o", "github",
 		"c", "copy",
+		"P", "pin",
 	)
 
 	parts := []string{headerLine}
@@ -368,7 +554,12 @@ func (rm ReposModel) renderHeaderLine(visible, total, offset, end int) string {
 // for the visible slice. `cursorRow` is zero-based within the slice
 // (caller already computed the offset). `sortMode` drives which
 // column header gets the accent + chevron treatment.
-func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort) string {
+// pinDivider is the count of pinned rows in the visible window
+// (post-offset). When >0 and <len(repos), the renderer inserts a
+// muted rule after that row so the pinned section reads as a
+// distinct band above the rest of the list. ≤0 or ≥len(repos)
+// suppresses the divider — there's nothing to separate.
+func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pinDivider int) string {
 	nameW := len("Name")
 	langW := len("Lang")
 	for _, r := range repos {
@@ -393,6 +584,7 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort) st
 	}
 
 	const (
+		ciW     = 1 // single dot, ANSI-coloured
 		starsW  = 7
 		forksW  = 6
 		issuesW = 6
@@ -421,6 +613,7 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort) st
 
 	headerCells := []string{
 		strings.Repeat(" ", cursorW),
+		decorate("●", ReposSortCI, ciW, "left"),
 		decorate("Name", ReposSortName, nameW, "left"),
 		mutedStyle.Render(padRight("Lang", langW)),
 		decorate("★", ReposSortStars, starsW, "right"),
@@ -481,9 +674,57 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort) st
 			pushed = mutedStyle.Render(pushed)
 		}
 
-		out = append(out, marker+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed)
+		ci := ciDot(r.CIState)
+
+		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed)
+
+		// Insert the pinned/rest divider exactly once, after the
+		// last pinned row in the visible window. A 1-cell muted
+		// rule wide enough to span the header line — re-using the
+		// header width is cheaper than re-computing column widths.
+		if pinDivider > 0 && i == pinDivider-1 && i+1 < len(repos) {
+			out = append(out, tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header))))
+		}
 	}
 	return strings.Join(out, "\n")
+}
+
+// ciDot maps the status-check rollup state to a single coloured
+// glyph. The dot is the universally recognised CI indicator
+// (green/red/yellow/grey) — same shape lazygit, gh dash and
+// github.com itself use. Wide-rune-safe: stays at exactly 1 cell
+// no matter the state, so the column never shifts.
+func ciDot(state string) string {
+	switch state {
+	case "SUCCESS":
+		return okStyle.Render("●")
+	case "FAILURE", "ERROR":
+		return errorStyle.Render("●")
+	case "PENDING", "EXPECTED":
+		return warnStyle.Render("●")
+	default:
+		// "" (no rollup), or an enum value GitHub adds in the
+		// future and we haven't mapped yet: dim dot so the column
+		// stays visually aligned without making a claim.
+		return mutedStyle.Render("·")
+	}
+}
+
+// ciSortRank orders CI states for the "failures first" sort. Lower
+// rank = surfaces earlier. Tied ranks fall through to the stable
+// secondary name sort in sortRepos, so two failing repos stay in
+// a predictable alphabetical order between refreshes.
+func ciSortRank(state string) int {
+	switch state {
+	case "FAILURE", "ERROR":
+		return 0
+	case "PENDING", "EXPECTED":
+		return 1
+	case "SUCCESS":
+		return 2
+	default:
+		return 3 // no rollup — push to the bottom
+	}
 }
 
 // cellWidth returns the visible cell width of s as rendered by a

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -404,9 +404,17 @@ func sortRepos(repos []github.Repo, mode ReposSort) []github.Repo {
 				return a.PushedAt.After(b.PushedAt)
 			}
 		}
-		// Stable secondary sort on name so equal rows don't shuffle
-		// between refreshes.
-		return strings.ToLower(a.Name) < strings.ToLower(b.Name)
+		// Stable secondary sort: name first, then URL as a final
+		// tie-breaker. Name alone isn't unique under
+		// ownerAffiliations: OWNER (an org repo and a personal
+		// repo may share a bare name), so equal-name rows would
+		// otherwise shuffle non-deterministically between
+		// refreshes. URL is GitHub's canonical per-repo identifier
+		// and guarantees a total order.
+		if !strings.EqualFold(a.Name, b.Name) {
+			return strings.ToLower(a.Name) < strings.ToLower(b.Name)
+		}
+		return a.URL < b.URL
 	})
 	return out
 }

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -592,7 +592,12 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 	}
 
 	const (
-		ciW     = 1 // single dot, ANSI-coloured
+		// CI column carries a 2-char "CI" header label (the bare
+		// dot was too cryptic — feedback from first smoke) plus
+		// a single coloured ● glyph per row, padded to the same
+		// width so the row dot stays aligned to the first char
+		// of the header label.
+		ciW     = 2
 		starsW  = 7
 		forksW  = 6
 		issuesW = 6
@@ -619,9 +624,17 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		return mutedStyle.Render(padRight(label, width))
 	}
 
+	// The leading cursorW spaces are folded into the first cell
+	// (CI column) rather than carried as a standalone slice entry.
+	// Otherwise `strings.Join(... , "  ")` would insert an extra
+	// 2-cell separator BETWEEN the cursor reserve and the CI
+	// column, shifting the entire header right by two cells while
+	// the row writer (marker + ci + "  " + name + …) stays put —
+	// the visible result was a header ● floating two cells to the
+	// right of every row dot. Folding keeps everything column-
+	// aligned in a single pass without touching the other cells.
 	headerCells := []string{
-		strings.Repeat(" ", cursorW),
-		decorate("●", ReposSortCI, ciW, "left"),
+		strings.Repeat(" ", cursorW) + decorate("CI", ReposSortCI, ciW, "left"),
 		decorate("Name", ReposSortName, nameW, "left"),
 		mutedStyle.Render(padRight("Lang", langW)),
 		decorate("★", ReposSortStars, starsW, "right"),
@@ -682,7 +695,11 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 			pushed = mutedStyle.Render(pushed)
 		}
 
-		ci := ciDot(r.CIState)
+		// Pad the dot to the full CI column width so the row
+		// stays aligned with the 2-char "CI" header label —
+		// padRightRaw is ANSI-aware so the trailing space lands
+		// after the styled glyph rather than inside the escape.
+		ci := padRightRaw(ciDot(r.CIState), 2)
 
 		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed)
 

--- a/internal/ui/repos_test.go
+++ b/internal/ui/repos_test.go
@@ -1,0 +1,177 @@
+package ui
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+func mkRepo(owner, name string, stars int) github.Repo {
+	return github.Repo{
+		Name:     name,
+		URL:      "https://github.com/" + owner + "/" + name,
+		Stars:    stars,
+		PushedAt: time.Unix(int64(stars), 0), // deterministic stable secondary sort
+	}
+}
+
+// TestPartitionByPinned pins the partition contract:
+//   - pinned slice ordered by position in the pins list, not by
+//     position in the repos input
+//   - case-insensitive owner/name match
+//   - rest preserves input order
+//   - URLs that don't parse into owner/name skip the partition
+func TestPartitionByPinned(t *testing.T) {
+	repos := []github.Repo{
+		mkRepo("alice", "alpha", 1),
+		mkRepo("bob", "beta", 2),
+		mkRepo("carol", "gamma", 3),
+	}
+	tests := []struct {
+		name       string
+		pins       []string
+		wantPinned []string // expected names in the pinned slice (in order)
+		wantRest   []string
+	}{
+		{
+			name:       "empty pins → everything in rest",
+			pins:       nil,
+			wantPinned: nil,
+			wantRest:   []string{"alpha", "beta", "gamma"},
+		},
+		{
+			name:       "single pin pulled to top",
+			pins:       []string{"bob/beta"},
+			wantPinned: []string{"beta"},
+			wantRest:   []string{"alpha", "gamma"},
+		},
+		{
+			name:       "pinned order matches pins order, not repo order",
+			pins:       []string{"carol/gamma", "alice/alpha"},
+			wantPinned: []string{"gamma", "alpha"},
+			wantRest:   []string{"beta"},
+		},
+		{
+			name:       "case-insensitive match",
+			pins:       []string{"ALICE/ALPHA"},
+			wantPinned: []string{"alpha"},
+			wantRest:   []string{"beta", "gamma"},
+		},
+		{
+			name:       "pin that matches no repo is silently absent",
+			pins:       []string{"nobody/nothing", "alice/alpha"},
+			wantPinned: []string{"alpha"},
+			wantRest:   []string{"beta", "gamma"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pinned, rest := partitionByPinned(repos, tt.pins)
+			got := names(pinned)
+			if !reflect.DeepEqual(got, tt.wantPinned) {
+				t.Errorf("pinned = %v, want %v", got, tt.wantPinned)
+			}
+			got = names(rest)
+			if !reflect.DeepEqual(got, tt.wantRest) {
+				t.Errorf("rest = %v, want %v", got, tt.wantRest)
+			}
+		})
+	}
+}
+
+// TestTogglePinList covers the add / remove / no-op-when-absent
+// behaviour the root model relies on.
+func TestTogglePinList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		key  string
+		add  bool
+		want []string
+	}{
+		{"add to empty", nil, "a/b", true, []string{"a/b"}},
+		{"add to non-empty appends", []string{"a/b"}, "c/d", true, []string{"a/b", "c/d"}},
+		{"add already-present is no-op", []string{"a/b"}, "A/B", true, []string{"a/b"}},
+		{"remove present", []string{"a/b", "c/d"}, "a/b", false, []string{"c/d"}},
+		{"remove case-insensitive", []string{"a/b"}, "A/B", false, nil},
+		{"remove absent is no-op", []string{"a/b"}, "z/y", false, []string{"a/b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := togglePinList(tt.in, tt.key, tt.add)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPinnedEqual covers the equality helper used to decide
+// whether a pin-toggle actually changed state.
+func TestPinnedEqual(t *testing.T) {
+	if !pinnedEqual(nil, nil) {
+		t.Errorf("nil/nil should be equal")
+	}
+	if !pinnedEqual([]string{"a/b"}, []string{"A/B"}) {
+		t.Errorf("case-insensitive equal failed")
+	}
+	if pinnedEqual([]string{"a/b"}, []string{"a/c"}) {
+		t.Errorf("different entries reported equal")
+	}
+	if pinnedEqual([]string{"a/b", "c/d"}, []string{"c/d", "a/b"}) {
+		t.Errorf("order mismatch reported equal")
+	}
+}
+
+// TestCiSortRank ensures failures sort before pending, before
+// success, before "no rollup". The Repos tab relies on this
+// monotonic order for the "failures first" sort cycle entry.
+func TestCiSortRank(t *testing.T) {
+	cases := []struct {
+		state string
+		want  int
+	}{
+		{"FAILURE", 0},
+		{"ERROR", 0},
+		{"PENDING", 1},
+		{"EXPECTED", 1},
+		{"SUCCESS", 2},
+		{"", 3},
+		{"SOMETHING_NEW_FROM_GITHUB", 3},
+	}
+	for _, c := range cases {
+		if got := ciSortRank(c.state); got != c.want {
+			t.Errorf("ciSortRank(%q) = %d, want %d", c.state, got, c.want)
+		}
+	}
+}
+
+// TestCiDot smoke-tests the glyph mapping: every known state
+// produces a 1-cell glyph after ANSI strip, and unknown states
+// fall back to a placeholder rather than panicking.
+func TestCiDot(t *testing.T) {
+	for _, state := range []string{"SUCCESS", "FAILURE", "ERROR", "PENDING", "EXPECTED", "", "FUTURE_ENUM"} {
+		got := ansi.Strip(ciDot(state))
+		if cw := strings.Count(got, ""); cw < 1 {
+			t.Errorf("ciDot(%q) = %q, expected at least one glyph", state, got)
+		}
+		if len([]rune(got)) != 1 {
+			t.Errorf("ciDot(%q) = %q (%d runes), want exactly 1 rune", state, got, len([]rune(got)))
+		}
+	}
+}
+
+func names(repos []github.Repo) []string {
+	if len(repos) == 0 {
+		return nil
+	}
+	out := make([]string, len(repos))
+	for i, r := range repos {
+		out[i] = r.Name
+	}
+	return out
+}

--- a/internal/ui/repos_test.go
+++ b/internal/ui/repos_test.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -156,9 +155,10 @@ func TestCiSortRank(t *testing.T) {
 func TestCiDot(t *testing.T) {
 	for _, state := range []string{"SUCCESS", "FAILURE", "ERROR", "PENDING", "EXPECTED", "", "FUTURE_ENUM"} {
 		got := ansi.Strip(ciDot(state))
-		if cw := strings.Count(got, ""); cw < 1 {
-			t.Errorf("ciDot(%q) = %q, expected at least one glyph", state, got)
-		}
+		// Exactly one rune-wide glyph for every state, including
+		// the unknown-state fallback. The column width budget in
+		// the Repos table assumes 1 cell here — any deviation
+		// would shift every right-side column by N cells.
 		if len([]rune(got)) != 1 {
 			t.Errorf("ciDot(%q) = %q (%d runes), want exactly 1 rune", state, got, len([]rune(got)))
 		}

--- a/internal/ui/themes.go
+++ b/internal/ui/themes.go
@@ -12,7 +12,7 @@ import (
 // every component:
 //
 //   - Accent  — identity colour (banner, section titles, icons,
-//               authenticated dot, focus ring, change-pulse border)
+//     authenticated dot, focus ring, change-pulse border)
 //   - Value   — the prominent numbers that read as "data"
 //   - OK      — semantic success (authenticated badge, "ready" PR state)
 //   - Warn    — unauthenticated, low rate-limit, stale data

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -662,13 +662,13 @@ func renderLanguages(langs []github.Language, available int) string {
 // cardSpec is the payload for one card in a responsive row.
 //
 //   - id     — stable key used to match against the pulse map when a
-//              value changed between refreshes.
+//     value changed between refreshes.
 //   - icon   — a single Unicode symbol prepended to the label. Geometric
-//              shapes only, no emoji (consistent rendering across
-//              terminals and fonts).
+//     shapes only, no emoji (consistent rendering across
+//     terminals and fonts).
 //   - label  — human-readable label, rendered muted.
 //   - short  — abbreviated label used in compact mode. Falls back to
-//              label when empty.
+//     label when empty.
 //   - value  — the integer displayed below the label.
 type cardSpec struct {
 	id    string

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -121,7 +121,7 @@ func (m Model) View() string {
 		case TabOverview:
 			b.WriteString(m.renderOverviewScrolled(s, available, tabHeight))
 		case TabRepos:
-			b.WriteString(m.repos.renderReposTab(s, available, tabHeight))
+			b.WriteString(m.repos.renderReposTab(s, available, tabHeight, m.pinned))
 		case TabPRs:
 			b.WriteString(m.prs.renderPRsTab(s, available, tabHeight))
 		case TabIssues:

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.12.0"
+const version = "0.13.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 		ConfigPath:  configPath,
 		Theme:       cfg.Theme,
 		AccentColor: cfg.AccentColor,
+		PinnedRepos: cfg.PinnedRepos,
 	})
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {

--- a/tapes/README.md
+++ b/tapes/README.md
@@ -17,9 +17,24 @@ deterministic GIFs / PNGs. Two payoffs:
 
 ## Running
 
-You need vhs installed (`brew install vhs` on macOS / Linux) and a
-valid `$GITHUB_TOKEN` exported (octoscope's real fetch path, no
-mocking — the tapes exercise the same code a user would). Then:
+Three prerequisites:
+
+1. **vhs** — `brew install vhs` on macOS / Linux.
+2. **`$GITHUB_TOKEN`** exported — the tapes drive octoscope's
+   real fetch path, no mocking. Without a token the tapes
+   capture an empty / rate-limited dashboard, which defeats the
+   point.
+3. **An `octoscope` binary on `$PATH`** — every tape boots the
+   app with `Type "octoscope"`, so the shell vhs spawns has to
+   resolve that name. One of:
+   - `go install .` from the repo root (lands in `$GOPATH/bin`,
+     which should be on `$PATH`)
+   - `make build BINDIR=/usr/local/bin` (or any other directory
+     already on `$PATH`)
+   - `brew install gfazioli/tap/octoscope` if you want the
+     released binary instead of your local checkout
+
+Then:
 
 ```sh
 make tapes        # render all .tape files in this directory

--- a/tapes/README.md
+++ b/tapes/README.md
@@ -1,0 +1,45 @@
+# tapes/
+
+[charmbracelet/vhs](https://github.com/charmbracelet/vhs) scripts that
+drive octoscope through canonical user flows and produce
+deterministic GIFs / PNGs. Two payoffs:
+
+1. **Reproducible smoke session.** The maintainer used to open
+   octoscope manually before each release, walk through the tabs,
+   verify the drill-ins repaint correctly. The same walkthrough is
+   now scripted — `make tapes` runs every scenario headlessly and
+   spits out the rendered output, no human at the keyboard.
+2. **Landing-page asset generation.** The cycling drill-in slideshow
+   on `docs/index.html` is built from `docs/screenshots/drill-in/`.
+   When the TUI's appearance changes (theme tweak, layout shift,
+   version banner bump) those screenshots used to be recaptured by
+   hand. The tapes regenerate them in one command.
+
+## Running
+
+You need vhs installed (`brew install vhs` on macOS / Linux) and a
+valid `$GITHUB_TOKEN` exported (octoscope's real fetch path, no
+mocking — the tapes exercise the same code a user would). Then:
+
+```sh
+make tapes        # render all .tape files in this directory
+make tape NAME=overview   # render a single tape
+```
+
+The output GIFs land in `tapes/out/` (gitignored). The ones we
+actually publish to the landing page get copied into
+`docs/screenshots/` manually after a visual review — that step
+is intentionally human-in-the-loop, since landing assets are
+public and should look intentional, not auto-generated.
+
+## Adding a new tape
+
+One `.tape` file per scenario, named after the feature it
+exercises (`pr-diff-viewer.tape`, `settings-panel.tape`, …). The
+vhs DSL is shell-like: `Type`, `Sleep`, `Enter`, `Hide`, `Show`,
+`Screenshot`. Read the vhs README for the full command set; the
+existing tapes here are the easiest reference.
+
+Keep tapes idempotent (no destructive operations — octoscope is
+read-only, so this comes for free) and short (under 30s render
+time keeps the smoke loop fast).

--- a/tapes/action-menu.tape
+++ b/tapes/action-menu.tape
@@ -1,0 +1,33 @@
+# Smoke + asset: action menu on a list row.
+# Goes to the Repos tab, lands on the first row, opens the
+# action menu with space. Captures the modal centred over the
+# table. Feeds docs/screenshots/drill-in/screenshot-action-menu.png.
+
+Output out/action-menu.gif
+
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set Theme "OneHalfDark"
+
+Type "octoscope"
+Enter
+Sleep 5s
+
+Type "2"
+Sleep 2s
+
+# Space opens the action menu modal (Open in GitHub / View details
+# / Pin / Copy URL on Repos).
+Space
+Sleep 2s
+
+Screenshot out/action-menu.png
+
+Sleep 1s
+
+# Close the menu (esc) and quit cleanly.
+Escape
+Sleep 1s
+Type "q"

--- a/tapes/overview.tape
+++ b/tapes/overview.tape
@@ -1,0 +1,30 @@
+# Smoke + asset: dashboard hero shot.
+# Captures the Overview tab on first paint — profile card, social,
+# activity, operational, network sections + languages bar.
+#
+# Used to regenerate docs/screenshots/screenshot.png when the
+# landing page falls out of sync with the current UI.
+
+Output out/overview.gif
+
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set Theme "OneHalfDark"
+
+Type "octoscope"
+Enter
+
+# Let the first GraphQL refresh complete (~2-3s on a typical
+# account) so the dashboard is fully populated before we
+# capture the still.
+Sleep 6s
+
+Screenshot out/overview.png
+
+# Tail of the recording so the GIF has a moment of breathing
+# before it loops.
+Sleep 1s
+
+Type "q"

--- a/tapes/pr-diff-viewer.tape
+++ b/tapes/pr-diff-viewer.tape
@@ -1,0 +1,47 @@
+# Smoke + asset: PR diff viewer (v0.12.0 deepest level).
+# Walks through PR detail → files-changed list → unified diff
+# viewer with chroma syntax highlighting. Captures both the
+# files list and the diff body. Feeds:
+#   docs/screenshots/drill-in/screenshot-files-changed.png
+#   docs/screenshots/drill-in/screenshot-file-diff.png
+
+Output out/pr-diff-viewer.gif
+
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set Theme "OneHalfDark"
+
+Type "octoscope"
+Enter
+Sleep 5s
+
+Type "3"
+Sleep 2s
+
+# Enter the PR detail, then f for the files list.
+Enter
+Sleep 3s
+
+Type "f"
+Sleep 2s
+
+Screenshot out/files-changed.png
+Sleep 1s
+
+# Enter on the first file row → chroma-highlighted diff.
+Enter
+Sleep 3s
+
+Screenshot out/file-diff.png
+Sleep 1s
+
+# Back out three levels: diff → files list → PR detail → PRs tab.
+Escape
+Sleep 500ms
+Escape
+Sleep 500ms
+Escape
+Sleep 500ms
+Type "q"

--- a/tapes/pr-drill-in.tape
+++ b/tapes/pr-drill-in.tape
@@ -1,0 +1,34 @@
+# Smoke + asset: PR drill-in detail (v0.11.0 surface).
+# Boots octoscope, switches to the PRs tab, presses enter on the
+# first row to open the drill-in. Captures the rich PR detail
+# (state chip, glamour-rendered description, reviewers, checks,
+# files-changed line, timeline). Feeds the
+# docs/screenshots/drill-in/screenshot-pr-detail.png frame.
+
+Output out/pr-drill-in.gif
+
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set Theme "OneHalfDark"
+
+Type "octoscope"
+Enter
+Sleep 5s
+
+Type "3"
+Sleep 2s
+
+# Enter on the first PR row → drill-in.
+Enter
+Sleep 3s
+
+Screenshot out/pr-detail.png
+
+Sleep 1s
+
+# Back out: esc closes the drill-in.
+Escape
+Sleep 500ms
+Type "q"

--- a/tapes/repos.tape
+++ b/tapes/repos.tape
@@ -1,0 +1,27 @@
+# Smoke + asset: Repos tab list.
+# Boots octoscope, switches to the Repos tab, lets the list render
+# with CI dots, pinned section, and the language column. Output is
+# the recurring screenshot we use on the landing under the
+# "tabs at a glance" mini-row.
+
+Output out/repos.gif
+
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set Theme "OneHalfDark"
+
+Type "octoscope"
+Enter
+Sleep 5s
+
+# Jump to Repos (tab index 2 in the 1-5 bar).
+Type "2"
+Sleep 2s
+
+Screenshot out/repos.png
+
+Sleep 1s
+
+Type "q"

--- a/tapes/settings-panel.tape
+++ b/tapes/settings-panel.tape
@@ -1,0 +1,30 @@
+# Smoke + asset: in-app settings panel.
+# Captures the panel opened with `,` so the modal's focus border,
+# row layout, and the theme cycler are visible. Feeds a future
+# docs/screenshots/screenshot-settings.png if/when we wire it
+# into the landing.
+
+Output out/settings.gif
+
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set Padding 10
+Set Theme "OneHalfDark"
+
+Type "octoscope"
+Enter
+Sleep 5s
+
+# Comma opens the in-app settings panel.
+Type ","
+Sleep 2s
+
+Screenshot out/settings.png
+
+Sleep 1s
+
+# Cancel without changing anything.
+Escape
+Sleep 500ms
+Type "q"


### PR DESCRIPTION
## Summary

Two user-facing additions on the Repos tab that turn it from a passive listing into something you actually live in, plus the infrastructure piece that takes a load off the maintainer's manual pre-release smoke session.

## What lands

### CI status column

- New `github.Repo.CIState` backed by GraphQL `defaultBranchRef.target.statusCheckRollup.state`.
- Renders as a coloured dot in the leftmost column of the Repos tab: 🟢 SUCCESS, 🔴 FAILURE/ERROR, 🟡 PENDING/EXPECTED, dim `·` for repos with no rollup.
- New sort cycle entry (`s`) lands on \"CI\" — failures sort first so the eye locks on what needs fixing.

### Pinned repos

- New `pinned_repos = [\"owner/repo\", ...]` config key. `config.SanitizePinnedRepos` drops empties / malformed / duplicate entries at load time.
- `P` (capital, so it doesn't collide with `p` public-only) on a Repos row toggles pin/unpin. Toast `owner/repo pinned` / `unpinned` for feedback.
- Pinned repos render in a sticky section at the top, separated from the rest by a muted rule. Order inside the section matches the config file's listing intent — no auto-sort of pinned.
- Action menu (`space`) on Repos gains a context-aware `Pin` / `Unpin` entry whose label tracks the current state.
- Sort cycle, `/` search and `p` public-only all respect the partition: pinned stays pinned, the rest behaves as before.
- Writeback to `config.toml` happens atomically on every toggle via the v0.8.1 helper, so pins survive a restart.

### vhs smoke harness

- New `tapes/` directory with five `.tape` scripts covering the canonical user flows (overview, repos, action menu, PR drill-in, PR diff viewer, settings panel).
- `make tapes` renders every tape into `tapes/out/` via vhs (`brew install vhs` first); `make tape NAME=overview` runs a single one. Replaces the maintainer's manual pre-release smoke session and doubles as a reproducible source for landing-page screenshots.
- `tapes/out/` is gitignored; the `.tape` scripts themselves are committed.

### ci.yml workflow

- New `.github/workflows/ci.yml` with three jobs (build / race-checked test / lint) on every push and PR. Caching keyed on `go.sum`.
- The vhs tapes are NOT invoked in CI — they need a real `$GITHUB_TOKEN` and the asset generation is intentionally human-in-the-loop.

## Architecture note — third parallel GraphQL query

The first iteration of this PR added `statusCheckRollup.state` inline on the existing `repoFields` query. On the maintainer's account (74 owned repos) that combined query exceeded the GraphQL gateway's complexity ceiling and returned a 502 — same failure shape as v0.10.1.

The fix splits CI into its own minimal query (`repoCIFields`: name + state only) running as the **third parallel goroutine** in `FetchStats`. Wall-clock latency stays close to the slowest of the three; the merge happens by repo name in `extractStats` since the `ownerAffiliations` scope on both repoFields and repoCIFields is identical.

`mergeRateLimit3` is the 3-way variant of the existing helper, picking the most pessimistic remaining and summing costs.

## Tests

- `internal/config`: `SanitizePinnedRepos` (empty / malformed / duplicate / case-insensitive) + end-to-end `Load` with a mixed-validity TOML file.
- `internal/ui`: `partitionByPinned`, `togglePinList`, `pinnedEqual`, `ciSortRank` (monotonic failure → success → unknown), `ciDot` (every state produces exactly one rune).

## Test plan

- [x] `go build` clean (dual-target)
- [x] `go test -race ./...` passes
- [x] Manual smoke on a 74-repo authenticated account: 502 reproduced on the inline version, disappeared after the split
- [x] Manual smoke: pin / unpin via `P` + action menu, persistence across restart, interaction with sort / search / public-only

## Known limitations / out of scope

- Pinning a fork is accepted (writes to config + toast fires) but the row doesn't appear in the pinned section because the main query filters `isFork: false`. Acceptable for v0.13.0; if it bites, a follow-up can either include forks in the dataset or refuse fork pins upfront.
- vhs tapes target a real authenticated account — they're not mocked. By design: the asset generator should produce what users actually see, not a stub.
- \"Watched repos\" (pinning repos that aren't yours) is the natural next step. Out of scope for v0.13.0 because it would need a separate query.