### PR TITLE
fix: paginate owned repositories so aggregates count past 100

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -717,7 +717,11 @@ type repoFields struct {
 				}
 			} `graphql:"languages(first: 10, orderBy: {field: SIZE, direction: DESC})"`
 		}
-	} `graphql:"repositories(first: 100, ownerAffiliations: OWNER, isFork: false)"`
+		PageInfo struct {
+			HasNextPage githubv4.Boolean
+			EndCursor   githubv4.String
+		}
+	} `graphql:"repositories(first: 100, after: $reposCursor, ownerAffiliations: OWNER, isFork: false)"`
 }
 
 // repoCIFields is the third parallel query introduced in v0.13.0
@@ -755,7 +759,136 @@ type repoCIFields struct {
 				}
 			} `graphql:"releases(first: 1, orderBy: {field: CREATED_AT, direction: DESC})"`
 		}
-	} `graphql:"repositories(first: 100, ownerAffiliations: OWNER, isFork: false)"`
+		PageInfo struct {
+			HasNextPage githubv4.Boolean
+			EndCursor   githubv4.String
+		}
+	} `graphql:"repositories(first: 100, after: $ciCursor, ownerAffiliations: OWNER, isFork: false)"`
+}
+
+// maxRepoPages bounds repositories pagination. Pages are sequential
+// (each needs the previous page's endCursor), so the page count
+// multiplies the dashboard-fetch wall-clock against the 30s timeout in
+// model.go. 5 × 100 = 500 repos fits comfortably and covers the vast
+// majority of accounts; beyond 500 the aggregates are still far closer
+// to the truth than the old hard 100 cap — a pathological account just
+// isn't walked to the very end, which beats timing the whole fetch out.
+// Mirrors the bounded-fan-out discipline used for watched repos and
+// star history.
+const maxRepoPages = 5
+
+// fetchRepoFieldsPaged walks repositories(first: 100) with cursor
+// pagination and accumulates every page's nodes into a single
+// repoFields, so extractStats aggregates stars / forks / open
+// issues+PRs / languages across the user's entire repo set rather than
+// just the first 100 — the pre-0.19.0 cap silently under-counted
+// accounts with >100 repos. TotalCount comes from the first page; the
+// returned envelope sums Cost across pages and keeps the last (most
+// drained) page's remaining/limit/resetAt. Bounded by maxRepoPages.
+func (c *Client) fetchRepoFieldsPaged(ctx context.Context) (repoFields, rateLimitFields, error) {
+	var acc repoFields
+	var lastRL rateLimitFields
+	var cursor *githubv4.String
+	totalCost := 0
+
+	for page := 0; page < maxRepoPages; page++ {
+		var (
+			rf  repoFields
+			rl  rateLimitFields
+			err error
+		)
+		if c.login == "" {
+			var q struct {
+				Viewer    repoFields
+				RateLimit rateLimitFields
+			}
+			err = c.gql.Query(ctx, &q, map[string]interface{}{"reposCursor": cursor})
+			rf, rl = q.Viewer, q.RateLimit
+		} else {
+			var q struct {
+				User      repoFields `graphql:"user(login: $login)"`
+				RateLimit rateLimitFields
+			}
+			err = c.gql.Query(ctx, &q, map[string]interface{}{
+				"login":       githubv4.String(c.login),
+				"reposCursor": cursor,
+			})
+			rf, rl = q.User, q.RateLimit
+		}
+		if err != nil {
+			return repoFields{}, rateLimitFields{}, err
+		}
+
+		if page == 0 {
+			acc.Repositories.TotalCount = rf.Repositories.TotalCount
+		}
+		acc.Repositories.Nodes = append(acc.Repositories.Nodes, rf.Repositories.Nodes...)
+		lastRL = rl
+		totalCost += int(rl.Cost)
+
+		if !bool(rf.Repositories.PageInfo.HasNextPage) {
+			break
+		}
+		next := rf.Repositories.PageInfo.EndCursor
+		cursor = &next
+	}
+
+	lastRL.Cost = githubv4.Int(totalCost)
+	return acc, lastRL, nil
+}
+
+// fetchRepoCIFieldsPaged is the repoCIFields counterpart of
+// fetchRepoFieldsPaged — same cursor-pagination accumulation so the CI
+// rollup + latest-release maps in extractStats cover every repo, not
+// just the first 100. The merge with repoFields happens by
+// NameWithOwner, so the two queries needn't paginate in lockstep.
+func (c *Client) fetchRepoCIFieldsPaged(ctx context.Context) (repoCIFields, rateLimitFields, error) {
+	var acc repoCIFields
+	var lastRL rateLimitFields
+	var cursor *githubv4.String
+	totalCost := 0
+
+	for page := 0; page < maxRepoPages; page++ {
+		var (
+			cf  repoCIFields
+			rl  rateLimitFields
+			err error
+		)
+		if c.login == "" {
+			var q struct {
+				Viewer    repoCIFields
+				RateLimit rateLimitFields
+			}
+			err = c.gql.Query(ctx, &q, map[string]interface{}{"ciCursor": cursor})
+			cf, rl = q.Viewer, q.RateLimit
+		} else {
+			var q struct {
+				User      repoCIFields `graphql:"user(login: $login)"`
+				RateLimit rateLimitFields
+			}
+			err = c.gql.Query(ctx, &q, map[string]interface{}{
+				"login":    githubv4.String(c.login),
+				"ciCursor": cursor,
+			})
+			cf, rl = q.User, q.RateLimit
+		}
+		if err != nil {
+			return repoCIFields{}, rateLimitFields{}, err
+		}
+
+		acc.Repositories.Nodes = append(acc.Repositories.Nodes, cf.Repositories.Nodes...)
+		lastRL = rl
+		totalCost += int(rl.Cost)
+
+		if !bool(cf.Repositories.PageInfo.HasNextPage) {
+			break
+		}
+		next := cf.Repositories.PageInfo.EndCursor
+		cursor = &next
+	}
+
+	lastRL.Cost = githubv4.Int(totalCost)
+	return acc, lastRL, nil
 }
 
 // FetchStats runs the dashboard fetch as **two parallel GraphQL
