### PR TITLE
Watching more, seeing more: star history · latest release · watched repos · theme fidelity (v0.14.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
 - **Repos** — every owned, non-fork repository in one sortable, searchable
   list. Columns: **CI status** (a coloured dot — green / red / yellow / dim
   — sourced from the default-branch status-check rollup), name, primary
-  language, stars, forks, open issues, open PRs, last push. Press `s` to
-  cycle sort (CI is in the cycle and surfaces failures first), `/` to
-  filter by substring, `P` on a row to pin a repo to a sticky section at
-  the top — the viewport scrolls so even a 100-repo account stays
-  navigable.
+  language, stars, forks, open issues, open PRs, last push, **latest
+  release** (tag + age, v0.14.0+). Press `s` to cycle sort (CI is in the
+  cycle and surfaces failures first; "release" sort lists the most
+  recently published first), `/` to filter by substring, `P` on a row to
+  pin a repo to a sticky section at the top — the viewport scrolls so
+  even a 100-repo account stays navigable. Add `watch_repos = ["..."]`
+  to the config to monitor repositories you don't own — they appear in
+  a third "Watched" section under your own list.
 - **PRs** — every open pull request you've authored, across every repo.
   Number, title, repo, state (draft / ready / conflicts) and last-update
   time. Same sort & search idioms as Repos.
@@ -348,6 +351,16 @@ theme = "octoscope"
 # pinned_repos = [
 #   "gfazioli/octoscope",
 #   "gfazioli/Mantine-Hint",
+# ]
+
+# External repositories to monitor in a Watched section under
+# the Repos tab (v0.14.0+). Hand-edit only — there is no
+# in-app toggle. Each entry resolves to its own GraphQL query
+# at refresh time; failures (404, private, network blip) are
+# dropped silently so a stale entry doesn't break refresh.
+# watch_repos = [
+#   "charmbracelet/bubbletea",
+#   "cli/cli",
 # ]
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -914,7 +914,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.13.0</span>
+                <span class="version-tag" id="version-pill">0.14.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1057,6 +1057,11 @@
                     <div class="feature-label">Repos tab gets serious</div>
                     <h3>CI status &middot; pinned repos</h3>
                     <p>New in v0.13.0. The Repos tab now leads with a <strong style="color: var(--text);">CI status dot</strong> on every row &mdash; green / red / yellow / dim &mdash; sourced from the default branch's status-check rollup, with a "by CI" sort that surfaces failing repos first. Press <code class="inline">P</code> on a row to <strong style="color: var(--text);">pin</strong> it: pinned repos stick to a section at the top of the list (order preserved across refreshes), and the choice is written back to <code class="inline">~/.config/octoscope/config.toml</code> automatically. Hand-edit the file to lock the ordering you want; press <code class="inline">P</code> again to unpin.</p>
+                </div>
+                <div class="feature wide">
+                    <div class="feature-label">Watching more, seeing more</div>
+                    <h3>Star history &middot; latest release &middot; watched repos</h3>
+                    <p>New in v0.14.0. A <strong style="color: var(--text);">12-month star-history sparkline</strong> lands in the Repos drill-in &mdash; <code class="inline">▁▂▃▄▅▆▇</code> blocks over weekly buckets, plus "+N in last 12mo &middot; last star Xd ago". A new <strong style="color: var(--text);">latest release column</strong> on the Repos tab shows tag + age ("v1.2.3 &middot; 3d") and joins the sort cycle. Add <code class="inline">watch_repos = ["owner/name", ...]</code> to the config to monitor <strong style="color: var(--text);">repositories you don't own</strong>: they appear in a dedicated Watched section under your list, fetched in parallel with the dashboard refresh. <strong style="color: var(--text);">Bonus polish</strong>: monochromatic themes (<code class="inline">monochrome</code>, <code class="inline">phosphor</code>, <code class="inline">amber</code>) now suppress the GitHub language palette, CI rollup green/red and Activity heatmap gradient &mdash; "zero chroma" finally means zero chroma end-to-end.</p>
                 </div>
                 <div class="feature wide">
                     <div class="feature-label">Configurable</div>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,13 @@ type Config struct {
 	// app on boot. Duplicates are de-duplicated keeping the first
 	// occurrence so the file's intent is preserved.
 	PinnedRepos []string `toml:"pinned_repos"`
+
+	// WatchRepos is the v0.14.0 counterpart of PinnedRepos for
+	// repositories the user doesn't own. Same "owner/name"
+	// schema, same sanitiser (SanitizeRepoList). Surfaces a
+	// separate section under the Repos tab populated by an extra
+	// per-entry GraphQL fetch — see Stats.WatchedRepos.
+	WatchRepos []string `toml:"watch_repos"`
 }
 
 // Defaults returns the values octoscope uses when no config file
@@ -79,20 +86,22 @@ func Defaults() Config {
 		Theme:           "octoscope",
 		AccentColor:     "",
 		PinnedRepos:     nil,
+		WatchRepos:      nil,
 	}
 }
 
-// SanitizePinnedRepos returns a fresh slice with empty entries
+// SanitizeRepoList returns a fresh slice with empty entries
 // dropped, "owner/name" shape enforced, and duplicates removed
 // (first occurrence wins so the file's ordering survives). Used
-// at Load time and as a defensive pre-Save scrub so a bad in-
-// memory list never reaches disk.
+// at Load time for both PinnedRepos and WatchRepos and as a
+// defensive pre-Save scrub so a bad in-memory list never reaches
+// disk.
 //
 // Anything that doesn't match a single "/" with non-empty owner
 // and non-empty name is silently dropped — callers can compare
 // len(in) vs len(out) to detect "the file had typos worth
 // telling the user about".
