### PR TITLE
Notified when it matters: review-requests inbox + macOS subtitle (v0.15.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
   a third "Watched" section under your own list.
 - **PRs** — every open pull request you've authored, across every repo.
   Number, title, repo, state (draft / ready / conflicts) and last-update
-  time. Same sort & search idioms as Repos.
+  time. Same sort & search idioms as Repos. **PRs awaiting your review**
+  (v0.15.0+) surface in a sticky section at the top of the tab when
+  someone has requested you as a reviewer — separated from your authored
+  list by a muted rule, ordered most-recently-updated first.
 - **Issues** — every open issue you've authored, wherever it lives. Same
   shape as PRs minus the state column.
 - **Activity** — 52-week contribution heatmap, plus total / current streak /

--- a/docs/index.html
+++ b/docs/index.html
@@ -914,7 +914,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.14.0</span>
+                <span class="version-tag" id="version-pill">0.15.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1062,6 +1062,11 @@
                     <div class="feature-label">Watching more, seeing more</div>
                     <h3>Star history &middot; latest release &middot; watched repos</h3>
                     <p>New in v0.14.0. A <strong style="color: var(--text);">12-month star-history sparkline</strong> lands in the Repos drill-in &mdash; <code class="inline">▁▂▃▄▅▆▇</code> blocks over weekly buckets, plus "+N in last 12mo &middot; last star Xd ago". A new <strong style="color: var(--text);">latest release column</strong> on the Repos tab shows tag + age ("v1.2.3 &middot; 3d") and joins the sort cycle. Add <code class="inline">watch_repos = ["owner/name", ...]</code> to the config to monitor <strong style="color: var(--text);">repositories you don't own</strong>: they appear in a dedicated Watched section under your list, fetched in parallel with the dashboard refresh. <strong style="color: var(--text);">Bonus polish</strong>: monochromatic themes (<code class="inline">monochrome</code>, <code class="inline">phosphor</code>, <code class="inline">amber</code>) now suppress the GitHub language palette, CI rollup green/red and Activity heatmap gradient &mdash; "zero chroma" finally means zero chroma end-to-end.</p>
+                </div>
+                <div class="feature wide">
+                    <div class="feature-label">Notified when it matters</div>
+                    <h3>Review requests inbox &middot; richer notifications</h3>
+                    <p>New in v0.15.0. The <strong style="color: var(--text);">PRs tab</strong> grows a sticky <strong style="color: var(--text);">"PRs awaiting your review"</strong> section above your authored list when someone has requested you as a reviewer &mdash; one search query (<code class="inline">review-requested:@me</code>) wired as a fifth parallel branch on the dashboard refresh, ordered most-recently-updated first, with the same drill-in / open-in-github / copy-URL key bindings as the rest of the tab. <strong style="color: var(--text);">macOS notifications</strong> now ship a subtitle ("Stars", "Followers", or "Stars &amp; Followers" when both moved at once) &mdash; one extra line in Notification Center that keeps the per-entry timestamp visible even when terminal-notifier groups them, and adds a visual category to the banner.</p>
                 </div>
                 <div class="feature wide">
                     <div class="feature-label">Configurable</div>

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -199,6 +199,14 @@ type PullRequest struct {
 	Mergeable string // MERGEABLE | CONFLICTING | UNKNOWN
 	UpdatedAt time.Time
 	IsPrivate bool
+
+	// AuthorLogin is empty for the user's authored PRs (Stats
+	// .OpenPullRequests) since the author is the viewer by
+	// definition. It's populated for the review-requests inbox
+	// (Stats.ReviewRequests) where the PR was opened by someone
+	// else and the UI wants to show "who's asking" alongside the
+	// title.
+	AuthorLogin string
 }
 
 // Issue is one open issue authored by the user, feeding the Issues
@@ -339,6 +347,17 @@ type Stats struct {
 	// can render in their own section and never get folded into
 	// the owned aggregates (TotalStars, ForksReceived, …).
 	WatchedRepos []Repo
+
+	// ReviewRequests are open pull requests where the viewer has
+	// been asked to review (v0.15.0+). Populated only when the
+	// client is authenticated AND running in viewer mode (no
+	// explicit login arg) — the GitHub search query uses
+	// `review-requested:@me` which is inherently personal. Empty
+	// otherwise. Surfaced by the PRs tab as a sticky section
+	// above "Your authored PRs"; not folded into the existing
+	// OpenPullRequests list because the two answer different
+	// questions ("things I created" vs "things waiting for me").
+	ReviewRequests []PullRequest
 
 	// Meta
 	Authenticated bool
@@ -741,12 +760,24 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		rlP, rlR, rlC    rateLimitFields
 		errP, errR, errC error
 		watched          []Repo
+		reviewRequests   []PullRequest
+		errRR            error
 	)
 
 	watchRefs := c.WatchRepos()
+	// Review-requests inbox is only fetched when the client is
+	// authenticated AND running in viewer mode (no explicit
+	// login arg). The search uses `review-requested:@me` which
+	// is inherently personal — there's no point asking GitHub
+	// for someone else's inbox.
+	wantReviewRequests := c.authenticated && c.login == ""
+
 	var wg sync.WaitGroup
 	wg.Add(3)
 	if len(watchRefs) > 0 {
+		wg.Add(1)
+	}
+	if wantReviewRequests {
 		wg.Add(1)
 	}
 
@@ -832,6 +863,22 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		}()
 	}
 