@@ -776,10 +909,12 @@ type repoCIFields struct {
 // point each, so the chip stays accurate to the actual budget
 // drawn.
 //
-// Limitation: repository pagination is capped at 100. Users with
-// more repos will under-count aggregated totals (stars, forks,
-// open issues, open PRs, language bytes). Viewer-level counters
-// (followers, PRs, issues) are unaffected.
+// Repository data is paginated to completion (bounded by
+// maxRepoPages) so aggregated totals — stars, forks, open
+// issues+PRs, language bytes — cover the account's entire repo set,
+// not just the first 100. The only residual cap is fork stargazers
+// for TotalStarsWithForks (profileFields.ForkedRepos stays
+// first: 100; >100 starred forks is vanishingly rare).
 func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	var (
 		profile          profileFields
@@ -833,24 +968,7 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 
 	go func() {
 		defer wg.Done()
-		if c.login == "" {
-			var q struct {
-				Viewer    repoFields
-				RateLimit rateLimitFields
-			}
-			errR = c.gql.Query(ctx, &q, nil)
-			repos = q.Viewer
-			rlR = q.RateLimit
-		} else {
-			var q struct {
-				User      repoFields `graphql:"user(login: $login)"`
-				RateLimit rateLimitFields
-			}
-			vars := map[string]interface{}{"login": githubv4.String(c.login)}
-			errR = c.gql.Query(ctx, &q, vars)
-			repos = q.User
-			rlR = q.RateLimit
-		}
+		repos, rlR, errR = c.fetchRepoFieldsPaged(ctx)
 	}()
 
 	// Third parallel query — CI rollup state per repo, kept on a
@@ -859,24 +977,7 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	// inline on repoFields 502'd the gateway on busy accounts.
 	go func() {
 		defer wg.Done()
-		if c.login == "" {
-			var q struct {
-				Viewer    repoCIFields
-				RateLimit rateLimitFields
-			}
-			errC = c.gql.Query(ctx, &q, nil)
-			repoCI = q.Viewer
-			rlC = q.RateLimit
-		} else {
-			var q struct {
-				User      repoCIFields `graphql:"user(login: $login)"`
-				RateLimit rateLimitFields
-			}
-			vars := map[string]interface{}{"login": githubv4.String(c.login)}
-			errC = c.gql.Query(ctx, &q, vars)
-			repoCI = q.User
-			rlC = q.RateLimit
-		}
+		repoCI, rlC, errC = c.fetchRepoCIFieldsPaged(ctx)
 	}()
 
 	// Fourth parallel branch — external watched repos. Each entry

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -891,23 +891,25 @@ func (c *Client) fetchRepoCIFieldsPaged(ctx context.Context) (repoCIFields, rate
 	return acc, lastRL, nil
 }
 
-// FetchStats runs the dashboard fetch as **two parallel GraphQL
-// queries** — profileFields and repoFields — and combines them
-// into the UI-facing Stats. Splitting was forced by GitHub's
-// gateway 502'ing the original single-query approach once an
-// account grew busy enough; the per-query complexity now sits
-// well under the threshold and total wall-clock latency stays
-// close to the slower of the two rather than their sum.
+// FetchStats runs the dashboard fetch as several parallel branches —
+// profileFields, repoFields and repoCIFields always, plus the
+// watched-repos fan-out and the review-requests search when
+// applicable — and combines them into the UI-facing Stats. Splitting
+// was forced by GitHub's gateway 502'ing the original single-query
+// approach once an account grew busy enough; each branch's complexity
+// now sits well under the threshold and total wall-clock latency stays
+// close to the slowest branch rather than their sum.
 //
-// Routes both queries against `viewer` when Client.login is
-// empty, otherwise against `user(login: $login)`. Errors from
-// either side fail the whole fetch — partial Stats would be
-// confusing in the UI (e.g. profile loaded but Repos tab empty).
+// Routes against `viewer` when Client.login is empty, otherwise
+// against `user(login: $login)`. An error from any required branch
+// fails the whole fetch — partial Stats would be confusing in the UI
+// (e.g. profile loaded but Repos tab empty).
 //
-// The reported RateLimit is whichever side has the smaller
-// `remaining` (most pessimistic estimate). Both queries cost ~1
-// point each, so the chip stays accurate to the actual budget
-// drawn.
+// The reported RateLimit is whichever branch has the smaller
+// `remaining` (most pessimistic estimate), with costs summed. The
+// profile branch is ~1 point; the repo branches now cost one point
+// per page walked (see fetchRepoFieldsPaged), so the chip tracks the
+// real budget drawn even on large accounts.
 //
 // Repository data is paginated to completion (bounded by
 // maxRepoPages) so aggregated totals — stars, forks, open


### PR DESCRIPTION
## Problem

`repoFields` and `repoCIFields` fetched only `repositories(first: 100)`, so on accounts with **more than 100 owned repos** the dashboard silently under-counted every aggregate derived from the repo nodes — `TotalStars`, `ForksReceived`, `OpenIssues`, `OpenPRs`, and the language byte totals — and the Repos list was truncated at 100. `PublicRepos` (from `TotalCount`) was correct, which made the mismatch easy to miss. Viewer-level counters (followers, authored PRs/issues) were never affected.

## Fix

Both queries now walk `repositories(first: 100)` with **cursor pagination** (`pageInfo { hasNextPage endCursor }` + an `after:` variable) and accumulate every page's nodes into a single struct before `extractStats` runs. `extractStats` is unchanged — it just iterates over the full node set now.

- Bounded by `maxRepoPages` (**5 → 500 repos**): pages are sequential (each needs the previous `endCursor`), so the page count multiplies wall-clock against the 30s dashboard-fetch timeout in `model.go`. 500 covers the vast majority of accounts; beyond that the totals are still far closer to the truth than the old hard 100 cap, and the fetch degrades to "not walked to the very end" rather than timing out.
- Accounts with ≤100 repos do a **single page** — unchanged cost.
- The per-branch rate-limit envelope sums `Cost` across pages and keeps the last (most-drained) page's `remaining`.

## Verification

Gated smoke test against the real API (deleted before commit, per project convention):

- **viewer (non-regression):** 82 repos, `len(Repositories) == TotalCount` — the new query collects every repo in one page.
- **`sindresorhus` (multi-page):** TotalCount 1123 → 500 collected via 5 pages, aggregate stars 757,921, CI states merged across pages.

`go vet`, `gofmt -l .` and the hermetic `go test ./...` suite all pass.

Part of the **0.19.0 "freshness & correctness"** scope (the second item, in-app update-check, lands in a follow-up PR carrying the release-prep).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository and CI data retrieval now uses paginated fetching so aggregated totals (stars, forks, open issues/PRs, language bytes) reflect full repository sets up to the pagination limit.
  * Improved handling of rate-limit information across multi-page fetches.
  * Fork-stargazer counts remain bounded by existing profile-side limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->