-func SanitizePinnedRepos(in []string) []string {
+func SanitizeRepoList(in []string) []string {
 	if len(in) == 0 {
 		return nil
 	}
@@ -170,6 +179,7 @@ func Load(path string) (Config, error) {
 		Theme           string   `toml:"theme"`
 		AccentColor     string   `toml:"accent_color"`
 		PinnedRepos     []string `toml:"pinned_repos"`
+		WatchRepos      []string `toml:"watch_repos"`
 	}
 	if _, err := toml.DecodeFile(path, &raw); err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
@@ -195,7 +205,8 @@ func Load(path string) (Config, error) {
 	if raw.AccentColor != "" {
 		cfg.AccentColor = raw.AccentColor
 	}
-	cfg.PinnedRepos = SanitizePinnedRepos(raw.PinnedRepos)
+	cfg.PinnedRepos = SanitizeRepoList(raw.PinnedRepos)
+	cfg.WatchRepos = SanitizeRepoList(raw.WatchRepos)
 
 	return cfg, nil
 }
@@ -231,7 +242,7 @@ func Save(path string, cfg Config) error {
 	// Defensive sanitisation here too — a caller that bypassed
 	// the in-memory normaliser can't sneak garbage onto disk.
 	pinnedLine := ""
-	if pins := SanitizePinnedRepos(cfg.PinnedRepos); len(pins) > 0 {
+	if pins := SanitizeRepoList(cfg.PinnedRepos); len(pins) > 0 {
 		var b strings.Builder
 		b.WriteString("\n# Repositories pinned to the top of the Repos tab.\n")
 		b.WriteString("# Order here is preserved; press P on a row to toggle.\n")
@@ -241,6 +252,23 @@ func Save(path string, cfg Config) error {
 		}
 		b.WriteString("]\n")
 		pinnedLine = b.String()
+	}
+
+	// watch_repos block: same shape as pinned_repos, hand-edit
+	// only (no runtime toggle), surfaces a separate section under
+	// the Repos tab for repositories the user doesn't own.
+	watchLine := ""
+	if watch := SanitizeRepoList(cfg.WatchRepos); len(watch) > 0 {
+		var b strings.Builder
+		b.WriteString("\n# External repositories to monitor in a dedicated\n")
+		b.WriteString("# Watched section under the Repos tab. Edit by hand —\n")
+		b.WriteString("# there's no runtime toggle.\n")
+		b.WriteString("watch_repos = [\n")
+		for _, p := range watch {
+			fmt.Fprintf(&b, "  %q,\n", p)
+		}
+		b.WriteString("]\n")
+		watchLine = b.String()
 	}
 
 	body := fmt.Sprintf(`# octoscope configuration
@@ -259,7 +287,7 @@ compact = %t
 # Visual theme. Built-in: octoscope (default), high-contrast,
 # terminal, monochrome, stranger-things, phosphor, amber.
 theme = %q
-%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, accentLine, pinnedLine)
+%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, accentLine, pinnedLine, watchLine)
 
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 )
 
-// TestSanitizePinnedRepos pins the contract: drop empties, drop
+// TestSanitizeRepoList pins the contract: drop empties, drop
 // malformed entries, de-duplicate case-insensitively, preserve
 // first-occurrence order, return nil for an all-empty input.
-func TestSanitizePinnedRepos(t *testing.T) {
+func TestSanitizeRepoList(t *testing.T) {
 	tests := []struct {
 		name string
 		in   []string
@@ -59,7 +59,7 @@ func TestSanitizePinnedRepos(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SanitizePinnedRepos(tt.in)
+			got := SanitizeRepoList(tt.in)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got %#v, want %#v", got, tt.want)
 			}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -39,6 +39,15 @@ type Client struct {
 	login         string
 	publicOnly    bool
 
+	// watchRepos is the live list of external "owner/name"
+	// identifiers the next FetchStats will resolve into
+	// Stats.WatchedRepos (v0.14.0). Driven by the user's
+	// `watch_repos` config key + setter so a settings-panel
+	// edit (when we add one) can refresh the set without
+	// rebuilding the Client.
+	watchReposMu sync.RWMutex
+	watchRepos   []string
+
 	// viewerID is the GraphQL node ID of the authenticated viewer,
 	// cached lazily (see ensureViewerID). Used as the $authorFilter
 	// variable in FetchRepoDetail's history query so the
@@ -165,6 +174,15 @@ type Repo struct {
 	// values from GitHub: SUCCESS, FAILURE, ERROR, PENDING,
 	// EXPECTED.
 	CIState string
+
+	// LatestReleaseTag and LatestReleasePublishedAt are the
+	// most recent GitHub Release on the repo, populated via
+	// the repoCIFields' second parallel query in v0.14.0. Tag
+	// is empty (and PublishedAt zero) when the repo has no
+	// releases — common for libraries that ship via tags only,
+	// or for repos that simply haven't cut anything yet.
+	LatestReleaseTag         string
+	LatestReleasePublishedAt time.Time
 }
 
 // PullRequest is one open PR authored by the user, feeding the PRs
@@ -314,6 +332,14 @@ type Stats struct {
 	// Network
 	Organizations []Organization
 
+	// WatchedRepos are external "owner/name" repositories the user
+	// listed in `watch_repos`. Same Repo shape as the owned set
+	// (so the Repos tab can render them with CI dot, latest
+	// release, language colour, etc.) but kept separate so they
+	// can render in their own section and never get folded into
+	// the owned aggregates (TotalStars, ForksReceived, …).
+	WatchedRepos []Repo
+
 	// Meta
 	Authenticated bool
 	// IsViewer is true when the stats belong to the authenticated
@@ -459,6 +485,27 @@ func (c *Client) SetPublicOnly(v bool) {
 // reflect the live state, not the launch-time value.
 func (c *Client) PublicOnly() bool {
 	return c.publicOnly
+}
+
+// SetWatchRepos replaces the list of external "owner/name"
+// identifiers the next FetchStats will resolve into
+// Stats.WatchedRepos. Takes a copy so callers can mutate their
+// slice without disturbing the client. RWMutex-guarded because
+// the BubbleTea runtime may interleave a SetWatchRepos and a
+// FetchStats in flight.
+func (c *Client) SetWatchRepos(refs []string) {
+	c.watchReposMu.Lock()
+	defer c.watchReposMu.Unlock()
+	c.watchRepos = append([]string(nil), refs...)
+}
+
+// WatchRepos returns the current list of watched repos —
+// snapshot copy so the caller can iterate without holding the
+// lock.
+func (c *Client) WatchRepos() []string {
+	c.watchReposMu.RLock()
+	defer c.watchReposMu.RUnlock()
+	return append([]string(nil), c.watchRepos...)
 }
 
 // profileFields is the "everything-except-the-repo-list" half of
@@ -632,10 +679,15 @@ type repoFields struct {
 // repository nodes blew GitHub's gateway complexity ceiling and
 // 502'd on busy accounts — exactly the same failure mode that
 // drove the v0.10.1 split. Each node carries only the bare
-// minimum (nameWithOwner + rollup state) so this query stays
-// cheap; the merge happens by NameWithOwner in extractStats so
-// org-level repos don't collide with personal repos that share
-// a bare name.
+// minimum (nameWithOwner + rollup state + latest release
+// header) so this query stays cheap; the merge happens by
+// NameWithOwner in extractStats so org-level repos don't
+// collide with personal repos that share a bare name.
+//
+// v0.14.0 piggybacks `releases(first: 1)` onto this query
+// instead of opening a fourth parallel goroutine — the extra
+// connection access is small relative to splitting cost, and
+// keeps mergeRateLimit3 / extractStats signatures unchanged.
 type repoCIFields struct {
 	Repositories struct {
 		Nodes []struct {
@@ -649,6 +701,12 @@ type repoCIFields struct {
 					} `graphql:"... on Commit"`
 				}
 			}
+			Releases struct {
+				Nodes []struct {
+					TagName     githubv4.String
+					PublishedAt githubv4.DateTime
+				}
+			} `graphql:"releases(first: 1, orderBy: {field: CREATED_AT, direction: DESC})"`
 		}
 	} `graphql:"repositories(first: 100, ownerAffiliations: OWNER, isFork: false)"`
 }
@@ -682,10 +740,15 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		repoCI           repoCIFields
 		rlP, rlR, rlC    rateLimitFields
 		errP, errR, errC error
+		watched          []Repo
 	)
 
+	watchRefs := c.WatchRepos()
 	var wg sync.WaitGroup
 	wg.Add(3)
+	if len(watchRefs) > 0 {
+		wg.Add(1)
+	}
 
 	go func() {
 		defer wg.Done()
@@ -757,6 +820,18 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		}
 	}()
 
+	// Fourth parallel branch — external watched repos. Each entry
+	// resolves to its own singleRepoQuery (FetchWatchedRepos
+	// fans out further internally). Failures are dropped silently:
+	// a stale `watch_repos` entry mustn't fail the whole
+	// dashboard.
+	if len(watchRefs) > 0 {
+		go func() {
+			defer wg.Done()
+			watched = c.FetchWatchedRepos(ctx, watchRefs)
+		}()
+	}
+
 	wg.Wait()
 
 	// Surface the first error — all three queries serve the same
@@ -775,6 +850,7 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 
 	stats := c.extractStats(profile, repos, repoCI)
 	stats.RateLimit = mergeRateLimit3(rlP, rlR, rlC)
+	stats.WatchedRepos = watched
 	return stats, nil
 }
 
@@ -905,20 +981,31 @@ func classifyErr(ctx context.Context, err error) FetchErrorReason {
 // the data merge happens in one place rather than scattered
 // across the call sites.
 func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *Stats {
-	// Build the CI lookup once, keyed on the canonical
-	// "owner/name" string. Bare Name isn't unique inside
-	// ownerAffiliations: OWNER once orgs are in the picture (an
-	// org may own a repo called the same as a personal one) —
-	// using NameWithOwner as the key keeps the merge correct in
-	// every account shape. Nodes are bounded by the
-	// repositories(first: 100) cap, so the map stays small.
+	// Build two lookups from the repoCIFields payload — one
+	// for the CI rollup state (v0.13.0), one for the latest
+	// release header (v0.14.0). Both keyed on the canonical
+	// "owner/name" string; bare Name isn't unique once orgs
+	// enter the picture. Nodes are bounded by the
+	// repositories(first: 100) cap, so the maps stay small.
 	ciByNameWithOwner := make(map[string]string, len(ci.Repositories.Nodes))
+	type releaseSummary struct {
+		tag         string
+		publishedAt time.Time
+	}
+	releaseByNameWithOwner := make(map[string]releaseSummary, len(ci.Repositories.Nodes))
 	for _, n := range ci.Repositories.Nodes {
 		key := string(n.NameWithOwner)
 		if key == "" {
 			continue
 		}
 		ciByNameWithOwner[key] = string(n.DefaultBranchRef.Target.Commit.StatusCheckRollup.State)
+		if len(n.Releases.Nodes) > 0 {
+			rel := n.Releases.Nodes[0]
+			releaseByNameWithOwner[key] = releaseSummary{
+				tag:         string(rel.TagName),
+				publishedAt: rel.PublishedAt.Time,
+			}
+		}
 	}
 	// Sanitize at the boundary — every GitHub-sourced string
 	// flowing into Stats passes through Sanitize so the UI layer
@@ -1010,18 +1097,22 @@ func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *S
 		stats.OpenIssues += int(repo.Issues.TotalCount)
 		stats.OpenPRs += int(repo.PullRequests.TotalCount)
 
+		key := string(repo.NameWithOwner)
+		rel := releaseByNameWithOwner[key]
 		stats.Repositories = append(stats.Repositories, Repo{
-			Name:            Sanitize(string(repo.Name)),
-			URL:             Sanitize(string(repo.URL)),
-			PrimaryLanguage: Sanitize(string(repo.PrimaryLanguage.Name)),
-			LanguageColor:   Sanitize(string(repo.PrimaryLanguage.Color)),
-			Stars:           int(repo.StargazerCount),
-			Forks:           int(repo.ForkCount),
-			OpenIssues:      int(repo.Issues.TotalCount),
-			OpenPRs:         int(repo.PullRequests.TotalCount),
-			PushedAt:        repo.PushedAt.Time,
-			IsPrivate:       bool(repo.IsPrivate),
-			CIState:         Sanitize(ciByNameWithOwner[string(repo.NameWithOwner)]),
+			Name:                     Sanitize(string(repo.Name)),
+			URL:                      Sanitize(string(repo.URL)),
+			PrimaryLanguage:          Sanitize(string(repo.PrimaryLanguage.Name)),
+			LanguageColor:            Sanitize(string(repo.PrimaryLanguage.Color)),
+			Stars:                    int(repo.StargazerCount),
+			Forks:                    int(repo.ForkCount),
+			OpenIssues:               int(repo.Issues.TotalCount),
+			OpenPRs:                  int(repo.PullRequests.TotalCount),
+			PushedAt:                 repo.PushedAt.Time,
+			IsPrivate:                bool(repo.IsPrivate),
+			CIState:                  Sanitize(ciByNameWithOwner[key]),
+			LatestReleaseTag:         Sanitize(rel.tag),
+			LatestReleasePublishedAt: rel.publishedAt,
 		})
 
 		for _, e := range repo.Languages.Edges {

--- a/internal/github/detail.go
+++ b/internal/github/detail.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/shurcooL/githubv4"
@@ -76,6 +77,14 @@ type RepoDetail struct {
 	OpenIssuesPreview []IssuePreview
 	OpenPRsPreview    []IssuePreview
 	Topics            []string
+
+	// StarHistory is the list of starredAt timestamps for the
+	// last 12 months (newest first), capped at starHistoryMax
+	// entries. Fetched as a second parallel query in
+	// FetchRepoDetail — see FetchStarHistory and the v0.14.0
+	// sparkline renderer in the UI layer.
+	StarHistory          []time.Time
+	StarHistoryTruncated bool
 }
 
 // Release is the headline info for one GitHub release. Populated
@@ -291,14 +300,57 @@ func (c *Client) FetchRepoDetail(ctx context.Context, owner, name string) (*Repo
 		"authorFilter": authorFilter,
 		"hasAuthor":    githubv4.Boolean(hasAuthor),
 	}
-	if err := c.gql.Query(ctx, &q, variables); err != nil {
-		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+
+	// Detail query and star-history walk run in parallel — same
+	// pattern as v0.12.0's PR drill-in (GraphQL + REST files) and
+	// v0.10.1's dashboard split. fetchCtx + sync.Once preserves
+	// the original failure reason if one side cancels the other,
+	// mirroring FetchPRDetail.
+	fetchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		wg         sync.WaitGroup
+		errOnce    sync.Once
+		firstErr   error
+		stars      []time.Time
+		starsTrunc bool
+	)
+	setErr := func(err error) {
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
 	}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if err := c.gql.Query(fetchCtx, &q, variables); err != nil {
+			setErr(&FetchError{Reason: classifyErr(fetchCtx, err), Err: err})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		s, trunc, err := c.FetchStarHistory(fetchCtx, owner, name)
+		if err != nil {
+			setErr(err)
+			return
+		}
+		stars, starsTrunc = s, trunc
+	}()
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
 	// Pass hasAuthor (not c.authenticated) so the UI flag tracks
 	// the actual filter state. They diverge in the edge case
 	// "authenticated but ensureViewerID failed silently" — the
 	// filter was skipped, so the UI shouldn't claim it applied.
-	return extractRepoDetail(owner, q, hasAuthor), nil
+	d := extractRepoDetail(owner, q, hasAuthor)
+	d.StarHistory = stars
+	d.StarHistoryTruncated = starsTrunc
+	return d, nil
 }
 
 // SplitOwnerName parses a github.com URL into its (owner, name)

--- a/internal/github/star_history.go
+++ b/internal/github/star_history.go
@@ -1,0 +1,113 @@
+package github
+
+import (
+	"context"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// starHistoryWindow is how far back FetchStarHistory walks before
+// it gives up. 12 months is the "last year of momentum" sparkline
+// most users want at a glance; anything older becomes background
+// info that the in-browser starchart fallback link handles.
+const starHistoryWindow = 365 * 24 * time.Hour
+
+// starHistoryPageSize is the per-page count for the stargazers
+// connection. GitHub caps at 100; using the cap minimises round-
+// trips for high-velocity repos.
+const starHistoryPageSize = 100
+
+// starHistoryMax is the absolute ceiling on entries returned —
+// even within the 12-month window. Mostly a safety net for repos
+// that pick up several thousand stars per year: past 1000 the
+// sparkline is already fully saturated and additional points buy
+// nothing visually. Truncation is surfaced via
+// RepoDetail.StarHistoryTruncated so the UI can append a "(showing
+// most recent N)" note.
+const starHistoryMax = 1000
+
+// starHistoryQuery walks stargazers DESC by starredAt — paginated
+// — and stops as soon as a page returns a timestamp older than
+// the 12-month window. Ordering descending means we never need to
+// know the total count upfront: we walk only the prefix we need,
+// then bail.
+type starHistoryQuery struct {
+	Repository struct {
+		Stargazers struct {
+			PageInfo struct {
+				HasNextPage githubv4.Boolean
+				EndCursor   githubv4.String
+			}
+			Edges []struct {
+				StarredAt githubv4.DateTime
+			}
+		} `graphql:"stargazers(first: $first, after: $after, orderBy: {field: STARRED_AT, direction: DESC})"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// FetchStarHistory returns the starredAt timestamps for one repo
+// over the last starHistoryWindow (newest first). Truncated is
+// true when the function bailed on starHistoryMax before reaching
+// either the end of the window or the end of the connection.
+//
+// Pagination strategy: DESC by starredAt + bail-on-old-page.
+// Worst case for a quiet repo: 1 round-trip. Worst case for a
+// trending repo: starHistoryMax / starHistoryPageSize = 10
+// round-trips, capped.
+//
+// Errors classify through the shared FetchError so the UI's
+// "rate-limited / token rejected / network" banners stay
+// consistent with the rest of the package.
+func (c *Client) FetchStarHistory(ctx context.Context, owner, name string) ([]time.Time, bool, error) {
+	cutoff := time.Now().Add(-starHistoryWindow)
+	var (
+		stars     []time.Time
+		truncated bool
+		after     githubv4.String
+		first     = githubv4.Int(starHistoryPageSize)
+	)
+	for {
+		var q starHistoryQuery
+		vars := map[string]interface{}{
+			"owner": githubv4.String(owner),
+			"name":  githubv4.String(name),
+			"first": first,
+		}
+		if after != "" {
+			vars["after"] = after
+		} else {
+			// Initial page: GitHub requires a String! (or null)
+			// for the $after var. The shurcooL client serialises
+			// an empty string fine; explicit nil here would force
+			// us to change variable types between iterations.
+			vars["after"] = (*githubv4.String)(nil)
+		}
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, false, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+		page := q.Repository.Stargazers
+		if len(page.Edges) == 0 {
+			break
+		}
+		for _, e := range page.Edges {
+			t := e.StarredAt.Time
+			if t.Before(cutoff) {
+				// Page is ordered DESC, so once we cross the
+				// cutoff every subsequent star is also out of
+				// window — we're done.
+				return stars, truncated, nil
+			}
+			stars = append(stars, t)
+			if len(stars) >= starHistoryMax {
+				truncated = true
+				return stars, truncated, nil
+			}
+		}
+		if !bool(page.PageInfo.HasNextPage) {
+			break
+		}
+		after = page.PageInfo.EndCursor
+	}
+	return stars, truncated, nil
+}

--- a/internal/github/watched_repos.go
+++ b/internal/github/watched_repos.go
@@ -100,11 +100,19 @@ func (c *Client) FetchWatchedRepo(ctx context.Context, owner, name string) (Repo
 	}, nil
 }
 
+// watchedRepoConcurrency caps how many singleRepoQuery
+// round-trips run in parallel inside FetchWatchedRepos. Picked
+// at "enough to amortise serial latency but small enough that
+// a 200-entry watch_repos list can't burst-flood GitHub or
+// blow the goroutine count". Same shape any well-behaved
+// fan-out client uses (kubectl, gh CLI, …).
+const watchedRepoConcurrency = 10
+
 // FetchWatchedRepos resolves a list of "owner/name" identifiers
 // into Repo structs by running FetchWatchedRepo for each entry
-// in parallel. Failed entries (404, private, network blip) are
-// dropped silently — the dashboard mustn't fail over a single
-// stale config line.
+// in parallel, bounded by watchedRepoConcurrency. Failed
+// entries (404, private, network blip) are dropped silently —
+// the dashboard mustn't fail over a single stale config line.
 //
 // Order is preserved: the returned slice matches the input
 // order, so the Watched section under the Repos tab renders in
@@ -115,6 +123,12 @@ func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) []Repo {
 	}
 	out := make([]Repo, len(refs))
 	ok := make([]bool, len(refs))
+
+	// Buffered channel as a semaphore — each goroutine takes
+	// a slot before issuing the query and releases it on exit.
+	// Cap at watchedRepoConcurrency so a huge watch_repos list
+	// doesn't flood GitHub with parallel requests.
+	sem := make(chan struct{}, watchedRepoConcurrency)
 	var wg sync.WaitGroup
 	for i, ref := range refs {
 		owner, name := splitOwnerNameKey(ref)
@@ -124,6 +138,8 @@ func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) []Repo {
 		wg.Add(1)
 		go func(idx int, owner, name string) {
 			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			r, err := c.FetchWatchedRepo(ctx, owner, name)
 			if err != nil {
 				return // drop silently

--- a/internal/github/watched_repos.go
+++ b/internal/github/watched_repos.go
@@ -1,0 +1,167 @@
+package github
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// singleRepoQuery mirrors the fields populated for owned repos in
+// repoFields + repoCIFields, but for a single repository looked
+// up by (owner, name). Used to power the Watched section under
+// the Repos tab (v0.14.0): one targeted query per entry in
+// `watch_repos`, run in parallel so the dashboard refresh stays
+// close to the slowest sibling rather than their sum.
+//
+// Kept as a separate struct (rather than re-using repoFields'
+// nested types) so future changes to the bulk repository list
+// can evolve without dragging the watched-repo fetch with them.
+type singleRepoQuery struct {
+	Repository struct {
+		Name            githubv4.String
+		NameWithOwner   githubv4.String
+		URL             githubv4.String `graphql:"url"`
+		IsPrivate       githubv4.Boolean
+		PushedAt        githubv4.DateTime
+		PrimaryLanguage struct {
+			Name  githubv4.String
+			Color githubv4.String
+		}
+		StargazerCount githubv4.Int
+		ForkCount      githubv4.Int
+		Issues         struct {
+			TotalCount githubv4.Int
+		} `graphql:"issues(states: OPEN)"`
+		PullRequests struct {
+			TotalCount githubv4.Int
+		} `graphql:"pullRequests(states: OPEN)"`
+		DefaultBranchRef struct {
+			Target struct {
+				Commit struct {
+					StatusCheckRollup struct {
+						State githubv4.StatusState
+					}
+				} `graphql:"... on Commit"`
+			}
+		}
+		Releases struct {
+			Nodes []struct {
+				TagName     githubv4.String
+				PublishedAt githubv4.DateTime
+			}
+		} `graphql:"releases(first: 1, orderBy: {field: CREATED_AT, direction: DESC})"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// FetchWatchedRepo runs one singleRepoQuery and reshapes the
+// payload into a Repo, ready to drop into Stats.WatchedRepos.
+// All user-controlled strings are scrubbed at the boundary via
+// Sanitize — same defence-in-depth pattern as extractStats.
+//
+// A 404 from GitHub (repo removed, renamed, made private) is
+// reported as a FetchError with ReasonServer; callers can choose
+// to drop the entry silently instead of failing the whole
+// dashboard. v0.14.0 takes the "drop silently" path so a single
+// stale `watch_repos` entry doesn't break refresh for the user.
+func (c *Client) FetchWatchedRepo(ctx context.Context, owner, name string) (Repo, error) {
+	var q singleRepoQuery
+	vars := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(name),
+	}
+	if err := c.gql.Query(ctx, &q, vars); err != nil {
+		return Repo{}, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	r := q.Repository
+	var (
+		relTag string
+		relAt  time.Time
+	)
+	if len(r.Releases.Nodes) > 0 {
+		relTag = Sanitize(string(r.Releases.Nodes[0].TagName))
+		relAt = r.Releases.Nodes[0].PublishedAt.Time
+	}
+	return Repo{
+		Name:                     Sanitize(string(r.Name)),
+		URL:                      Sanitize(string(r.URL)),
+		PrimaryLanguage:          Sanitize(string(r.PrimaryLanguage.Name)),
+		LanguageColor:            Sanitize(string(r.PrimaryLanguage.Color)),
+		Stars:                    int(r.StargazerCount),
+		Forks:                    int(r.ForkCount),
+		OpenIssues:               int(r.Issues.TotalCount),
+		OpenPRs:                  int(r.PullRequests.TotalCount),
+		PushedAt:                 r.PushedAt.Time,
+		IsPrivate:                bool(r.IsPrivate),
+		CIState:                  Sanitize(string(r.DefaultBranchRef.Target.Commit.StatusCheckRollup.State)),
+		LatestReleaseTag:         relTag,
+		LatestReleasePublishedAt: relAt,
+	}, nil
+}
+
+// FetchWatchedRepos resolves a list of "owner/name" identifiers
+// into Repo structs by running FetchWatchedRepo for each entry
+// in parallel. Failed entries (404, private, network blip) are
+// dropped silently — the dashboard mustn't fail over a single
+// stale config line.
+//
+// Order is preserved: the returned slice matches the input
+// order, so the Watched section under the Repos tab renders in
+// the order the user wrote in their config file.
+func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) []Repo {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]Repo, len(refs))
+	ok := make([]bool, len(refs))
+	var wg sync.WaitGroup
+	for i, ref := range refs {
+		owner, name := splitOwnerNameKey(ref)
+		if owner == "" || name == "" {
+			continue
+		}
+		wg.Add(1)
+		go func(idx int, owner, name string) {
+			defer wg.Done()
+			r, err := c.FetchWatchedRepo(ctx, owner, name)
+			if err != nil {
+				return // drop silently
+			}
+			out[idx] = r
+			ok[idx] = true
+		}(i, owner, name)
+	}
+	wg.Wait()
+	// Compact the slice in input order, skipping failures.
+	compact := out[:0]
+	for i, r := range out {
+		if !ok[i] {
+			continue
+		}
+		compact = append(compact, r)
+	}
+	return compact
+}
+
+// splitOwnerNameKey parses an "owner/name" config string. Mirror
+// of the more strict SanitizeRepoList in internal/config; kept
+// local so the github package doesn't import config.
+func splitOwnerNameKey(s string) (string, string) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			if i == 0 || i == len(s)-1 {
+				return "", ""
+			}
+			// Reject "a/b/c" style entries — must be exactly one slash.
+			rest := s[i+1:]
+			for j := 0; j < len(rest); j++ {
+				if rest[j] == '/' {
+					return "", ""
+				}
+			}
+			return s[:i], rest
+		}
+	}
+	return "", ""
+}

--- a/internal/github/watched_repos_test.go
+++ b/internal/github/watched_repos_test.go
@@ -1,0 +1,35 @@
+package github
+
+import "testing"
+
+// splitOwnerNameKey is the bare-bones parser used by
+// FetchWatchedRepos; the strict sanitisation pass happens
+// upstream in config.SanitizeRepoList. Pins the contract that
+// no double-slash, leading-slash or trailing-slash entry can
+// produce a half-valid (owner, name) pair the caller would
+// then issue against GitHub.
+func TestSplitOwnerNameKey(t *testing.T) {
+	tests := []struct {
+		in        string
+		wantOwner string
+		wantName  string
+	}{
+		{"gfazioli/octoscope", "gfazioli", "octoscope"},
+		{"a/b", "a", "b"},
+		{"", "", ""},
+		{"no-slash", "", ""},
+		{"/leading", "", ""},
+		{"trailing/", "", ""},
+		{"three/segments/here", "", ""},
+		{"//", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			gotO, gotN := splitOwnerNameKey(tt.in)
+			if gotO != tt.wantOwner || gotN != tt.wantName {
+				t.Errorf("splitOwnerNameKey(%q) = (%q, %q), want (%q, %q)",
+					tt.in, gotO, gotN, tt.wantOwner, tt.wantName)
+			}
+		})
+	}
+}

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -9,17 +9,37 @@ import (
 )
 
 // heatmapLevels are the 5 foreground colours used to shade contribution
-// cells, indexed 0 (no contributions) .. 4 (busiest bucket). The ramp
-// walks the accent-pink hue from a dark surface into the full brand
-// colour, with deliberately wide steps so adjacent buckets stay
-// visually distinct (the previous 4-shade ramp had too little contrast
-// between "medium" and "busy").
+// cells when the active theme is NOT monochromatic. Indexed 0 (no
+// contributions) .. 4 (busiest bucket). The ramp walks the accent-pink
+// hue from a dark surface into the full brand colour, with deliberately
+// wide steps so adjacent buckets stay visually distinct (the previous
+// 4-shade ramp had too little contrast between "medium" and "busy").
+//
+// On monochromatic themes (`monochrome` / `phosphor` / `amber`) the
+// heatmap re-routes through monoHeatColor so the gradient stays
+// inside the theme's six palette slots — see heatColor.
 var heatmapLevels = [5]lipgloss.Color{
 	lipgloss.Color("#21262D"), // empty — barely-visible surface grey
 	lipgloss.Color("#5E1230"), // faint
 	lipgloss.Color("#993366"), // medium
 	lipgloss.Color("#CC3380"), // bright
 	lipgloss.Color("#F00050"), // accent / busiest
+}
+
+// heatColor returns the appropriate cell foreground colour for
+// the given bucket, honouring the theme's Monochromatic flag.
+// Callers should never index heatmapLevels directly.
+func heatColor(level int) lipgloss.Color {
+	if IsMonochromatic() {
+		return monoHeatColor(level)
+	}
+	if level < 0 {
+		level = 0
+	}
+	if level >= len(heatmapLevels) {
+		level = len(heatmapLevels) - 1
+	}
+	return heatmapLevels[level]
 }
 
 // heatmapCell is the glyph drawn in each day cell. A single monospace
@@ -194,7 +214,7 @@ func monthSpan(weeks [][]github.ContributionDay, from, m int) int {
 // contributor and a prolific one both get meaningful contrast.
 func styleCell(count, maxCount int) string {
 	if count == 0 || maxCount == 0 {
-		return lipgloss.NewStyle().Foreground(heatmapLevels[0]).Render(heatmapCell)
+		return lipgloss.NewStyle().Foreground(heatColor(0)).Render(heatmapCell)
 	}
 	// Clamp to 1..4 so any non-zero count renders with visible colour.
 	bucket := 1 + (count-1)*4/maxIntOne(maxCount)
@@ -204,7 +224,7 @@ func styleCell(count, maxCount int) string {
 	if bucket < 1 {
 		bucket = 1
 	}
-	return lipgloss.NewStyle().Foreground(heatmapLevels[bucket]).Render(heatmapCell)
+	return lipgloss.NewStyle().Foreground(heatColor(bucket)).Render(heatmapCell)
 }
 
 // maxIntOne returns n or 1 if n is zero, used to guard integer
@@ -223,7 +243,7 @@ func renderHeatmapLegend() string {
 	var swatches []string
 	for i := 0; i < 5; i++ {
 		swatches = append(swatches,
-			lipgloss.NewStyle().Foreground(heatmapLevels[i]).Render(heatmapCell),
+			lipgloss.NewStyle().Foreground(heatColor(i)).Render(heatmapCell),
 		)
 	}
 	return heatmapLegendStyle.Render("less ") +

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -341,7 +341,7 @@ type Options struct {
 
 	// PinnedRepos is the persisted list of "owner/name" identifiers
 	// that the Repos tab renders in a sticky section at the top.
-	// Already sanitised (see config.SanitizePinnedRepos) by the
+	// Already sanitised (see config.SanitizeRepoList) by the
 	// caller — NewModel trusts the slice as-is.
 	PinnedRepos []string
 }

--- a/internal/ui/monochrome.go
+++ b/internal/ui/monochrome.go
@@ -1,0 +1,53 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+// This file collects the small palette-translation helpers the
+// renderer reaches for when the active theme is monochromatic
+// (see Theme.Monochromatic — `monochrome`, `phosphor`, `amber`).
+// The contract is "no external semantic colour leaks in": the
+// GitHub language palette, the CI rollup green/red/yellow and
+// the Activity heatmap gradient all collapse into shades drawn
+// from the six theme slots so the theme's promise is respected
+// end-to-end.
+
+// monoRankColor picks a colour for the i-th item in an n-item
+// ordered list when the active theme is monochromatic. Walks
+// the theme's six palette slots from "most prominent" (Value)
+// to "quiet" (Muted) so the eye still picks up the leader of
+// the list. Used by the language bar in the Overview tab.
+//
+// rank is 0-indexed; n is the total count. Returns colValue
+// for n<=1 (degenerate case, only one item to render). For
+// n>1, the slot index scales linearly across the six slots.
+func monoRankColor(rank, n int) lipgloss.Color {
+	slots := []lipgloss.Color{colValue, colAccent, colOK, colWarn, colError, colMuted}
+	if n <= 1 {
+		return slots[0]
+	}
+	idx := rank * (len(slots) - 1) / (n - 1)
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(slots) {
+		idx = len(slots) - 1
+	}
+	return slots[idx]
+}
+
+// monoHeatColor returns the colour for one cell of the Activity
+// heatmap when the theme is monochromatic. heatLevel runs 0-4
+// (the same buckets the regular gradient uses), 0 = empty, 4 =
+// busiest. Scales from Muted (dim) up through Accent (most
+// prominent) so the heatmap still reads as a heatmap on a
+// `monochrome` / `phosphor` / `amber` background.
+func monoHeatColor(level int) lipgloss.Color {
+	scale := []lipgloss.Color{colMuted, colError, colWarn, colOK, colAccent}
+	if level < 0 {
+		level = 0
+	}
+	if level >= len(scale) {
+		level = len(scale) - 1
+	}
+	return scale[level]
+}

--- a/internal/ui/pr_detail.go
+++ b/internal/ui/pr_detail.go
@@ -610,11 +610,19 @@ func prTimelineGlyph(kind string) string {
 	}
 }
 
-// prDetailLabels renders the labels as a dot-separated list,
-// each in its GitHub-assigned hex colour.
+// prDetailLabels renders the labels as a dot-separated list.
+// Each label uses its GitHub-assigned hex colour unless the
+// active theme is monochromatic — in that case labels fall back
+// to plain foreground so the PR detail stays within the theme's
+// palette (see Theme.Monochromatic).
 func prDetailLabels(labels []github.LabelSummary) string {
+	mono := IsMonochromatic()
 	var parts []string
 	for _, l := range labels {
+		if mono {
+			parts = append(parts, l.Name)
+			continue
+		}
 		colour := lipgloss.Color("#" + strings.TrimPrefix(l.Color, "#"))
 		parts = append(parts, lipgloss.NewStyle().Foreground(colour).Render(l.Name))
 	}

--- a/internal/ui/repo_detail.go
+++ b/internal/ui/repo_detail.go
@@ -280,6 +280,13 @@ func (rd RepoDetailModel) computeBody(width int) string {
 		b.WriteString("\n\n")
 	}
 
+	// ---- Star history (12mo sparkline) — hidden when the repo
+	// had no stars in the window.
+	if hist := repoDetailStarHistory(d); hist != "" {
+		b.WriteString(hist)
+		b.WriteString("\n\n")
+	}
+
 	// ---- Languages
 	if len(d.Languages) > 0 {
 		b.WriteString(renderLanguages(d.Languages, width))
@@ -352,11 +359,16 @@ func repoDetailChips(d *github.RepoDetail) string {
 		parts = append(parts, mutedStyle.Render(d.License))
 	}
 	if d.PrimaryLanguage != "" {
-		if d.PrimaryLanguageColor != "" {
+		// Suppress the GitHub-hex chip in monochromatic themes —
+		// see Theme.Monochromatic for the contract.
+		switch {
+		case IsMonochromatic():
+			parts = append(parts, mutedStyle.Render(d.PrimaryLanguage))
+		case d.PrimaryLanguageColor != "":
 			parts = append(parts,
 				lipgloss.NewStyle().Foreground(lipgloss.Color(d.PrimaryLanguageColor)).Render(d.PrimaryLanguage),
 			)
-		} else {
+		default:
 			parts = append(parts, mutedStyle.Render(d.PrimaryLanguage))
 		}
 	}

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -641,19 +641,19 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		// a single coloured ● glyph per row, padded to the same
 		// width so the row dot stays aligned to the first char
 		// of the header label.
-		ciW = 2
-		// Release column shows "v1.2.3 · 3d" — tag (truncated)
-		// + relative age. 14 cells fits the common case
-		// ("v123.456.789 1y") without clipping, while a missing
-		// release falls back to a muted em-dash.
-		releaseW = 14
-		starsW   = 7
-		forksW   = 6
-		issuesW  = 6
-		prsW     = 5
-		pushedW  = 10 // "Xd ago" / "Xw ago" / "Xmo ago"
-		cursorW  = 2  // "▸ " / "  "
+		ciW     = 2
+		starsW  = 7
+		forksW  = 6
+		issuesW = 6
+		prsW    = 5
+		pushedW = 10 // "Xd ago" / "Xw ago" / "Xmo ago"
+		cursorW = 2  // "▸ " / "  "
 	)
+	// reposReleaseW (package-level, see below) is the width of
+	// the Release column; kept out of the local block so
+	// formatLatestRelease can read the same value and the two
+	// can never desync.
+	const releaseW = reposReleaseW
 
 	// Column header: plain mutedStyle, except the sorted column gets
 	// activeTabStyle + a trailing chevron so the eye finds it.
@@ -776,6 +776,14 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 	return strings.Join(out, "\n")
 }
 
+// reposReleaseW is the cell width of the Repos-tab "Release"
+// column. Shared between the column layout in renderReposTable
+// and formatLatestRelease's tag-budget math so the two can't
+// desync if the width ever changes. v1.2.3 (6) + " · " (3) +
+// "Xmo ago" (worst case 8) ≈ 17; 14 fits the common case
+// without clipping and leaves the table dense.
+const reposReleaseW = 14
+
 // formatLatestRelease renders the Repos-tab release column:
 // "tag · Xd" — tag truncated to fit, plus the relative age of
 // publishedAt. Returns an em-dash when the repo has no release
@@ -789,14 +797,14 @@ func formatLatestRelease(tag string, publishedAt time.Time) string {
 		return "—"
 	}
 	age := formatRelativeAgo(publishedAt)
-	// Available cells: 14 (releaseW) minus age (≤8 chars worst
+	// Available cells: reposReleaseW minus age (≤8 chars worst
 	// case like "12mo ago") minus the " · " separator (3) =
 	// budget for the tag itself. Truncate the tag, not the age,
 	// because the age conveys recency at a glance while a long
 	// tag like "v123.456.789-rc.1" is rarely informative past
 	// its prefix.
 	const overhead = 3 // " · "
-	tagBudget := 14 - cellWidth(age) - overhead
+	tagBudget := reposReleaseW - cellWidth(age) - overhead
 	if tagBudget < 4 {
 		tagBudget = 4
 	}

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -24,17 +24,19 @@ const (
 	ReposSortStars
 	ReposSortForks
 	ReposSortName
-	ReposSortCI // v0.13.0 — surface failing CI first
+	ReposSortCI      // v0.13.0 — surface failing CI first
+	ReposSortRelease // v0.14.0 — most recent release first
 )
 
 // reposSortLabels is the human-readable name for each sort mode,
 // shown in the tab header so the user knows what they're looking at.
 var reposSortLabels = [...]string{
-	ReposSortPushed: "pushed",
-	ReposSortStars:  "★ stars",
-	ReposSortForks:  "⑂ forks",
-	ReposSortName:   "name",
-	ReposSortCI:     "CI",
+	ReposSortPushed:  "pushed",
+	ReposSortStars:   "★ stars",
+	ReposSortForks:   "⑂ forks",
+	ReposSortName:    "name",
+	ReposSortCI:      "CI",
+	ReposSortRelease: "release",
 }
 
 // reposSortChevron is the arrow glyph drawn next to the sorted
@@ -42,11 +44,12 @@ var reposSortLabels = [...]string{
 // metric columns) and ↑ for the ascending name sort. CI sorts
 // failures-first, so the chevron points up to the "worst" rows.
 var reposSortChevron = [...]string{
-	ReposSortPushed: "↓",
-	ReposSortStars:  "↓",
-	ReposSortForks:  "↓",
-	ReposSortName:   "↑",
-	ReposSortCI:     "↑",
+	ReposSortPushed:  "↓",
+	ReposSortStars:   "↓",
+	ReposSortForks:   "↓",
+	ReposSortName:    "↑",
+	ReposSortCI:      "↑",
+	ReposSortRelease: "↓",
 }
 
 // ReposModel is the Repos-tab sub-state: cursor position, sort mode,
@@ -85,7 +88,7 @@ func (rm ReposModel) selectedRepo(stats *github.Stats, pinned []string) (github.
 	if stats == nil {
 		return github.Repo{}, false
 	}
-	rows := visibleRepos(stats.Repositories, rm.query, rm.sort, pinned)
+	rows, _, _, _ := visibleReposPartitioned(stats.Repositories, stats.WatchedRepos, rm.query, rm.sort, pinned)
 	if len(rows) == 0 {
 		return github.Repo{}, false
 	}
@@ -117,6 +120,29 @@ func visibleRepos(repos []github.Repo, query string, mode ReposSort, pinned []st
 	out = append(out, pinnedRows...)
 	out = append(out, rest...)
 	return out
+}
+
+// visibleReposPartitioned is the 3-way layout the Repos tab
+// actually paints: pinned at top, owned rest in the middle,
+// watched externals at the bottom. Each segment is independently
+// filtered (search applies to all three) but only the rest is
+// sorted by the active sort cycle — pinned and watched preserve
+// the user's config ordering on purpose.
+//
+// Returns a flat slice (for the cursor + viewport math) plus
+// the count of each section so the renderer can insert the
+// muted rules between segments. Sections of zero length are
+// silently absent from the output.
+func visibleReposPartitioned(owned, watched []github.Repo, query string, mode ReposSort, pinned []string) (rows []github.Repo, pinCount, restCount, watchCount int) {
+	filtered := filterRepos(owned, query)
+	pinnedRows, rest := partitionByPinned(filtered, pinned)
+	rest = sortRepos(rest, mode)
+	watchRows := filterRepos(watched, query)
+	rows = make([]github.Repo, 0, len(pinnedRows)+len(rest)+len(watchRows))
+	rows = append(rows, pinnedRows...)
+	rows = append(rows, rest...)
+	rows = append(rows, watchRows...)
+	return rows, len(pinnedRows), len(rest), len(watchRows)
 }
 
 // partitionByPinned splits `repos` into (pinned, rest):
@@ -255,11 +281,11 @@ func (rm ReposModel) Update(msg tea.Msg, stats *github.Stats, pinned []string) (
 	}
 
 	// Row count drives cursor bounds. Built from the same pipeline
-	// the renderer uses (visibleRepos) so Update + View can never
-	// disagree on which repo lives at index N.
+	// the renderer uses (visibleReposPartitioned) so Update + View
+	// can never disagree on which repo lives at index N.
 	var rows []github.Repo
 	if stats != nil {
-		rows = visibleRepos(stats.Repositories, rm.query, rm.sort, pinned)
+		rows, _, _, _ = visibleReposPartitioned(stats.Repositories, stats.WatchedRepos, rm.query, rm.sort, pinned)
 	}
 	n := len(rows)
 
@@ -399,6 +425,16 @@ func sortRepos(repos []github.Repo, mode ReposSort) []github.Repo {
 			if ar != br {
 				return ar < br // failures (low rank) first
 			}
+		case ReposSortRelease:
+			// Repos with no release sort to the bottom (zero time
+			// would otherwise sort to the top under "most recent").
+			az, bz := a.LatestReleasePublishedAt.IsZero(), b.LatestReleasePublishedAt.IsZero()
+			if az != bz {
+				return !az // a has a release and b doesn't → a first
+			}
+			if !az && !a.LatestReleasePublishedAt.Equal(b.LatestReleasePublishedAt) {
+				return a.LatestReleasePublishedAt.After(b.LatestReleasePublishedAt)
+			}
 		default: // ReposSortPushed
 			if !a.PushedAt.Equal(b.PushedAt) {
 				return a.PushedAt.After(b.PushedAt)
@@ -447,9 +483,10 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 		return mutedStyle.Render("(no repositories to show yet — waiting for first refresh)")
 	}
 
-	rows := visibleRepos(stats.Repositories, rm.query, rm.sort, pinned)
-	pinnedCount, _ := partitionByPinned(filterRepos(stats.Repositories, rm.query), pinned)
-	pinCount := len(pinnedCount)
+	rows, pinCount, restCount, watchCount := visibleReposPartitioned(
+		stats.Repositories, stats.WatchedRepos, rm.query, rm.sort, pinned,
+	)
+	_ = restCount // currently only the divider positions need it
 
 	// Clamp the cursor in case the repo count shrank across a refresh
 	// (private repo flipped public, repo deleted, filter narrowed the
@@ -515,7 +552,11 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 			mutedStyle.Render("   (esc to clear)")
 	}
 
-	table := renderReposTable(rows[offset:end], cursor-offset, rm.sort, pinCount-offset)
+	// Two dividers: after the last pinned row, and after the last
+	// owned (rest) row. Watched-repo section sits at the bottom.
+	watchStart := pinCount + restCount
+	_ = watchCount // count is implicit from len(rows) - watchStart
+	table := renderReposTable(rows[offset:end], cursor-offset, rm.sort, pinCount-offset, watchStart-offset)
 
 	hint := keyHints(
 		"↑↓", "move",
@@ -562,12 +603,15 @@ func (rm ReposModel) renderHeaderLine(visible, total, offset, end int) string {
 // for the visible slice. `cursorRow` is zero-based within the slice
 // (caller already computed the offset). `sortMode` drives which
 // column header gets the accent + chevron treatment.
-// pinDivider is the count of pinned rows in the visible window
-// (post-offset). When >0 and <len(repos), the renderer inserts a
-// muted rule after that row so the pinned section reads as a
-// distinct band above the rest of the list. ≤0 or ≥len(repos)
-// suppresses the divider — there's nothing to separate.
-func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pinDivider int) string {
+// pinDivider / watchDivider are the indices (in the visible
+// window, post-offset) AFTER which the renderer inserts a muted
+// rule. They mark the pinned/rest boundary and the rest/watched
+// boundary respectively. ≤0 or ≥len(repos) suppresses the
+// corresponding divider — there's nothing to separate.
+//
+// Order matters: pinDivider must be ≤ watchDivider; the
+// pinned segment always comes first.
+func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pinDivider, watchDivider int) string {
 	nameW := len("Name")
 	langW := len("Lang")
 	for _, r := range repos {
@@ -597,13 +641,18 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		// a single coloured ● glyph per row, padded to the same
 		// width so the row dot stays aligned to the first char
 		// of the header label.
-		ciW     = 2
-		starsW  = 7
-		forksW  = 6
-		issuesW = 6
-		prsW    = 5
-		pushedW = 10 // "Xd ago" / "Xw ago" / "Xmo ago"
-		cursorW = 2  // "▸ " / "  "
+		ciW = 2
+		// Release column shows "v1.2.3 · 3d" — tag (truncated)
+		// + relative age. 14 cells fits the common case
+		// ("v123.456.789 1y") without clipping, while a missing
+		// release falls back to a muted em-dash.
+		releaseW = 14
+		starsW   = 7
+		forksW   = 6
+		issuesW  = 6
+		prsW     = 5
+		pushedW  = 10 // "Xd ago" / "Xw ago" / "Xmo ago"
+		cursorW  = 2  // "▸ " / "  "
 	)
 
 	// Column header: plain mutedStyle, except the sorted column gets
@@ -642,6 +691,7 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		mutedStyle.Render(padLeft("⚠", issuesW)),
 		mutedStyle.Render(padLeft("⎇", prsW)),
 		decorate("Pushed", ReposSortPushed, pushedW, "left"),
+		decorate("Release", ReposSortRelease, releaseW, "left"),
 	}
 	header := strings.Join(headerCells, "  ")
 
@@ -664,18 +714,24 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		}
 
 		var lang string
-		if r.PrimaryLanguage == "" {
+		switch {
+		case r.PrimaryLanguage == "":
 			// Em-dash is 3 bytes in UTF-8 but 1 visible cell, so we
 			// can't use byte-based padRight here — it would under-pad
 			// by 2 cells and shift every column to its right.
 			lang = padRightRaw(mutedStyle.Render("—"), langW)
-		} else if r.LanguageColor != "" {
+		case IsMonochromatic():
+			// Monochromatic theme suppresses GitHub's language hex
+			// palette — render in plain foreground so the row stays
+			// within the theme's six colour slots.
+			lang = padRight(truncate(r.PrimaryLanguage, langW), langW)
+		case r.LanguageColor != "":
 			lang = padRightRaw(
 				lipgloss.NewStyle().Foreground(lipgloss.Color(r.LanguageColor)).
 					Render(truncate(r.PrimaryLanguage, langW)),
 				langW,
 			)
-		} else {
+		default:
 			lang = padRight(truncate(r.PrimaryLanguage, langW), langW)
 		}
 
@@ -684,6 +740,7 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		issues := padLeftStr(formatCompact(r.OpenIssues), issuesW)
 		prs := padLeftStr(formatCompact(r.OpenPRs), prsW)
 		pushed := padRight(formatRelativeAgo(r.PushedAt), pushedW)
+		release := padRight(formatLatestRelease(r.LatestReleaseTag, r.LatestReleasePublishedAt), releaseW)
 
 		if !active {
 			// Dim non-selected secondary columns so the active row
@@ -693,6 +750,7 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 			issues = mutedStyle.Render(issues)
 			prs = mutedStyle.Render(prs)
 			pushed = mutedStyle.Render(pushed)
+			release = mutedStyle.Render(release)
 		}
 
 		// Pad the dot to the full CI column width so the row
@@ -701,17 +759,48 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		// after the styled glyph rather than inside the escape.
 		ci := padRightRaw(ciDot(r.CIState), 2)
 
-		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed)
+		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed+"  "+release)
 
-		// Insert the pinned/rest divider exactly once, after the
-		// last pinned row in the visible window. A 1-cell muted
-		// rule wide enough to span the header line — re-using the
-		// header width is cheaper than re-computing column widths.
+		// Insert the section dividers exactly once each, after
+		// the last row of the pinned and rest segments. Re-uses
+		// the header width so the rule spans the same band as
+		// the table.
+		rule := tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header)))
 		if pinDivider > 0 && i == pinDivider-1 && i+1 < len(repos) {
-			out = append(out, tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header))))
+			out = append(out, rule)
+		}
+		if watchDivider > 0 && i == watchDivider-1 && i+1 < len(repos) && watchDivider != pinDivider {
+			out = append(out, rule)
 		}
 	}
 	return strings.Join(out, "\n")
+}
+
+// formatLatestRelease renders the Repos-tab release column:
+// "tag · Xd" — tag truncated to fit, plus the relative age of
+// publishedAt. Returns an em-dash when the repo has no release
+// so the column stays visually present without making a claim.
+//
+// Lives next to ciDot because the same width budget logic
+// applies and the two are siblings in the v0.13.0 + v0.14.0
+// Repos-tab additions.
+func formatLatestRelease(tag string, publishedAt time.Time) string {
+	if tag == "" || publishedAt.IsZero() {
+		return "—"
+	}
+	age := formatRelativeAgo(publishedAt)
+	// Available cells: 14 (releaseW) minus age (≤8 chars worst
+	// case like "12mo ago") minus the " · " separator (3) =
+	// budget for the tag itself. Truncate the tag, not the age,
+	// because the age conveys recency at a glance while a long
+	// tag like "v123.456.789-rc.1" is rarely informative past
+	// its prefix.
+	const overhead = 3 // " · "
+	tagBudget := 14 - cellWidth(age) - overhead
+	if tagBudget < 4 {
+		tagBudget = 4
+	}
+	return truncate(tag, tagBudget) + " · " + age
 }
 
 // ciDot maps the status-check rollup state to a single coloured
@@ -719,7 +808,24 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 // (green/red/yellow/grey) — same shape lazygit, gh dash and
 // github.com itself use. Wide-rune-safe: stays at exactly 1 cell
 // no matter the state, so the column never shifts.
+//
+// On monochromatic themes the four states fall back to distinct
+// glyphs (✓ / ✕ / ⋯ / ·) instead of distinct colours — without
+// chroma the eye can't tell a "green dot" from a "red dot" on a
+// monochrome background.
 func ciDot(state string) string {
+	if IsMonochromatic() {
+		switch state {
+		case "SUCCESS":
+			return okStyle.Render("✓")
+		case "FAILURE", "ERROR":
+			return errorStyle.Render("✕")
+		case "PENDING", "EXPECTED":
+			return warnStyle.Render("⋯")
+		default:
+			return mutedStyle.Render("·")
+		}
+	}
 	switch state {
 	case "SUCCESS":
 		return okStyle.Render("●")

--- a/internal/ui/star_history.go
+++ b/internal/ui/star_history.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// sparkBars are the unicode block glyphs used to draw the
+// star-history sparkline, sorted from least to most intense.
+// One bar per weekly bucket; the 0 slot is intentionally a
+// "tick" rune rather than a blank space so empty weeks still
+// register as part of the 52-week axis — a young repo with
+// stars only in the last fortnight should still look like a
+// 52-cell timeline ending in a peak, not a tiny bar floating
+// halfway across the line.
+var sparkBars = [8]rune{
+	'·', // empty week — muted tick on the timeline axis
+	'▁', '▂', '▃', '▄', '▅', '▆', '▇',
+}
+
+// starSparkBuckets is the number of weekly buckets in the
+// rendered sparkline. 52 weeks = a full year, matching the
+// FetchStarHistory window (`starHistoryWindow = 365d`).
+const starSparkBuckets = 52
+
+// renderStarSparkline produces the body of the "Star history
+// (12mo)" section of the Repos drill-in: a 52-char sparkline
+// summarising weekly star counts, plus a footer line with the
+// total and last-star age. Returns "" when the repo had no
+// stars in the window — caller hides the section in that case.
+//
+// The sparkline is intentionally narrow (52 cells) so it fits
+// inside the detail-view viewport regardless of terminal width.
+// Bigger renderings (with axis ticks, hover) belong on
+// starchart.cc — we link there as a fallback.
+func renderStarSparkline(stars []time.Time, truncated bool) string {
+	if len(stars) == 0 {
+		return ""
+	}
+	buckets := bucketStars(stars, time.Now(), starSparkBuckets)
+	spark := sparklineString(buckets)
+
+	// Total inside the window + last-star recency, both useful
+	// at-a-glance metrics under the bars.
+	var lastAgo string
+	if len(stars) > 0 {
+		// stars is DESC ordered (newest first) from
+		// FetchStarHistory, so stars[0] is the most recent.
+		lastAgo = formatRelativeAgo(stars[0])
+	}
+	suffix := ""
+	if truncated {
+		suffix = mutedStyle.Render(" (cap reached)")
+	}
+	footer := fmt.Sprintf("+%d in last 12mo · last star %s", len(stars), lastAgo)
+	return spark + "\n" + mutedStyle.Render(footer) + suffix
+}
+
+// bucketStars distributes star timestamps into `n` weekly
+// buckets ending at `now`. Index 0 is the oldest week (≈12mo
+// ago); index n-1 is the most recent week. Stars outside the
+// window are silently dropped — the caller will already have
+// capped them via starHistoryWindow.
+func bucketStars(stars []time.Time, now time.Time, n int) []int {
+	out := make([]int, n)
+	if n <= 0 {
+		return out
+	}
+	// Each bucket covers (now - (n-i) * week, now - (n-i-1) * week].
+	const week = 7 * 24 * time.Hour
+	for _, t := range stars {
+		delta := now.Sub(t)
+		if delta < 0 {
+			delta = 0
+		}
+		idx := n - 1 - int(delta/week)
+		if idx < 0 || idx >= n {
+			continue
+		}
+		out[idx]++
+	}
+	return out
+}
+
+// sparklineString maps a slice of counts to the 8-glyph block
+// scale. Counts are normalised against the slice's own maximum
+// so a quiet repo's sparkline still has visible peaks (the
+// maximum bar reads as ▇, not just one cell above empty).
+// Empty weeks render as a muted `·` so the 52-week axis stays
+// visually continuous even on young repos.
+func sparklineString(buckets []int) string {
+	max := 0
+	for _, n := range buckets {
+		if n > max {
+			max = n
+		}
+	}
+	if max == 0 {
+		return ""
+	}
+	// Build the line glyph-by-glyph so empties and bars carry
+	// different styles (muted tick vs accent bar). Concatenating
+	// styled fragments rather than colouring the whole string in
+	// one shot keeps the tick reads-as-axis instead of reads-as-
+	// data.
+	var b strings.Builder
+	emptyGlyph := mutedStyle.Render(string(sparkBars[0]))
+	bar := boldStyle.Foreground(colAccent)
+	for _, n := range buckets {
+		if n <= 0 {
+			b.WriteString(emptyGlyph)
+			continue
+		}
+		// Scale 1..max → 1..7 (we leave 0 for "empty"); use
+		// integer arithmetic so the result is deterministic.
+		idx := 1 + (n-1)*(len(sparkBars)-2)/maxIntPositive(max-1)
+		if idx >= len(sparkBars) {
+			idx = len(sparkBars) - 1
+		}
+		b.WriteString(bar.Render(string(sparkBars[idx])))
+	}
+	return b.String()
+}
+
+// maxIntPositive returns n if positive, 1 otherwise. Guards
+// integer divisions in the sparkline scale when max == 1
+// (every bucket has at most one star).
+func maxIntPositive(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// repoDetailStarHistory is the section heading + sparkline body
+// wrapper called from RepoDetailModel.computeBody. Returns "" so
+// the caller can simply skip the section when the repo has no
+// stars in the window.
+func repoDetailStarHistory(d *github.RepoDetail) string {
+	body := renderStarSparkline(d.StarHistory, d.StarHistoryTruncated)
+	if body == "" {
+		return ""
+	}
+	return subSectionTitleStyle.Render("Star history (12mo)") + "\n" + body
+}

--- a/internal/ui/star_history.go
+++ b/internal/ui/star_history.go
@@ -41,7 +41,7 @@ func renderStarSparkline(stars []time.Time, truncated bool) string {
 		return ""
 	}
 	buckets := bucketStars(stars, time.Now(), starSparkBuckets)
-	spark := sparklineString(buckets)
+	spark := styledSparkline(sparklineString(buckets))
 
 	// Total inside the window + last-star recency, both useful
 	// at-a-glance metrics under the bars.
@@ -86,11 +86,16 @@ func bucketStars(stars []time.Time, now time.Time, n int) []int {
 }
 
 // sparklineString maps a slice of counts to the 8-glyph block
-// scale. Counts are normalised against the slice's own maximum
-// so a quiet repo's sparkline still has visible peaks (the
-// maximum bar reads as ▇, not just one cell above empty).
-// Empty weeks render as a muted `·` so the 52-week axis stays
-// visually continuous even on young repos.
+// scale, returning the plain glyph sequence (no ANSI styling).
+// Counts are normalised against the slice's own maximum so a
+// quiet repo's sparkline still has visible peaks (the maximum
+// bar reads as ▇, not just one cell above empty). Empty weeks
+// render as a `·` tick so the 52-week axis stays visually
+// continuous even on young repos.
+//
+// Plain string by design — styling lives in styledSparkline so
+// the test layer asserts on stable glyphs without depending on
+// lipgloss colour-mode detection.
 func sparklineString(buckets []int) string {
 	max := 0
 	for _, n := range buckets {
@@ -101,17 +106,10 @@ func sparklineString(buckets []int) string {
 	if max == 0 {
 		return ""
 	}
-	// Build the line glyph-by-glyph so empties and bars carry
-	// different styles (muted tick vs accent bar). Concatenating
-	// styled fragments rather than colouring the whole string in
-	// one shot keeps the tick reads-as-axis instead of reads-as-
-	// data.
-	var b strings.Builder
-	emptyGlyph := mutedStyle.Render(string(sparkBars[0]))
-	bar := boldStyle.Foreground(colAccent)
-	for _, n := range buckets {
+	runes := make([]rune, len(buckets))
+	for i, n := range buckets {
 		if n <= 0 {
-			b.WriteString(emptyGlyph)
+			runes[i] = sparkBars[0]
 			continue
 		}
 		// Scale 1..max → 1..7 (we leave 0 for "empty"); use
@@ -120,7 +118,29 @@ func sparklineString(buckets []int) string {
 		if idx >= len(sparkBars) {
 			idx = len(sparkBars) - 1
 		}
-		b.WriteString(bar.Render(string(sparkBars[idx])))
+		runes[i] = sparkBars[idx]
+	}
+	return string(runes)
+}
+
+// styledSparkline paints the plain glyph string from
+// sparklineString: empty `·` ticks in muted, filled bars in
+// accent+bold. Separate from sparklineString so the binning
+// logic stays unit-testable without lipgloss colour-mode
+// dependencies.
+func styledSparkline(plain string) string {
+	if plain == "" {
+		return ""
+	}
+	var b strings.Builder
+	emptyGlyph := mutedStyle.Render(string(sparkBars[0]))
+	bar := boldStyle.Foreground(colAccent)
+	for _, r := range plain {
+		if r == sparkBars[0] {
+			b.WriteString(emptyGlyph)
+		} else {
+			b.WriteString(bar.Render(string(r)))
+		}
 	}
 	return b.String()
 }

--- a/internal/ui/star_history_test.go
+++ b/internal/ui/star_history_test.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// bucketStars must distribute timestamps across n weekly
+// buckets with index 0 = oldest, n-1 = most recent. Pins the
+// contract that fuels the sparkline renderer.
+func TestBucketStars(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	week := 7 * 24 * time.Hour
+
+	tests := []struct {
+		name  string
+		stars []time.Time
+		n     int
+		want  []int
+	}{
+		{
+			name:  "empty input",
+			stars: nil,
+			n:     4,
+			want:  []int{0, 0, 0, 0},
+		},
+		{
+			name: "all in most-recent bucket",
+			stars: []time.Time{
+				now,
+				now.Add(-2 * time.Hour),
+			},
+			n:    4,
+			want: []int{0, 0, 0, 2},
+		},
+		{
+			name: "spread across last 3 weeks",
+			stars: []time.Time{
+				now.Add(-1 * week / 2),      // bucket n-1
+				now.Add(-(1*week + week/2)), // bucket n-2
+				now.Add(-(2*week + week/2)), // bucket n-3
+			},
+			n:    4,
+			want: []int{0, 1, 1, 1},
+		},
+		{
+			name: "out-of-window dropped",
+			stars: []time.Time{
+				now.Add(-1 * time.Hour), // n-1
+				now.Add(-100 * week),    // way out, dropped
+			},
+			n:    4,
+			want: []int{0, 0, 0, 1},
+		},
+		{
+			name:  "n=0 returns empty",
+			stars: []time.Time{now},
+			n:     0,
+			want:  []int{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bucketStars(tt.stars, now, tt.n)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(got)=%d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("bucket %d = %d, want %d", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// sparklineString maps integer buckets to 8 block glyphs. Pins
+// the corner cases: all-empty input collapses to empty string,
+// scaling stays monotonic, single non-zero bucket renders at
+// the highest level.
+func TestSparklineString(t *testing.T) {
+	tests := []struct {
+		name    string
+		buckets []int
+		want    string
+	}{
+		{
+			name:    "all empty → empty string",
+			buckets: []int{0, 0, 0},
+			want:    "",
+		},
+		{
+			name:    "single bucket scales to max",
+			buckets: []int{0, 0, 5, 0},
+			// Empty weeks render as muted ticks (`·`), one
+			// per bucket, so the timeline axis stays
+			// visible even when most weeks are empty.
+			want: "··▇·",
+		},
+		{
+			name:    "monotonic ramp produces increasing bars",
+			buckets: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			// First is empty (count 0 → muted tick), others
+			// scale 1..max=7.
+			want: "·▁▂▃▄▅▆▇",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sparklineString(tt.buckets)
+			if !strings.HasSuffix(got, strings.TrimPrefix(tt.want, " ")) && got != tt.want {
+				// Accept exact match OR (for the "single bucket"
+				// case) just the suffix — string len matches the
+				// input bucket count regardless.
+				if got != tt.want {
+					t.Errorf("got %q, want %q", got, tt.want)
+				}
+			}
+			if got != "" && len([]rune(got)) != len(tt.buckets) {
+				t.Errorf("length mismatch: got %d runes, want %d", len([]rune(got)), len(tt.buckets))
+			}
+		})
+	}
+}

--- a/internal/ui/star_history_test.go
+++ b/internal/ui/star_history_test.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"strings"
 	"testing"
 	"time"
 )
@@ -109,13 +108,8 @@ func TestSparklineString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sparklineString(tt.buckets)
-			if !strings.HasSuffix(got, strings.TrimPrefix(tt.want, " ")) && got != tt.want {
-				// Accept exact match OR (for the "single bucket"
-				// case) just the suffix — string len matches the
-				// input bucket count regardless.
-				if got != tt.want {
-					t.Errorf("got %q, want %q", got, tt.want)
-				}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
 			}
 			if got != "" && len([]rune(got)) != len(tt.buckets) {
 				t.Errorf("length mismatch: got %d runes, want %d", len([]rune(got)), len(tt.buckets))

--- a/internal/ui/themes.go
+++ b/internal/ui/themes.go
@@ -30,6 +30,26 @@ type Theme struct {
 	Warn   lipgloss.Color
 	Error  lipgloss.Color
 	Muted  lipgloss.Color
+
+	// Monochromatic, when true, signals the renderer that this
+	// theme is intended to be tonally uniform: no semantic colour
+	// from outside the six palette slots should leak in. The
+	// language bar's GitHub-hex colours, the CI rollup dot's
+	// green/red/yellow, the Activity heatmap gradient and the
+	// PR-state chips all fall back to value-graded shades of the
+	// Muted / Accent slots so the theme's promise ("zero chroma"
+	// for `monochrome`, "shades of green" for `phosphor`, "shades
+	// of amber" for `amber`) is respected end-to-end. See
+	// IsMonochromatic for the runtime accessor.
+	Monochromatic bool
+}
+
+// IsMonochromatic reports whether the active theme has asked the
+// renderer to suppress external semantic colours. Used by the
+// language bar, CI dot, +/- diff counts, PR state chips and the
+// Activity heatmap.
+func IsMonochromatic() bool {
+	return currentTheme != nil && currentTheme.Monochromatic
 }
 
 // themes holds the built-in palettes. Keep keys lowercase, hyphenated;
@@ -68,13 +88,14 @@ var themes = map[string]*Theme{
 	"monochrome": {
 		// All greys, no chroma. For B&W terminals or zero-distraction
 		// dashboards. Hierarchy is preserved purely through value.
-		Name:   "monochrome",
-		Accent: "252",
-		Value:  "255",
-		OK:     "250",
-		Warn:   "248",
-		Error:  "245",
-		Muted:  "240",
+		Name:          "monochrome",
+		Accent:        "252",
+		Value:         "255",
+		OK:            "250",
+		Warn:          "248",
+		Error:         "245",
+		Muted:         "240",
+		Monochromatic: true,
 	},
 	"stranger-things": {
 		// 80s logo crimson on near-black, with the "Christmas lights"
@@ -95,26 +116,28 @@ var themes = map[string]*Theme{
 		// CRT terminals had nothing else to give. The user reads
 		// alarm from context (the "errored" word, the position) the
 		// way they did in 1983.
-		Name:   "phosphor",
-		Accent: "#33FF66",
-		Value:  "#7FFF7F",
-		OK:     "#33FF66",
-		Warn:   "#A8FF8B",
-		Error:  "#9FFF9F",
-		Muted:  "#006633",
+		Name:          "phosphor",
+		Accent:        "#33FF66",
+		Value:         "#7FFF7F",
+		OK:            "#33FF66",
+		Warn:          "#A8FF8B",
+		Error:         "#9FFF9F",
+		Muted:         "#006633",
+		Monochromatic: true,
 	},
 	"amber": {
 		// The other half of the 80s CRT story — IBM 5151, WordStar,
 		// the amber phosphor that was easier on the eyes during long
 		// terminal sessions. Same pure-monochrome philosophy as
 		// phosphor: every slot is a shade of amber, errors included.
-		Name:   "amber",
-		Accent: "#FFB000",
-		Value:  "#FFD27F",
-		OK:     "#FFB000",
-		Warn:   "#FFC844",
-		Error:  "#FFD27F",
-		Muted:  "#5C3F00",
+		Name:          "amber",
+		Accent:        "#FFB000",
+		Value:         "#FFD27F",
+		OK:            "#FFB000",
+		Warn:          "#FFC844",
+		Error:         "#FFD27F",
+		Muted:         "#5C3F00",
+		Monochromatic: true,
 	},
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -631,15 +631,26 @@ func renderLanguages(langs []github.Language, available int) string {
 
 	var b strings.Builder
 	b.WriteString(subSectionTitleStyle.Render("Languages") + "\n")
-	for _, l := range langs {
+	mono := IsMonochromatic()
+	for i, l := range langs {
 		pct := float64(l.Bytes) / float64(total) * 100
 		filled := int(float64(barWidth)*pct/100 + 0.5)
 		if filled < 1 && l.Bytes > 0 {
 			filled = 1
 		}
 
-		barColour := lipgloss.Color(l.Color)
-		if l.Color == "" {
+		// Monochromatic themes (monochrome / phosphor / amber)
+		// suppress the GitHub language palette and rank-scale
+		// the bars through their own six slots instead — the
+		// theme's "no external colour" promise is respected
+		// even for what would otherwise read as data colour.
+		var barColour lipgloss.Color
+		switch {
+		case mono:
+			barColour = monoRankColor(i, len(langs))
+		case l.Color != "":
+			barColour = lipgloss.Color(l.Color)
+		default:
 			barColour = colMuted
 		}
 		filledBar := lipgloss.NewStyle().Foreground(barColour).Render(strings.Repeat("█", filled))

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.13.0"
+const version = "0.14.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI
@@ -73,6 +73,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "octoscope: %v\n", err)
 		os.Exit(1)
 	}
+	client.SetWatchRepos(cfg.WatchRepos)
 
 	model := ui.NewModel(client, version, ui.Options{
 		Interval:    cfg.RefreshInterval,


### PR DESCRIPTION
## Summary

Four additions on the Repos surface that turn it from "your owned repos" into "every repo you care about, with the signals that matter": **star history sparkline** in the Repos drill-in, **latest release column** on the Repos tab, **watched repos** for repositories you don't own, and **theme fidelity** in monochromatic themes (a bonus polish from PH/maintainer feedback).

## What lands

### Star history sparkline (Repos drill-in)

- New `github.RepoDetail.StarHistory` + `FetchStarHistory` — paginates `stargazers(orderBy: STARRED_AT DESC)` and bails out as soon as a page crosses the 12-month window. Capped at `starHistoryMax` (1000) to bound trending-repo cost.
- `FetchRepoDetail` runs the detail query and the star-history walk **in parallel** (`sync.Once` + ctx-with-cancel) — wall-clock latency stays close to the slower of the two.
- Renders as an ASCII sparkline (`▁▂▃▄▅▆▇` blocks over 52 weekly buckets) inside the Repos drill-in, between Latest release and Languages. Empty weeks render as muted `·` ticks so the axis stays visually continuous on young repos (otherwise a single peak would float at the right edge, disconnected from the heading).
- Footer: `+N in last 12mo · last star Xd ago`.

### Latest release column (Repos tab)

- New `github.Repo.LatestReleaseTag` + `LatestReleasePublishedAt`, populated via `releases(first: 1)` piggybacked onto the existing `repoCIFields` parallel query — no new round-trip.
- New `Release` column on the Repos tab: `tag · 3d ago` or em-dash when the repo has no release.
- New `ReposSortRelease` entry in the sort cycle — most recently published first; repos with no release sort to the bottom.

### Watched repos (external)

- New `watch_repos = ["owner/name", ...]` config key. Same sanitiser (`SanitizeRepoList`, renamed from `SanitizePinnedRepos`) so the parsing is shared with pinned repos.
- `github.Client` grows `watchRepos` + `SetWatchRepos` so the in-memory list can be updated without rebuilding the client. `FetchStats` picks it up as the **fourth parallel branch**: `FetchWatchedRepos` fans out one `singleRepoQuery` per entry, drops failures silently so a stale config line can't break refresh.
- Repos tab renders a third sticky section under the pinned-then-owned partition, separated by a second muted rule. New `visibleReposPartitioned` returns the flat slice plus section counts so the cursor walks all three uniformly and `renderReposTable` knows where to insert each rule.

### Theme fidelity in monochromatic themes (bonus)

`monochrome`, `phosphor` and `amber` themes promise "zero chroma" / "shades of [green / amber]" but the renderer was still leaking external semantic colour: GitHub language palette, CI rollup green/red, Activity heatmap pink gradient. Fixed in this release.

- `ui.Theme` grows a `Monochromatic` flag. Runtime `IsMonochromatic` check substitutes:
  - Language bar (Overview, Repos column, Repo-detail chip) → plain foreground or a six-step rank-scale through the theme's own palette
  - PR-detail labels → drop the per-label hex
  - Activity heatmap → `heatColor()` routes through `monoHeatColor` (Muted → Accent scale)
  - CI rollup dot → distinct glyphs (`✓` / `✕` / `⋯` / `·`) instead of relying on green/red/yellow chroma the theme has deliberately removed
- New `internal/ui/monochrome.go` centralises the rank-scale and heatmap-bucket mappings so future renderers have one contract to follow.

## Tests

- `internal/ui/star_history_test.go`: `bucketStars` contract (oldest-first → newest-last, out-of-window drop, n=0 edge), `sparklineString` (all-empty collapse, max scaling, monotonic ramp).
- `internal/github/watched_repos_test.go`: `splitOwnerNameKey` (no slash, leading slash, trailing slash, three segments, empty input).

## Verification on real data

Smoke-tested the star-history sparkline against the GitHub API on the maintainer's account — every count matched at the pelo:

| Repo | octoscope shows | GitHub API |
|---|---|---|
| `gfazioli/octoscope` | +38 in 12mo · 4d ago | total 38, **38 in window**, last 2026-05-18 |
| `gfazioli/mantine-split-pane` | +44 in 12mo · 1w ago | total 76, **44 in window**, last 2026-05-16 |

The 76→44 delta for `mantine-split-pane` confirms the 12-month cap is doing what it should.

## Test plan

- [x] `go build` clean (dual-target)
- [x] `go test -race ./...` passes
- [x] Manual smoke on the maintainer's account across `octoscope`, `monochrome`, `phosphor`, `amber` themes
- [x] Manual smoke with `watch_repos` populated — third section renders under the rule, cursor walks all three sections cleanly

## Docs / release prep included

This PR also folds in the release-prep commit (same pattern as v0.13.0): `main.go` version bump, README updates, docs/index.html version pill + new "At a glance" card describing the four additions.