+	// Fifth parallel branch — review-requests inbox (v0.15.0).
+	// Single search query, cheap enough to ride alongside the
+	// rest of the dashboard refresh. Gated on authenticated-
+	// viewer mode upstream (wantReviewRequests).
+	if wantReviewRequests {
+		go func() {
+			defer wg.Done()
+			rr, err := c.FetchReviewRequests(ctx)
+			if err != nil {
+				errRR = err
+				return
+			}
+			reviewRequests = rr
+		}()
+	}
+
 	wg.Wait()
 
 	// Surface the first error — all three queries serve the same
@@ -847,10 +894,14 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	if errC != nil {
 		return nil, &FetchError{Reason: classifyErr(ctx, errC), Err: errC}
 	}
+	if errRR != nil {
+		return nil, errRR
+	}
 
 	stats := c.extractStats(profile, repos, repoCI)
 	stats.RateLimit = mergeRateLimit3(rlP, rlR, rlC)
 	stats.WatchedRepos = watched
+	stats.ReviewRequests = reviewRequests
 	return stats, nil
 }
 

--- a/internal/github/review_requests.go
+++ b/internal/github/review_requests.go
@@ -1,0 +1,89 @@
+package github
+
+import (
+	"context"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// reviewRequestsPageSize bounds the inbox returned by
+// FetchReviewRequests. 20 is plenty for "PRs waiting on you" —
+// past that the user has bigger problems than a sparkline can
+// help with, and the PRs tab caps its visible window anyway.
+const reviewRequestsPageSize = 20
+
+// reviewRequestsQuery uses GitHub's search interface (the only
+// path that exposes the `review-requested:@me` filter — there's
+// no equivalent on `viewer.pullRequests`). One search query,
+// roughly 1-2 complexity points, well under the gateway budget.
+type reviewRequestsQuery struct {
+	Search struct {
+		IssueCount githubv4.Int
+		Nodes      []struct {
+			Typename    githubv4.String `graphql:"__typename"`
+			PullRequest struct {
+				Number     githubv4.Int
+				Title      githubv4.String
+				URL        githubv4.String `graphql:"url"`
+				IsDraft    githubv4.Boolean
+				UpdatedAt  githubv4.DateTime
+				Repository struct {
+					NameWithOwner githubv4.String
+					IsPrivate     githubv4.Boolean
+				}
+				Author struct {
+					Login githubv4.String
+				}
+				Mergeable githubv4.MergeableState
+			} `graphql:"... on PullRequest"`
+		}
+	} `graphql:"search(query: $q, type: ISSUE, first: $first)"`
+}
+
+// FetchReviewRequests returns the open pull requests where the
+// authenticated viewer has been requested as a reviewer. The
+// `review-requested:@me` qualifier is GitHub's idiomatic way to
+// express this; combined with `is:open` it surfaces exactly the
+// "PRs waiting on you" set.
+//
+// Returns nil + nil error when the client isn't a candidate for
+// this query (unauthenticated, or running with an explicit user
+// arg). Callers can treat nil as "feature not applicable here"
+// without distinguishing it from "no results today".
+func (c *Client) FetchReviewRequests(ctx context.Context) ([]PullRequest, error) {
+	if !c.authenticated || c.login != "" {
+		return nil, nil
+	}
+	var q reviewRequestsQuery
+	vars := map[string]interface{}{
+		"q":     githubv4.String("is:open is:pr review-requested:@me archived:false"),
+		"first": githubv4.Int(reviewRequestsPageSize),
+	}
+	if err := c.gql.Query(ctx, &q, vars); err != nil {
+		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	out := make([]PullRequest, 0, len(q.Search.Nodes))
+	for _, n := range q.Search.Nodes {
+		if string(n.Typename) != "PullRequest" {
+			// Search returns SearchResultItem (a union); we asked
+			// for type: ISSUE which yields both Issue and
+			// PullRequest. Defensive skip just in case GitHub
+			// ever broadens the result shape — the inline
+			// fragment already filters us to PRs in practice.
+			continue
+		}
+		pr := n.PullRequest
+		out = append(out, PullRequest{
+			Number:      int(pr.Number),
+			Title:       Sanitize(string(pr.Title)),
+			URL:         Sanitize(string(pr.URL)),
+			Repo:        Sanitize(string(pr.Repository.NameWithOwner)),
+			IsDraft:     bool(pr.IsDraft),
+			Mergeable:   string(pr.Mergeable),
+			UpdatedAt:   pr.UpdatedAt.Time,
+			IsPrivate:   bool(pr.Repository.IsPrivate),
+			AuthorLogin: Sanitize(string(pr.Author.Login)),
+		})
+	}
+	return out, nil
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -53,19 +53,29 @@ func resolveIcon() string {
 	return iconPath
 }
 
-// Send fires a desktop notification with the given title and message.
-// clickURL, if non-empty, is the page that should open when the user
-// activates the notification (supported on macOS via terminal-notifier
-// only — beeep on the other platforms ignores it for now).
+// Send fires a desktop notification with the given title, subtitle
+// and message. subtitle is optional and surfaces a second line
+// under the title on platforms that support it (macOS via
+// terminal-notifier); beeep on Linux/Windows ignores it. clickURL,
+// if non-empty, is the page that should open when the user
+// activates the notification (supported on macOS only).
 //
-// Returns the underlying error if all backends failed; nil otherwise.
-// Callers in octoscope discard the error: a failed notification is
-// not worth surfacing in the TUI.
-func Send(title, message, clickURL string) error {
+// Why subtitle (v0.15.0): macOS's Notification Center groups
+// notifications by app, and within a group only the most recent
+// entry shows its timestamp at a glance. Adding a subtitle gives
+// each notification a visible second line ("Stars" / "Followers")
+// that survives the grouping AND keeps the per-entry timestamp
+// visible — a small win that also makes the banner read better
+// at first glance.
+//
+// Returns the underlying error if all backends failed; nil
+// otherwise. Callers in octoscope discard the error: a failed
+// notification is not worth surfacing in the TUI.
+func Send(title, subtitle, message, clickURL string) error {
 	icon := resolveIcon()
 
 	if runtime.GOOS == "darwin" {
-		if err := sendViaTerminalNotifier(title, message, icon, clickURL); err == nil {
+		if err := sendViaTerminalNotifier(title, subtitle, message, icon, clickURL); err == nil {
 			return nil
 		}
 		// Fall through to beeep so we still ring + show *something*
@@ -78,7 +88,7 @@ func Send(title, message, clickURL string) error {
 // sendViaTerminalNotifier shells out to the brew-installable
 // `terminal-notifier` CLI. Returns an error if the binary is missing
 // (so the caller can fall back) or if the launch fails.
-func sendViaTerminalNotifier(title, message, icon, clickURL string) error {
+func sendViaTerminalNotifier(title, subtitle, message, icon, clickURL string) error {
 	bin, err := exec.LookPath("terminal-notifier")
 	if err != nil {
 		return errors.New("notify: terminal-notifier not found")
@@ -87,6 +97,9 @@ func sendViaTerminalNotifier(title, message, icon, clickURL string) error {
 	args := []string{
 		"-title", title,
 		"-message", message,
+	}
+	if subtitle != "" {
+		args = append(args, "-subtitle", subtitle)
 	}
 	// We deliberately do NOT pass -appIcon here. On modern macOS
 	// (Big Sur+) the system not only ignores the override but causes

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -279,17 +279,30 @@ func notifyDeltas(old, new *github.Stats) tea.Cmd {
 	}
 
 	clickURL := ""
+	// subtitle is the semantic category — "Stars" / "Followers"
+	// / "Stars & Followers" when both moved at once. Gives the
+	// macOS Notification Center a second line that keeps the
+	// per-entry timestamp visible even when terminal-notifier
+	// notifications group (see notify.Send doc for the
+	// rationale). When only one bucket moved it doubles as the
+	// natural click-target hint.
+	subtitle := ""
 	if new.Login != "" {
 		switch {
+		case followersChanged && starsChanged:
+			subtitle = "Stars & Followers"
+			clickURL = "https://github.com/" + new.Login
 		case followersChanged:
+			subtitle = "Followers"
 			clickURL = "https://github.com/" + new.Login
 		case starsChanged:
+			subtitle = "Stars"
 			clickURL = "https://github.com/" + new.Login + "?tab=stars"
 		}
 	}
 
 	return func() tea.Msg {
-		_ = notify.Send("octoscope — "+who, msg, clickURL)
+		_ = notify.Send("octoscope — "+who, subtitle, msg, clickURL)
 		_ = notify.Beep()
 		return nil
 	}

--- a/internal/ui/prs.go
+++ b/internal/ui/prs.go
@@ -48,14 +48,14 @@ func (pm PRsModel) IsInputMode() bool {
 }
 
 // selectedPR returns the PR at the current cursor inside the
-// sorted-and-filtered view. Same idiom as ReposModel.selectedRepo —
-// used by the action menu so the dispatcher doesn't reimplement the
-// list pipeline.
+// partitioned view. Same idiom as ReposModel.selectedRepo with
+// pinned/watched — used by the action menu so the dispatcher
+// doesn't reimplement the list pipeline.
 func (pm PRsModel) selectedPR(stats *github.Stats) (github.PullRequest, bool) {
 	if stats == nil {
 		return github.PullRequest{}, false
 	}
-	rows := sortPRs(filterPRs(stats.OpenPullRequests, pm.query), pm.sort)
+	rows, _, _ := visiblePRsPartitioned(stats.ReviewRequests, stats.OpenPullRequests, pm.query, pm.sort)
 	if len(rows) == 0 {
 		return github.PullRequest{}, false
 	}
@@ -69,6 +69,28 @@ func (pm PRsModel) selectedPR(stats *github.Stats) (github.PullRequest, bool) {
 	return rows[idx], true
 }
 
+// visiblePRsPartitioned is the canonical pipeline the PRs tab
+// paints. Two sections, flat slice:
+//
+//   - Review-requests (Stats.ReviewRequests) on top, kept in
+//     API order (UpdatedAt DESC) so the most recently-touched
+//     row surfaces first. Sort cycle does NOT apply here —
+//     they're an inbox, not a sortable dataset.
+//   - Authored PRs (Stats.OpenPullRequests) below, with the
+//     same filter + sort pipeline the v0.11.0 PRs tab used.
+//
+// Returns (rows, reviewCount, authoredCount) so the renderer
+// can insert the rule divider after the review-requests
+// segment. Cursor walks both sections uniformly.
+func visiblePRsPartitioned(reviews, authored []github.PullRequest, query string, mode PRsSort) (rows []github.PullRequest, reviewCount, authoredCount int) {
+	rev := filterPRs(reviews, query)
+	auth := sortPRs(filterPRs(authored, query), mode)
+	rows = make([]github.PullRequest, 0, len(rev)+len(auth))
+	rows = append(rows, rev...)
+	rows = append(rows, auth...)
+	return rows, len(rev), len(auth)
+}
+
 // Update routes keys received while the PRs tab is active.
 func (pm PRsModel) Update(msg tea.Msg, stats *github.Stats) (PRsModel, tea.Cmd) {
 	km, ok := msg.(tea.KeyMsg)
@@ -79,10 +101,15 @@ func (pm PRsModel) Update(msg tea.Msg, stats *github.Stats) (PRsModel, tea.Cmd) 
 		return pm.updateSearch(km), nil
 	}
 
-	n := 0
+	// Row count drives cursor bounds. Built from the same
+	// pipeline the renderer uses (visiblePRsPartitioned) so
+	// Update + View can never disagree on which PR lives at
+	// index N — same drift-prevention rationale as Repos v0.13.
+	var rows []github.PullRequest
 	if stats != nil {
-		n = len(filterPRs(stats.OpenPullRequests, pm.query))
+		rows, _, _ = visiblePRsPartitioned(stats.ReviewRequests, stats.OpenPullRequests, pm.query, pm.sort)
 	}
+	n := len(rows)
 
 	switch km.String() {
 	case "up", "k":
@@ -107,22 +134,19 @@ func (pm PRsModel) Update(msg tea.Msg, stats *github.Stats) (PRsModel, tea.Cmd) 
 	case "enter", "d":
 		// v0.11.0: Enter / d → drill-in detail. Was openURLCmd
 		// through v0.10.1. See repos.go for the rationale.
-		if stats == nil || n == 0 || pm.cursor >= n {
+		if n == 0 || pm.cursor >= n {
 			return pm, nil
 		}
-		rows := sortPRs(filterPRs(stats.OpenPullRequests, pm.query), pm.sort)
 		return pm, viewPRDetailCmd(rows[pm.cursor])
 	case "o":
-		if stats == nil || n == 0 || pm.cursor >= n {
+		if n == 0 || pm.cursor >= n {
 			return pm, nil
 		}
-		rows := sortPRs(filterPRs(stats.OpenPullRequests, pm.query), pm.sort)
 		return pm, openURLCmd(rows[pm.cursor].URL)
 	case "c":
-		if stats == nil || n == 0 || pm.cursor >= n {
+		if n == 0 || pm.cursor >= n {
 			return pm, nil
 		}
-		rows := sortPRs(filterPRs(stats.OpenPullRequests, pm.query), pm.sort)
 		return pm, copyURLCmd(rows[pm.cursor].URL)
 	case "esc":
 		if pm.query != "" {
@@ -203,11 +227,11 @@ func (pm PRsModel) renderPRsTab(stats *github.Stats, available, availableHeight 
 	if stats == nil {
 		return mutedStyle.Render("(no pull-request data yet — waiting for first refresh)")
 	}
-	if len(stats.OpenPullRequests) == 0 {
+	if len(stats.OpenPullRequests) == 0 && len(stats.ReviewRequests) == 0 {
 		return mutedStyle.Render("(no open pull requests you authored)")
 	}
 
-	rows := sortPRs(filterPRs(stats.OpenPullRequests, pm.query), pm.sort)
+	rows, reviewCount, _ := visiblePRsPartitioned(stats.ReviewRequests, stats.OpenPullRequests, pm.query, pm.sort)
 
 	cursor := pm.cursor
 	if cursor >= len(rows) {
@@ -260,7 +284,12 @@ func (pm PRsModel) renderPRsTab(stats *github.Stats, available, availableHeight 
 			mutedStyle.Render("   (esc to clear)")
 	}
 
-	table := renderPRsTable(rows[offset:end], cursor-offset, pm.sort)
+	// reviewDivider marks the index (within the visible window)
+	// AFTER which the renderer inserts the rule separating the
+	// review-requests sticky section from the authored list.
+	// ≤0 or ≥len(slice) suppresses the divider.
+	reviewDivider := reviewCount - offset
+	table := renderPRsTable(rows[offset:end], cursor-offset, pm.sort, reviewDivider)
 
 	hint := keyHints(
 		"↑↓", "move",
@@ -305,7 +334,12 @@ func (pm PRsModel) renderHeaderLine(visible, total, offset, end int) string {
 // renderPRsTable lays out the PRs list: number, title, repo, state
 // (draft / ready / conflicts), updated. Truncation is applied per
 // column so a single long title doesn't push everything off-screen.
-func renderPRsTable(prs []github.PullRequest, cursorRow int, sortMode PRsSort) string {
+//
+// reviewDivider is the index (within the visible window, post-
+// offset) AFTER which the renderer inserts a muted rule separating
+// the "PRs awaiting your review" sticky section from "Your authored
+// PRs" below. ≤0 or ≥len(prs) suppresses the divider.
+func renderPRsTable(prs []github.PullRequest, cursorRow int, sortMode PRsSort, reviewDivider int) string {
 	const (
 		cursorW  = 2
 		numberW  = 6 // "#12345"
@@ -371,6 +405,14 @@ func renderPRsTable(prs []github.PullRequest, cursorRow int, sortMode PRsSort) s
 		}
 
 		out = append(out, marker+num+"  "+title+"  "+repo+"  "+state+"  "+updated)
+
+		// Insert the review-requests / authored divider exactly
+		// once, after the last review-requests row in the visible
+		// window. Header width drives the rule length so it spans
+		// the same band as the table itself.
+		if reviewDivider > 0 && i == reviewDivider-1 && i+1 < len(prs) {
+			out = append(out, tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header))))
+		}
 	}
 	return strings.Join(out, "\n")
 }

--- a/internal/ui/prs_test.go
+++ b/internal/ui/prs_test.go
@@ -1,0 +1,79 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestVisiblePRsPartitioned pins the contract that drives the PRs
+// tab partitioning: review-requests on top (API order, no sort
+// applied), authored below (filtered + sorted), counts reported
+// so the renderer knows where to insert the rule.
+func TestVisiblePRsPartitioned(t *testing.T) {
+	mk := func(num int, title, repo string, updated time.Time) github.PullRequest {
+		return github.PullRequest{Number: num, Title: title, Repo: repo, UpdatedAt: updated}
+	}
+	now := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+
+	reviews := []github.PullRequest{
+		// API returns DESC by UpdatedAt — assume that here too.
+		mk(234, "fix: race", "alice/foo", now.Add(-2*24*time.Hour)),
+		mk(189, "refactor", "bob/bar", now.Add(-5*24*time.Hour)),
+	}
+	authored := []github.PullRequest{
+		// Mixed-order on purpose to verify sort kicks in.
+		mk(50, "my old PR", "me/x", now.Add(-30*24*time.Hour)),
+		mk(100, "my new PR", "me/y", now.Add(-1*24*time.Hour)),
+	}
+
+	t.Run("both sections present, ordering", func(t *testing.T) {
+		rows, rc, ac := visiblePRsPartitioned(reviews, authored, "", PRsSortUpdated)
+		if rc != 2 || ac != 2 {
+			t.Fatalf("counts = (%d, %d), want (2, 2)", rc, ac)
+		}
+		if len(rows) != 4 {
+			t.Fatalf("len(rows) = %d, want 4", len(rows))
+		}
+		// First two: reviews in API order.
+		if rows[0].Number != 234 || rows[1].Number != 189 {
+			t.Errorf("review-requests order broken: got #%d, #%d", rows[0].Number, rows[1].Number)
+		}
+		// Next two: authored sorted DESC by UpdatedAt → #100 first.
+		if rows[2].Number != 100 || rows[3].Number != 50 {
+			t.Errorf("authored sort broken: got #%d, #%d (want #100, #50)", rows[2].Number, rows[3].Number)
+		}
+	})
+
+	t.Run("empty review-requests → only authored", func(t *testing.T) {
+		rows, rc, ac := visiblePRsPartitioned(nil, authored, "", PRsSortUpdated)
+		if rc != 0 || ac != 2 {
+			t.Errorf("counts = (%d, %d), want (0, 2)", rc, ac)
+		}
+		if len(rows) != 2 || rows[0].Number != 100 {
+			t.Errorf("authored-only path broken: got len=%d first=#%d", len(rows), rows[0].Number)
+		}
+	})
+
+	t.Run("empty authored → only review-requests", func(t *testing.T) {
+		rows, rc, ac := visiblePRsPartitioned(reviews, nil, "", PRsSortUpdated)
+		if rc != 2 || ac != 0 {
+			t.Errorf("counts = (%d, %d), want (2, 0)", rc, ac)
+		}
+		if len(rows) != 2 || rows[0].Number != 234 {
+			t.Errorf("review-only path broken: got len=%d first=#%d", len(rows), rows[0].Number)
+		}
+	})
+
+	t.Run("filter applies to both segments", func(t *testing.T) {
+		rows, rc, ac := visiblePRsPartitioned(reviews, authored, "race", PRsSortUpdated)
+		// Only #234 ("fix: race") matches in reviews; nothing in authored.
+		if rc != 1 || ac != 0 {
+			t.Errorf("filter counts = (%d, %d), want (1, 0)", rc, ac)
+		}
+		if len(rows) != 1 || rows[0].Number != 234 {
+			t.Errorf("filter broken: got len=%d first=#%v", len(rows), rows[0].Number)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.14.0"
+const version = "0.15.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## Summary

Two additions that close the loop between "watching" (what v0.14.0 widened) and **noticing** (what's actually waiting for your attention). One feature lands on screen, the other on your macOS notification center; both keep octoscope read-only.

## What lands

### Review-requests inbox (PRs tab)

The PRs tab grows a sticky section **"PRs awaiting your review"** above your authored list. Same partition idiom as Repos pinned/watched (v0.13/v0.14): muted rule separator, cursor walks both segments uniformly, sort cycle only re-orders the authored half (review-requests stay in GitHub's `UPDATED_AT DESC` order). Section absent when count is 0.

**Architecture:**
- New `github.Stats.ReviewRequests []PullRequest`, populated by a single GraphQL `search(query: "is:open is:pr review-requested:@me archived:false")` — the only path that exposes the `review-requested` qualifier (no `viewer.pullRequests` equivalent).
- `FetchStats` picks the query up as a **fifth parallel goroutine**, gated on `c.authenticated && c.login == ""` (viewer mode only — `@me` is inherently personal). Empty otherwise, the rest of the dashboard refreshes untouched.
- `PullRequest` grows `AuthorLogin` (sanitised), empty for your own authored PRs and populated for review-requests so the drill-in can show who's asking.
- Same `Enter` / `o` / `c` keybindings — drilling in opens the existing PR detail (v0.11.0 surface), opening on github.com / copying URL work as usual.

### macOS notification subtitle

`notify.Send` signature gains a `subtitle` parameter. On macOS the value is forwarded to `terminal-notifier` via `-subtitle`; beeep on Linux/Windows ignores it.

The Stars/Followers change handler now passes:
- `"Stars"` when only stars moved
- `"Followers"` when only followers moved  
- `"Stars & Followers"` when both moved at once

Two payoffs:
1. macOS Notification Center keeps the **per-entry timestamp visible** even when terminal-notifier groups notifications — without `-subtitle`, grouped notifications collapse and only the most recent shows its timestamp at a glance.
2. The banner gains a visible **category line** under the title, useful after the initial milliseconds-after-arrival window.

## Tests

- `internal/ui/prs_test.go`: `visiblePRsPartitioned` (both segments present + ordering, empty review-requests, empty authored, filter applies to both segments).

## Smoke verification (maintainer's account)

Confirmed working end-to-end on a 3-PR state (1 review-request + 2 authored):
- Sticky section renders with the muted rule separator
- Cursor traverses both segments
- Enter on review-request row opens the PR detail (different author from viewer)
- macOS notifications fired via test command show `Stars` / `Followers` subtitle and keep per-entry timestamps in the Notification Center

## Docs / release prep included

Same pattern as v0.13/v0.14: `main.go` version bump, README updates, `docs/index.html` version pill + new "At a glance" card "Notified when it matters". One atomic PR — merging it tags directly.

## Test plan

- [x] `go build` clean (dual-target)
- [x] `go test -race ./...` passes
- [x] Manual smoke: PRs tab with 1 review-request + 2 authored, partition + cursor verified
- [x] Manual smoke: macOS notifications via terminal-notifier carry subtitle + timestamp survives grouping