### PR TITLE
fix: three P0 bugs — private leak in public-only, config data loss, hidden watched repos

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -914,7 +914,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.15.0</span>
+                <span class="version-tag" id="version-pill">0.15.1</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -378,9 +378,12 @@ type Stats struct {
 // Public returns a copy of s with private repositories, PRs, issues,
 // watched repos and review requests stripped from the lists. Aggregate
 // counters that depend on per-repo data (TotalStars, ForksReceived,
-// OpenIssues, OpenPRs, PublicRepos, Languages) are recomputed from the
-// kept repos so the Overview cards stay consistent with what the lists
-// show.
+// OpenIssues, OpenPRs, PublicRepos) are recomputed from the kept repos
+// so the Overview cards stay consistent with what the lists show.
+// Languages is deliberately passed through unchanged — it's a
+// profile-level metric and per-repo language byte counts aren't stored
+// on Repo, so it can't be split by visibility here (see the inline
+// comment in the repo loop below).
 //
 // Every list-bearing field that can carry a private item MUST be
 // filtered here — the whole point of public-only/screenshot mode is

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -375,11 +375,18 @@ type Stats struct {
 	RateLimit *RateLimit
 }
 
-// Public returns a copy of s with private repositories, PRs and
-// issues stripped from the lists. Aggregate counters that depend on
-// per-repo data (TotalStars, ForksReceived, OpenIssues, OpenPRs,
-// PublicRepos, Languages) are recomputed from the kept repos so the
-// Overview cards stay consistent with what the lists show.
+// Public returns a copy of s with private repositories, PRs, issues,
+// watched repos and review requests stripped from the lists. Aggregate
+// counters that depend on per-repo data (TotalStars, ForksReceived,
+// OpenIssues, OpenPRs, PublicRepos, Languages) are recomputed from the
+// kept repos so the Overview cards stay consistent with what the lists
+// show.
+//
+// Every list-bearing field that can carry a private item MUST be
+// filtered here — the whole point of public-only/screenshot mode is
+// that nothing private reaches the screen. When a new private-aware
+// list is added to Stats, add its skip loop below (and a case to
+// TestPublicStripsEveryPrivateList).
 //
 // Top-level viewer counters that don't depend on per-repo data
 // (Followers, Following, PRsTotal, PRsMerged, IssuesAuthored,
@@ -405,7 +412,6 @@ func (s *Stats) Public() *Stats {
 	// TotalStars in public-only mode so the secondary line vanishes
 	// rather than misrepresenting a partial number.
 	out.TotalStarsWithForks = 0
-	langMap := map[string]*Language{}
 	for _, r := range s.Repositories {
 		if r.IsPrivate {
 			continue
@@ -421,10 +427,6 @@ func (s *Stats) Public() *Stats {
 		// aggregate across all owned repos and is a profile-level
 		// metric, not a per-item leak.
 	}
-	for _, l := range s.Languages {
-		langMap[l.Name] = nil
-	}
-	_ = langMap // reserved for future per-repo language breakdown
 	out.PublicRepos = len(out.Repositories)
 
 	out.TotalStarsWithForks = out.TotalStars
@@ -449,6 +451,29 @@ func (s *Stats) Public() *Stats {
 			continue
 		}
 		out.OpenIssuesList = append(out.OpenIssuesList, is)
+	}
+
+	// Watched repos (v0.14.0) carry the same Repo shape as the owned
+	// set, so a watched *private* repo would leak its name / CI /
+	// release in screenshot mode. Strip them. They're intentionally
+	// kept out of the owned aggregates, so nothing to recompute.
+	out.WatchedRepos = nil
+	for _, r := range s.WatchedRepos {
+		if r.IsPrivate {
+			continue
+		}
+		out.WatchedRepos = append(out.WatchedRepos, r)
+	}
+
+	// Review requests (v0.15.0) are PRs awaiting the viewer's review;
+	// a private-repo PR would leak its title / repo / author. Strip
+	// them too.
+	out.ReviewRequests = nil
+	for _, pr := range s.ReviewRequests {
+		if pr.IsPrivate {
+			continue
+		}
+		out.ReviewRequests = append(out.ReviewRequests, pr)
 	}
 
 	return &out

--- a/internal/github/public_test.go
+++ b/internal/github/public_test.go
@@ -1,0 +1,163 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestPublicStripsPrivateFromKnownLists pins the concrete behaviour of
+// Stats.Public(): every list-bearing field drops its private entries
+// while the public ones survive, and the per-repo aggregates are
+// recomputed off the kept repos only.
+func TestPublicStripsPrivateFromKnownLists(t *testing.T) {
+	s := &Stats{
+		Repositories: []Repo{
+			{Name: "pub-a", Stars: 3, Forks: 1, OpenIssues: 2, OpenPRs: 1},
+			{Name: "secret", Stars: 100, Forks: 50, OpenIssues: 9, OpenPRs: 9, IsPrivate: true},
+			{Name: "pub-b", Stars: 4, Forks: 2, OpenIssues: 0, OpenPRs: 0},
+		},
+		OpenPullRequests: []PullRequest{
+			{Number: 1, Title: "public pr", Repo: "owner/pub-a"},
+			{Number: 2, Title: "private pr", Repo: "owner/secret", IsPrivate: true},
+		},
+		OpenIssuesList: []Issue{
+			{Number: 10, Title: "public issue", Repo: "owner/pub-a"},
+			{Number: 11, Title: "private issue", Repo: "owner/secret", IsPrivate: true},
+		},
+		WatchedRepos: []Repo{
+			{Name: "watched-pub"},
+			{Name: "watched-private", IsPrivate: true},
+		},
+		ReviewRequests: []PullRequest{
+			{Number: 20, Title: "review me", Repo: "someone/pub", AuthorLogin: "alice"},
+			{Number: 21, Title: "secret review", Repo: "someone/private", AuthorLogin: "bob", IsPrivate: true},
+		},
+	}
+
+	got := s.Public()
+
+	wantNames := func(field string, got, want []string) {
+		t.Helper()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s = %v, want %v", field, got, want)
+		}
+	}
+
+	repoNames := func(rs []Repo) []string {
+		out := make([]string, len(rs))
+		for i, r := range rs {
+			out[i] = r.Name
+		}
+		return out
+	}
+	prTitles := func(ps []PullRequest) []string {
+		out := make([]string, len(ps))
+		for i, p := range ps {
+			out[i] = p.Title
+		}
+		return out
+	}
+
+	wantNames("Repositories", repoNames(got.Repositories), []string{"pub-a", "pub-b"})
+	wantNames("WatchedRepos", repoNames(got.WatchedRepos), []string{"watched-pub"})
+	wantNames("OpenPullRequests", prTitles(got.OpenPullRequests), []string{"public pr"})
+	wantNames("ReviewRequests", prTitles(got.ReviewRequests), []string{"review me"})
+
+	if len(got.OpenIssuesList) != 1 || got.OpenIssuesList[0].Title != "public issue" {
+		t.Errorf("OpenIssuesList = %+v, want only the public issue", got.OpenIssuesList)
+	}
+
+	// Aggregates recomputed off the kept (public) repos only.
+	if got.TotalStars != 7 { // 3 + 4, not 107
+		t.Errorf("TotalStars = %d, want 7 (private repo's 100 must not count)", got.TotalStars)
+	}
+	if got.ForksReceived != 3 { // 1 + 2
+		t.Errorf("ForksReceived = %d, want 3", got.ForksReceived)
+	}
+	if got.PublicRepos != 2 {
+		t.Errorf("PublicRepos = %d, want 2", got.PublicRepos)
+	}
+	if got.OpenPRsAuthored != 1 {
+		t.Errorf("OpenPRsAuthored = %d, want 1", got.OpenPRsAuthored)
+	}
+
+	// The source must be untouched (Public returns a copy).
+	if len(s.Repositories) != 3 || len(s.ReviewRequests) != 2 {
+		t.Errorf("Public() mutated the source: repos=%d reviewReqs=%d", len(s.Repositories), len(s.ReviewRequests))
+	}
+}
+
+// TestPublicStripsEveryPrivateList is a drift guard. It reflectively
+// finds every slice field on Stats whose element type carries an
+// IsPrivate bool, seeds each with one public + one private entry, and
+// asserts Public() drops the private one from ALL of them. When a new
+// private-aware list is added to Stats, this test seeds and checks it
+// automatically — so forgetting the skip loop in Public() fails here
+// instead of leaking in screenshot mode (the v0.x scar this guards).
+func TestPublicStripsEveryPrivateList(t *testing.T) {
+	fields := privateAwareSliceFields(reflect.TypeOf(Stats{}))
+	if len(fields) < 5 {
+		t.Fatalf("expected at least 5 private-aware list fields on Stats, found %d (%v) — "+
+			"the reflection helper may be broken", len(fields), fieldNames(fields))
+	}
+
+	s := &Stats{}
+	sv := reflect.ValueOf(s).Elem()
+	for _, f := range fields {
+		fv := sv.Field(f.idx)
+		sl := reflect.MakeSlice(fv.Type(), 2, 2)
+		sl.Index(0).FieldByName("IsPrivate").SetBool(false) // public, must survive
+		sl.Index(1).FieldByName("IsPrivate").SetBool(true)  // private, must be dropped
+		fv.Set(sl)
+	}
+
+	got := s.Public()
+	gv := reflect.ValueOf(got).Elem()
+	for _, f := range fields {
+		fv := gv.Field(f.idx)
+		if fv.Len() == 0 {
+			t.Errorf("Public() dropped every entry from %s; the public one should survive", f.name)
+			continue
+		}
+		for j := 0; j < fv.Len(); j++ {
+			if fv.Index(j).FieldByName("IsPrivate").Bool() {
+				t.Errorf("Public() left a private entry in %s — add a skip loop for it in Public()", f.name)
+				break
+			}
+		}
+	}
+}
+
+type sliceField struct {
+	idx  int
+	name string
+}
+
+// privateAwareSliceFields returns the index+name of every exported
+// slice field on t whose element is a struct with a bool IsPrivate
+// field — i.e. every list that can carry a private item.
+func privateAwareSliceFields(t reflect.Type) []sliceField {
+	var out []sliceField
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Type.Kind() != reflect.Slice {
+			continue
+		}
+		elem := f.Type.Elem()
+		if elem.Kind() != reflect.Struct {
+			continue
+		}
+		if pf, ok := elem.FieldByName("IsPrivate"); ok && pf.Type.Kind() == reflect.Bool {
+			out = append(out, sliceField{idx: i, name: f.Name})
+		}
+	}
+	return out
+}
+
+func fieldNames(fs []sliceField) []string {
+	out := make([]string, len(fs))
+	for i, f := range fs {
+		out[i] = f.name
+	}
+	return out
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -608,15 +608,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// overflow detection stay in step.
 			syncOverviewViewport(&m)
 			syncActivityViewport(&m)
-			if m.configPath != "" {
-				_ = config.Save(m.configPath, config.Config{
-					RefreshInterval: m.interval,
-					PublicOnly:      newVal,
-					Compact:         m.compact,
-					Theme:           m.theme,
-					AccentColor:     m.accentColor,
-				})
-			}
+			// Best-effort writeback through the shared read-modify-write
+			// helper so toggling public-only can't clobber pinned_repos
+			// / watch_repos. m.client already holds the new value.
+			_ = m.persistConfig()
 			return m, nil
 		case "r":
 			if !m.loading {
@@ -902,36 +897,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.pinned = nextPinned
 
-		// Best-effort writeback. A config-less launch (no path)
-		// keeps the pin in-memory only — same trade-off the
-		// settings panel makes for other keys.
-		//
-		// IMPORTANT: we re-Load the file before saving so the
-		// writeback preserves keys we don't touch here (e.g.
-		// keys the user added by hand that the in-memory Model
-		// doesn't track). If that Load fails — malformed TOML,
-		// permissions changed mid-session, file removed — we
-		// MUST NOT proceed to Save, because Save would otherwise
-		// overwrite the on-disk file with config.Defaults()
-		// plus our in-memory state, silently nuking the user's
-		// hand-edits. Surface the failure as a toast and keep
-		// the pin in memory only.
+		// Best-effort writeback through the shared read-modify-write
+		// helper (persistConfig). A config-less launch (no path) keeps
+		// the pin in-memory only — same trade-off the settings panel
+		// makes for other keys. On any failure the on-disk file is left
+		// untouched and the pin stays in memory only; surface that as a
+		// toast. m.pinned was already updated above, so persistConfig
+		// snapshots the new pin set.
 		saveErr := ""
-		if m.configPath != "" {
-			cfgOnDisk, loadErr := config.Load(m.configPath)
-			if loadErr != nil {
-				saveErr = "config unreadable, pin kept in memory only"
-			} else {
-				cfgOnDisk.PinnedRepos = m.pinned
-				cfgOnDisk.RefreshInterval = m.interval
-				cfgOnDisk.PublicOnly = m.client.PublicOnly()
-				cfgOnDisk.Compact = m.compact
-				cfgOnDisk.Theme = m.theme
-				cfgOnDisk.AccentColor = m.accentColor
-				if err := config.Save(m.configPath, cfgOnDisk); err != nil {
-					saveErr = "config write failed: " + err.Error()
-				}
-			}
+		if err := m.persistConfig(); err != nil {
+			saveErr = "config not saved, pin kept in memory only"
 		}
 
 		switch {
@@ -971,6 +946,48 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// persistConfig writes the Model's current UI settings back to the
+// config file using a read-modify-write cycle, and is the single
+// writer every save path must route through. It re-Loads the on-disk
+// config first so keys the Model doesn't track — watch_repos and any
+// keys the user added by hand — survive the write; only the fields the
+// in-app UI can change are overwritten.
+//
+// Returns nil when there is no config path (a config-less launch keeps
+// settings in memory only) or on success. A non-nil error means the
+// on-disk file was left UNTOUCHED: if the re-Load fails (malformed
+// TOML, perms changed mid-session, file removed) we MUST NOT Save, or
+// Save would overwrite the file with Defaults() plus our in-memory
+// state, silently nuking the user's hand-edits. Callers decide whether
+// to surface the failure; the in-memory state is already updated either
+// way.
+//
+// Callers MUST update the live Model fields (m.interval, m.compact,
+// m.client publicOnly, m.theme, m.accentColor, m.pinned) BEFORE calling
+// this — it snapshots whatever the Model currently holds.
+func (m *Model) persistConfig() error {
+	if m.configPath == "" {
+		return nil
+	}
+	cfgOnDisk, err := config.Load(m.configPath)
+	if err != nil {
+		return err
+	}
+	cfgOnDisk.RefreshInterval = m.interval
+	cfgOnDisk.PublicOnly = m.client.PublicOnly()
+	cfgOnDisk.Compact = m.compact
+	cfgOnDisk.Theme = m.theme
+	cfgOnDisk.AccentColor = m.accentColor
+	cfgOnDisk.PinnedRepos = m.pinned
+	// NOTE: WatchRepos is deliberately NOT touched — it's hand-edit
+	// only (no runtime toggle), so cfgOnDisk keeps whatever Load read
+	// from disk. Re-loading instead of building a struct literal is the
+	// whole point: it's what stops watch_repos (and any hand-edited
+	// key) from being silently dropped — the v0.x data-loss bug this
+	// helper exists to prevent.
+	return config.Save(m.configPath, cfgOnDisk)
+}
+
 // applySettingsAndClose commits the staged values from the settings
 // modal: it mutates the live Model fields, persists to disk (if a
 // config path was given on launch), closes the panel, and returns a
@@ -1003,20 +1020,16 @@ func (m *Model) applySettingsAndClose() tea.Cmd {
 		m.spinner.Style = lipgloss.NewStyle().Foreground(colAccent)
 	}
 
-	// Persist. If the path is empty (no HOME / XDG_CONFIG_HOME
+	// Persist via the shared read-modify-write helper so saving from
+	// the settings panel preserves pinned_repos / watch_repos / any
+	// hand-edited keys. If the path is empty (no HOME / XDG_CONFIG_HOME
 	// resolved) or the write fails, just stay quiet — the in-memory
-	// state is already updated, and surfacing a "save failed"
-	// toast right now would be more noise than value. A future
-	// release can add a footer indicator for this if it ever bites.
-	if m.configPath != "" {
-		_ = config.Save(m.configPath, config.Config{
-			RefreshInterval: newInterval,
-			PublicOnly:      newPublicOnly,
-			Compact:         newCompact,
-			Theme:           m.theme,
-			AccentColor:     m.accentColor,
-		})
-	}
+	// state is already updated, and surfacing a "save failed" toast
+	// right now would be more noise than value. A future release can
+	// add a footer indicator for this if it ever bites. (The live
+	// Model fields were all set above, so persistConfig snapshots the
+	// new values.)
+	_ = m.persistConfig()
 
 	m.settings = m.settings.Close()
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -906,7 +906,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// snapshots the new pin set.
 		saveErr := ""
 		if err := m.persistConfig(); err != nil {
-			saveErr = "config not saved, pin kept in memory only"
+			// Include the underlying error so the user can tell an
+			// unreadable file (fix the TOML — hand-edits intact) from a
+			// write failure (perms / disk). persistConfig returns the
+			// distinguishing error from either config.Load or config.Save.
+			saveErr = "config not saved (" + err.Error() + "), pin kept in memory only"
 		}
 
 		switch {
@@ -949,18 +953,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // persistConfig writes the Model's current UI settings back to the
 // config file using a read-modify-write cycle, and is the single
 // writer every save path must route through. It re-Loads the on-disk
-// config first so keys the Model doesn't track — watch_repos and any
-// keys the user added by hand — survive the write; only the fields the
-// in-app UI can change are overwritten.
+// config first so the one known key the Model doesn't track —
+// watch_repos — survives the write; only the fields the in-app UI can
+// change are overwritten.
+//
+// Scope of "preserved": config.Save rewrites the file from a fixed
+// template, so this path preserves the KNOWN config keys (watch_repos
+// in particular), NOT arbitrary unknown keys a user might add by hand.
+// octoscope's config schema is closed — BurntSushi/toml ignores
+// unknown keys on Load and they aren't re-emitted on Save — so there's
+// nothing else to preserve.
 //
 // Returns nil when there is no config path (a config-less launch keeps
 // settings in memory only) or on success. A non-nil error means the
 // on-disk file was left UNTOUCHED: if the re-Load fails (malformed
 // TOML, perms changed mid-session, file removed) we MUST NOT Save, or
 // Save would overwrite the file with Defaults() plus our in-memory
-// state, silently nuking the user's hand-edits. Callers decide whether
-// to surface the failure; the in-memory state is already updated either
-// way.
+// state, silently nuking the user's known keys (watch_repos /
+// pinned_repos). Callers decide whether to surface the failure; the
+// in-memory state is already updated either way.
 //
 // Callers MUST update the live Model fields (m.interval, m.compact,
 // m.client publicOnly, m.theme, m.accentColor, m.pinned) BEFORE calling
@@ -981,10 +992,10 @@ func (m *Model) persistConfig() error {
 	cfgOnDisk.PinnedRepos = m.pinned
 	// NOTE: WatchRepos is deliberately NOT touched — it's hand-edit
 	// only (no runtime toggle), so cfgOnDisk keeps whatever Load read
-	// from disk. Re-loading instead of building a struct literal is the
-	// whole point: it's what stops watch_repos (and any hand-edited
-	// key) from being silently dropped — the v0.x data-loss bug this
-	// helper exists to prevent.
+	// from disk. Re-loading the known fields instead of building a
+	// struct literal is the whole point: it's what stops watch_repos
+	// from being silently dropped — the v0.x data-loss bug this helper
+	// exists to prevent.
 	return config.Save(m.configPath, cfgOnDisk)
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -967,11 +967,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // Returns nil when there is no config path (a config-less launch keeps
 // settings in memory only) or on success. A non-nil error means the
 // on-disk file was left UNTOUCHED: if the re-Load fails (malformed
-// TOML, perms changed mid-session, file removed) we MUST NOT Save, or
-// Save would overwrite the file with Defaults() plus our in-memory
-// state, silently nuking the user's known keys (watch_repos /
-// pinned_repos). Callers decide whether to surface the failure; the
-// in-memory state is already updated either way.
+// TOML, perms changed mid-session) we MUST NOT Save, or Save would
+// overwrite the file with Defaults() plus our in-memory state,
+// silently nuking the user's known keys (watch_repos / pinned_repos).
+// Callers decide whether to surface the failure; the in-memory state
+// is already updated either way.
+//
+// A *missing* file is NOT a re-Load failure — config.Load returns
+// defaults with a nil error — so persistConfig will recreate the file
+// from the current Model state. The only loss in that edge (config
+// deleted mid-session) is a hand-edited watch_repos, which the removed
+// file no longer carries; acceptable, since the user deleted it.
 //
 // Callers MUST update the live Model fields (m.interval, m.compact,
 // m.client publicOnly, m.theme, m.accentColor, m.pinned) BEFORE calling
@@ -1032,8 +1038,10 @@ func (m *Model) applySettingsAndClose() tea.Cmd {
 	}
 
 	// Persist via the shared read-modify-write helper so saving from
-	// the settings panel preserves pinned_repos / watch_repos / any
-	// hand-edited keys. If the path is empty (no HOME / XDG_CONFIG_HOME
+	// the settings panel preserves the known keys the Model doesn't
+	// track — watch_repos in particular (see persistConfig's contract;
+	// arbitrary unknown keys are not preserved, the schema is closed).
+	// If the path is empty (no HOME / XDG_CONFIG_HOME
 	// resolved) or the write fails, just stay quiet — the in-memory
 	// state is already updated, and surfacing a "save failed" toast
 	// right now would be more noise than value. A future release can

--- a/internal/ui/persist_test.go
+++ b/internal/ui/persist_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,9 +56,10 @@ func TestPersistConfigPreservesHandEditedLists(t *testing.T) {
 	// list loaded into memory (NewModel does this from opts.PinnedRepos).
 	m := newTestModel(t, path, false, seed.PinnedRepos)
 
-	// Simulate the user flipping public-only and changing the interval
-	// via the settings panel, then persisting — the exact path that
-	// used to clobber the file.
+	// Change UI settings, then persist through the single helper every
+	// save path routes through. (The end-to-end tests below drive the
+	// actual Update / applySettingsAndClose callers; this one pins the
+	// helper itself.)
 	m.client.SetPublicOnly(true)
 	m.interval = 30 * time.Second
 	m.compact = true
@@ -127,4 +129,110 @@ func TestPersistConfigNoPathIsNoOp(t *testing.T) {
 	if err := m.persistConfig(); err != nil {
 		t.Errorf("persistConfig with empty path = %v, want nil", err)
 	}
+}
+
+// TestApplySettingsAndClosePreservesLists drives the real settings-panel
+// caller — one of the two paths the P0 data-loss bug actually lived in —
+// end-to-end: stage new values via SettingsModel.Open, call
+// applySettingsAndClose, and assert pinned_repos / watch_repos survive on
+// disk. This guards the wiring, not just the helper: a future
+// struct-literal config.Save reintroduced in this caller (the exact
+// shape of the original bug) fails here even though the helper-only tests
+// would stay green.
+func TestApplySettingsAndClosePreservesLists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	seed := config.Defaults()
+	seed.PinnedRepos = []string{"gfazioli/octoscope"}
+	seed.WatchRepos = []string{"charmbracelet/bubbletea", "cli/cli"}
+	if err := config.Save(path, seed); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	m := newTestModel(t, path, false, seed.PinnedRepos)
+	m.stats = nil // viewport syncs become safe no-ops
+
+	// Stage the new values exactly as the settings modal would, keeping
+	// the theme unchanged so applySettingsAndClose doesn't touch the
+	// spinner / re-apply the theme.
+	m.settings = m.settings.Open(30*time.Second, true, true, m.theme)
+	_ = m.applySettingsAndClose()
+
+	got, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(got.PinnedRepos) != 1 || got.PinnedRepos[0] != "gfazioli/octoscope" {
+		t.Errorf("pinned_repos lost via settings save: %v", got.PinnedRepos)
+	}
+	if len(got.WatchRepos) != 2 {
+		t.Errorf("watch_repos lost via settings save: %v", got.WatchRepos)
+	}
+	if !got.PublicOnly || got.RefreshInterval != 30*time.Second || !got.Compact {
+		t.Errorf("settings not applied: public=%v interval=%v compact=%v",
+			got.PublicOnly, got.RefreshInterval, got.Compact)
+	}
+}
+
+// TestPinToggleThroughUpdate drives the pin-toggle caller end-to-end via
+// Update(pinToggledMsg), covering the success and error branches that
+// the helper-only tests don't reach.
+func TestPinToggleThroughUpdate(t *testing.T) {
+	const repoURL = "https://github.com/gfazioli/octoscope"
+
+	t.Run("success persists pin and preserves watch_repos", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.toml")
+		seed := config.Defaults()
+		seed.WatchRepos = []string{"charmbracelet/bubbletea"}
+		if err := config.Save(path, seed); err != nil {
+			t.Fatalf("seed Save: %v", err)
+		}
+
+		m := newTestModel(t, path, false, nil)
+		updated, _ := m.Update(pinToggledMsg{url: repoURL, pin: true})
+		m2 := updated.(Model)
+
+		if len(m2.pinned) != 1 || m2.pinned[0] != "gfazioli/octoscope" {
+			t.Errorf("pinned in memory = %v, want [gfazioli/octoscope]", m2.pinned)
+		}
+		if !strings.Contains(m2.toastMsg, "pinned") {
+			t.Errorf("toast = %q, want a pinned confirmation", m2.toastMsg)
+		}
+		got, err := config.Load(path)
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if len(got.PinnedRepos) != 1 || got.PinnedRepos[0] != "gfazioli/octoscope" {
+			t.Errorf("pinned_repos on disk = %v", got.PinnedRepos)
+		}
+		if len(got.WatchRepos) != 1 || got.WatchRepos[0] != "charmbracelet/bubbletea" {
+			t.Errorf("watch_repos lost on pin save: %v", got.WatchRepos)
+		}
+	})
+
+	t.Run("unreadable config keeps pin in memory and reports the error", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.toml")
+		if err := os.WriteFile(path, []byte("= = not valid toml ]["), 0o600); err != nil {
+			t.Fatalf("write malformed: %v", err)
+		}
+		before, _ := os.ReadFile(path)
+
+		m := newTestModel(t, path, false, nil)
+		updated, _ := m.Update(pinToggledMsg{url: repoURL, pin: true})
+		m2 := updated.(Model)
+
+		if len(m2.pinned) != 1 {
+			t.Errorf("pin should be kept in memory on save failure, got %v", m2.pinned)
+		}
+		if !strings.Contains(m2.toastMsg, "kept in memory only") {
+			t.Errorf("toast = %q, want an in-memory-only failure message", m2.toastMsg)
+		}
+		after, _ := os.ReadFile(path)
+		if string(before) != string(after) {
+			t.Errorf("unreadable config was overwritten:\nbefore=%q\nafter=%q", before, after)
+		}
+	})
 }

--- a/internal/ui/persist_test.go
+++ b/internal/ui/persist_test.go
@@ -1,0 +1,130 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gfazioli/octoscope/internal/config"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// newTestModel builds a minimal Model wired to a real (offline) client
+// pointed at configPath. The GITHUB_TOKEN env forces github.New down
+// its fast, network-free path (no `gh auth token` shell-out), so the
+// test stays hermetic.
+func newTestModel(t *testing.T, configPath string, publicOnly bool, pinned []string) Model {
+	t.Helper()
+	t.Setenv("GITHUB_TOKEN", "test-token-not-used")
+	client, err := github.New("octocat", github.Options{PublicOnly: publicOnly})
+	if err != nil {
+		t.Fatalf("github.New: %v", err)
+	}
+	return Model{
+		client:      client,
+		configPath:  configPath,
+		interval:    60 * time.Second,
+		compact:     false,
+		theme:       "octoscope",
+		accentColor: "",
+		pinned:      append([]string(nil), pinned...),
+	}
+}
+
+// TestPersistConfigPreservesHandEditedLists is the regression test for
+// the v0.x data-loss bug: persisting UI settings (public-only toggle,
+// settings panel) used to rewrite the file from a struct literal that
+// omitted pinned_repos / watch_repos, silently erasing them. The
+// read-modify-write persistConfig helper must keep both — pinned_repos
+// from the Model, watch_repos straight off disk (no runtime surface).
+func TestPersistConfigPreservesHandEditedLists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// A hand-written config carrying BOTH lists plus an accent the
+	// Model also tracks.
+	seed := config.Defaults()
+	seed.PinnedRepos = []string{"gfazioli/octoscope"}
+	seed.WatchRepos = []string{"charmbracelet/bubbletea", "cli/cli"}
+	if err := config.Save(path, seed); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	// Boot a Model as if launched against that file, with the pinned
+	// list loaded into memory (NewModel does this from opts.PinnedRepos).
+	m := newTestModel(t, path, false, seed.PinnedRepos)
+
+	// Simulate the user flipping public-only and changing the interval
+	// via the settings panel, then persisting — the exact path that
+	// used to clobber the file.
+	m.client.SetPublicOnly(true)
+	m.interval = 30 * time.Second
+	m.compact = true
+	if err := m.persistConfig(); err != nil {
+		t.Fatalf("persistConfig: %v", err)
+	}
+
+	// Reload from disk and assert nothing was lost.
+	got, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(got.PinnedRepos) != 1 || got.PinnedRepos[0] != "gfazioli/octoscope" {
+		t.Errorf("pinned_repos lost: got %v, want [gfazioli/octoscope]", got.PinnedRepos)
+	}
+	if len(got.WatchRepos) != 2 ||
+		got.WatchRepos[0] != "charmbracelet/bubbletea" || got.WatchRepos[1] != "cli/cli" {
+		t.Errorf("watch_repos lost: got %v, want [charmbracelet/bubbletea cli/cli]", got.WatchRepos)
+	}
+	// And the UI changes did land.
+	if !got.PublicOnly {
+		t.Error("public_only not persisted")
+	}
+	if got.RefreshInterval != 30*time.Second {
+		t.Errorf("refresh_interval = %v, want 30s", got.RefreshInterval)
+	}
+	if !got.Compact {
+		t.Error("compact not persisted")
+	}
+}
+
+// TestPersistConfigLeavesFileUntouchedOnReadError pins the safety
+// invariant: if the on-disk file can't be re-read, persistConfig must
+// NOT overwrite it (which would nuke hand-edits with Defaults()), and
+// must return the error so the caller can keep state in memory only.
+func TestPersistConfigLeavesFileUntouchedOnReadError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// Write a deliberately malformed TOML so config.Load errors.
+	if err := os.WriteFile(path, []byte("this is = = not valid toml ]["), 0o600); err != nil {
+		t.Fatalf("write malformed: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	m := newTestModel(t, path, false, []string{"gfazioli/octoscope"})
+	if err := m.persistConfig(); err == nil {
+		t.Fatal("persistConfig returned nil on an unreadable config; expected an error")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("persistConfig overwrote an unreadable config file:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+// TestPersistConfigNoPathIsNoOp confirms a config-less launch keeps
+// settings in memory only without error.
+func TestPersistConfigNoPathIsNoOp(t *testing.T) {
+	m := newTestModel(t, "", false, nil)
+	if err := m.persistConfig(); err != nil {
+		t.Errorf("persistConfig with empty path = %v, want nil", err)
+	}
+}

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -479,14 +479,30 @@ type pinToggledMsg struct {
 // caller doesn't know the terminal height yet; render everything
 // and let the terminal scroll as a fallback.
 func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHeight int, pinned []string) string {
-	if stats == nil || len(stats.Repositories) == 0 {
+	if stats == nil {
 		return mutedStyle.Render("(no repositories to show yet — waiting for first refresh)")
 	}
 
+	// Build the row pipeline FIRST, then guard on the flat result.
+	// Guarding on len(stats.Repositories) here would hide the Watched
+	// section whenever the owned set is empty (a brand-new account, or
+	// public-only mode with every owned repo private) while the cursor
+	// and action menu — which both walk visibleReposPartitioned — keep
+	// operating on the now-invisible watched rows. That paint/cursor
+	// desync is the bug this ordering guards against.
 	rows, pinCount, restCount, watchCount := visibleReposPartitioned(
 		stats.Repositories, stats.WatchedRepos, rm.query, rm.sort, pinned,
 	)
 	_ = restCount // currently only the divider positions need it
+
+	if len(rows) == 0 {
+		// An active filter that matched nothing reads differently from
+		// "no repos yet" — keep the esc-to-clear affordance discoverable.
+		if rm.query != "" {
+			return mutedStyle.Render(fmt.Sprintf("(no repositories match %q — esc to clear)", rm.query))
+		}
+		return mutedStyle.Render("(no repositories to show yet — waiting for first refresh)")
+	}
 
 	// Clamp the cursor in case the repo count shrank across a refresh
 	// (private repo flipped public, repo deleted, filter narrowed the
@@ -537,7 +553,12 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 		end = len(rows)
 	}
 
-	headerLine := rm.renderHeaderLine(len(rows), len(stats.Repositories), offset, end)
+	// total spans both list-bearing sections (owned + watched) so the
+	// "N of M" filter count stays honest when a Watched section is
+	// present — otherwise it undercounts M (and could read "3 of 0"
+	// in the empty-owned case).
+	total := len(stats.Repositories) + len(stats.WatchedRepos)
+	headerLine := rm.renderHeaderLine(len(rows), total, offset, end)
 
 	// Search-prompt or filter-indicator line sits between the header
 	// and the table so the eye picks it up without scanning.

--- a/internal/ui/repos_render_test.go
+++ b/internal/ui/repos_render_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestRenderReposTabShowsWatchedWhenOwnedEmpty is the regression for the
+// P0 paint/cursor desync: when the owned set is empty but watch_repos is
+// configured (a brand-new account; public-only mode with every owned
+// repo private), the Watched section must still render. The cursor and
+// the action menu both walk visibleReposPartitioned — which includes
+// watched rows — so painting the "no repositories" empty-state instead
+// stranded the cursor on rows the user couldn't see.
+func TestRenderReposTabShowsWatchedWhenOwnedEmpty(t *testing.T) {
+	applyTheme("octoscope", "")
+
+	stats := &github.Stats{
+		Repositories: nil,
+		WatchedRepos: []github.Repo{mkRepo("charmbracelet", "bubbletea", 20000)},
+	}
+	rm := ReposModel{}
+
+	out := ansi.Strip(rm.renderReposTab(stats, 120, 40, nil))
+	if strings.Contains(out, "no repositories to show yet") {
+		t.Fatalf("renderReposTab painted the empty-state and hid the Watched section:\n%s", out)
+	}
+	if !strings.Contains(out, "bubbletea") {
+		t.Errorf("watched repo not rendered when owned set is empty:\n%s", out)
+	}
+
+	// The paint and the cursor/action-menu source must agree.
+	r, ok := rm.selectedRepo(stats, nil)
+	if !ok || r.Name != "bubbletea" {
+		t.Errorf("selectedRepo = (%q, %v), want the watched repo to be selectable", r.Name, ok)
+	}
+}
+
+// TestRenderReposTabEmptyStates keeps the early-return behaviour honest
+// now that the guard is on len(rows) rather than len(Repositories):
+// truly-empty shows the waiting message, a no-match filter shows the
+// esc-to-clear message instead.
+func TestRenderReposTabEmptyStates(t *testing.T) {
+	applyTheme("octoscope", "")
+
+	t.Run("nothing fetched", func(t *testing.T) {
+		out := ansi.Strip(ReposModel{}.renderReposTab(&github.Stats{}, 120, 40, nil))
+		if !strings.Contains(out, "waiting for first refresh") {
+			t.Errorf("want waiting message, got:\n%s", out)
+		}
+	})
+
+	t.Run("filter matches nothing", func(t *testing.T) {
+		stats := &github.Stats{Repositories: []github.Repo{mkRepo("alice", "alpha", 1)}}
+		rm := ReposModel{query: "zzz-no-match"}
+		out := ansi.Strip(rm.renderReposTab(stats, 120, 40, nil))
+		if !strings.Contains(out, "no repositories match") {
+			t.Errorf("want no-match message, got:\n%s", out)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.15.0"
+const version = "0.15.1"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## Summary

Fixes the three P0 findings from the full-codebase review. They share one root cause: **state added to `Stats` or to a config write-path silently bypassed an existing filter / persist step, with nothing enforcing the second touch.** Each fix ships with a regression test that pins the invariant so the class can't recur.

No behaviour change for the happy path; this is purely closing gaps.

## The three fixes (one atomic commit each)

### 1. `fix(github)` — private watched repos & review requests leaked in `--public-only`
`Stats.Public()` (the screenshot/screen-share view) filtered `Repositories`, `OpenPullRequests`, `OpenIssuesList` but not the two list-bearing fields added later — `WatchedRepos` (v0.14.0) and `ReviewRequests` (v0.15.0). In public-only mode a watched **private** repo leaked its name / CI / latest release, and a review-request on a private-repo PR leaked its title / repo / author.

- Added the two missing private-skip loops.
- Deleted the dead `langMap` block in the same function (built, then `_ = langMap`).
- **Regression test** `TestPublicStripsEveryPrivateList` is a *reflective drift guard*: it enumerates every `[]T` field on `Stats` whose element carries an `IsPrivate bool`, seeds each with public+private entries, and asserts `Public()` drops the private one from **all** of them. A future private-aware list added without a skip loop fails this test instead of leaking.

### 2. `fix(ui)` — settings / public-only saves erased `pinned_repos` & `watch_repos`
The public-only toggle and the settings panel both rewrote the config from a `config.Config` struct literal that omitted `PinnedRepos` / `WatchRepos`. Saving from either silently erased those keys (and any hand-edited key) from disk — invisible until next launch.

- Extracted a single read-modify-write helper `Model.persistConfig()`: re-`Load`s the on-disk config, overwrites only UI-changeable fields, `Save`s. Routed **all three** write paths through it (public toggle, settings panel, and the pin-toggle path that already did this inline) — one writer means they can't drift again.
- Preserves the existing safety contract: on a re-`Load` error it returns the error **without** writing, so a malformed/locked file is never clobbered with `Defaults()`.
- **Regression tests**: lists survive a save; an unreadable file is left byte-for-byte untouched; empty path is a clean no-op.

### 3. `fix(ui)` — Watched section vanished when the owned repo set was empty
`renderReposTab` early-returned the empty-state on `len(stats.Repositories) == 0`, hiding the Watched section for brand-new accounts (or `--public-only` with every owned repo private) — while the cursor (`Update`) and action menu (`selectedRepo`) kept walking `visibleReposPartitioned`, which **includes** watched rows. Classic v0.11.0 paint/cursor desync.

- Build the partition first, order the `stats == nil` guard before it, guard on `len(rows) == 0` — render / cursor / action menu now agree on the row set. A no-match filter shows a distinct esc-to-clear message.
- Header `total` now spans owned+watched so the "N of M" count is honest (was undercounting; could read "3 of 0").
- **Regression test**: watched repos render and are selectable when owned is empty; empty-state vs no-match-filter messages are distinct.

## Verification
- `go test ./...` — all green; `go test -race` on changed packages — clean
- `go vet ./...`, `gofmt -l .` — clean
- `make build` — dual-target OK

## Scope notes
- The **PRs tab** was checked for the same class as #3 — it already guards on *both* `OpenPullRequests` and `ReviewRequests`, so it's fine. Its analogous "N of M" header undercount is a separate **P2** low item (review finding #9), left out to keep this PR P0-only.
- Remaining review findings (auto-refresh timer-chain, `config.NormalizeInterval`, PR-diff scroll/mono-theme, search-box `KeyType`, dependency bump, perf one-liners, feature ideas) are tracked for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)