### PR TITLE
feat: in-app update check (0.19.0 freshness & correctness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ quiet days sit on the surface grey). Underneath:
     `terminal-notifier` icon instead. Cosmetic only.
   - **Linux & Windows**: notifications carry the embedded octoscope
     icon. Click activation depends on your DE / shell — best-effort.
+- **Update notice** — on launch (and hourly) octoscope checks whether a
+  newer release is out and, if so, shows a quiet line under the banner
+  with the right upgrade command for how you installed it (`brew`,
+  `go install`, `gh extension`, or a download link). It **never
+  self-updates** — the package manager owns the binary. Turn the check
+  off with `check_for_updates = false`; it's also suppressed under
+  `--public-only`.
 
 ### What octoscope can't show
 
@@ -377,6 +384,12 @@ theme = "octoscope"
 # out, or pass --no-sponsor for a single run. Always suppressed under
 # --public-only so screenshots stay clean.
 show_sponsor = true
+
+# Check for a newer octoscope release on launch + hourly, and show a
+# small notice under the banner when one exists (v0.19.0+). octoscope
+# never self-updates — it only suggests the upgrade command for how you
+# installed it. Set to false to disable the check entirely.
+check_for_updates = true
 
 # Optional override for just the accent slot of the active theme.
 # Hex ("#FF0080") or ANSI 256 ("201"). Leave unset to keep the

--- a/docs/index.html
+++ b/docs/index.html
@@ -998,7 +998,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.18.0</span>
+                <span class="version-tag" id="version-pill">0.19.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1166,6 +1166,11 @@
                     <div class="feature-label">Insight</div>
                     <h3>Cumulative stars &middot; rate-limit panel &middot; work filters</h3>
                     <p>New in v0.18.0. Inside a repo's detail view, <code class="inline">v</code> switches the 12-month star sparkline between <strong style="color: var(--text);">weekly density and a cumulative growth curve</strong> (star-history.com style). Press <code class="inline">%</code> anywhere for the <strong style="color: var(--text);">rate-limit detail panel</strong> &mdash; a per-resource breakdown of every REST + GraphQL budget (used, remaining, reset) from GitHub's free <code class="inline">/rate_limit</code> endpoint: the footer chip tells you how you're doing, the panel tells you why. And on the Repos tab, <code class="inline">w</code> cycles the <strong style="color: var(--text);">work filters</strong> &mdash; <em>PRs open</em>, <em>CI broken</em>, <em>stale 90d</em> &mdash; quick presets for &ldquo;where is my attention needed&rdquo; that compose with the <code class="inline">/</code> search and span pinned, owned and watched sections alike.</p>
+                </div>
+                <div class="feature wide">
+                    <div class="feature-label">Freshness &amp; correctness</div>
+                    <h3>Update notice &middot; accurate totals past 100 repos</h3>
+                    <p>New in v0.19.0. octoscope now <strong style="color: var(--text);">checks for a newer release</strong> on launch and hourly, showing a quiet line under the banner with the right upgrade command for how you installed it (<code class="inline">brew</code>, <code class="inline">go install</code>, <code class="inline">gh extension</code>, or a download link) &mdash; it <strong style="color: var(--text);">never self-updates</strong>, the package manager owns the binary. Disable with <code class="inline">check_for_updates = false</code>. And the dashboard now <strong style="color: var(--text);">counts all your repositories</strong> instead of just the first 100: stars, forks, open issues/PRs and language totals were silently under-counted on prolific accounts, now paginated to completion (up to 500) so the numbers &mdash; and the Repos list &mdash; are complete.</p>
                 </div>
                 <div class="feature wide">
                     <div class="feature-label">Configurable</div>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,14 @@ type Config struct {
 	// stay clean) and overridable per-run with the --no-sponsor CLI
 	// flag, which is the convenient lever for local testing.
 	ShowSponsor bool `toml:"show_sponsor"`
+
+	// CheckForUpdates gates the v0.19.0 in-app update check: a small
+	// "newer octoscope available" notice driven by a periodic poll of
+	// the GitHub Releases API (on launch + hourly). Defaults to true;
+	// set false to disable the check and the notice entirely. The check
+	// never auto-updates the binary — it only suggests the right upgrade
+	// command for how octoscope was installed.
+	CheckForUpdates bool `toml:"check_for_updates"`
 }
 
 // DefaultRefreshInterval is the auto-refresh cadence used when none is
@@ -123,6 +131,7 @@ func Defaults() Config {
 		PinnedRepos:     nil,
 		WatchRepos:      nil,
 		ShowSponsor:     true,
+		CheckForUpdates: true,
 	}
 }
 
@@ -217,6 +226,7 @@ func Load(path string) (Config, error) {
 		PinnedRepos     []string `toml:"pinned_repos"`
 		WatchRepos      []string `toml:"watch_repos"`
 		ShowSponsor     *bool    `toml:"show_sponsor"`
+		CheckForUpdates *bool    `toml:"check_for_updates"`
 	}
 	if _, err := toml.DecodeFile(path, &raw); err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
@@ -246,6 +256,9 @@ func Load(path string) (Config, error) {
 	cfg.WatchRepos = SanitizeRepoList(raw.WatchRepos)
 	if raw.ShowSponsor != nil {
 		cfg.ShowSponsor = *raw.ShowSponsor
+	}
+	if raw.CheckForUpdates != nil {
+		cfg.CheckForUpdates = *raw.CheckForUpdates
 	}
 
 	return cfg, nil
@@ -331,7 +344,12 @@ theme = %q
 # Show the sponsor splash at launch. Set to false to opt out, or pass
 # --no-sponsor for a single run. Always suppressed under --public-only.
 show_sponsor = %t
-%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, accentLine, pinnedLine, watchLine)
+
+# Check for a newer octoscope release (on launch + hourly) and show a
+# small notice when one exists. Never auto-updates the binary — it only
+# suggests the upgrade command. Set to false to disable.
+check_for_updates = %t
+%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, cfg.CheckForUpdates, accentLine, pinnedLine, watchLine)
 
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {

--- a/internal/github/release.go
+++ b/internal/github/release.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// latestReleaseURL is the REST endpoint for octoscope's own latest
+// published release. It is hard-coded to the canonical repo on purpose:
+// the in-app update check asks "is there a newer octoscope?", which is
+// always about gfazioli/octoscope regardless of whose profile the user
+// is viewing. Pre-releases are excluded by /releases/latest.
+const latestReleaseURL = "https://api.github.com/repos/gfazioli/octoscope/releases/latest"
+
+// FetchLatestRelease returns the tag name of octoscope's latest
+// published release (e.g. "v0.19.0"), for the in-app update check.
+//
+// The endpoint is public, so this works unauthenticated too. A repo
+// with no releases yet (404) returns ("", nil) rather than an error —
+// "no release to compare against" is a normal state, not a failure.
+// Mirrors the REST + error-classification shape of FetchRateLimits.
+func (c *Client) FetchLatestRelease(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return "", &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.rest.Do(req)
+	if err != nil {
+		return "", &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", &FetchError{
+			Reason: ReasonServer,
+			Err:    fmt.Errorf("github rest %s: %s", resp.Status, Sanitize(strings.TrimSpace(string(body)))),
+		}
+	}
+
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", &FetchError{Reason: ReasonServer, Err: err}
+	}
+	// Sanitize at the extractor boundary like every other GitHub string.
+	return Sanitize(strings.TrimSpace(payload.TagName)), nil
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -508,9 +508,12 @@ func (m Model) Init() tea.Cmd {
 		m.spinner.Tick,
 	}
 	// Update check (v0.19.0): an immediate cache-aware check plus the
-	// hourly poll. Gated on the config knob — off means zero extra
-	// network and no notice. Independent of the dashboard refresh chain.
-	if m.checkForUpdates {
+	// hourly poll. Gated on the config knob AND --public-only — a
+	// public-only / screenshot session does no release polling and
+	// writes no cache, so tape runs stay hermetic (the notice is also
+	// hidden in the render path; this stops the work at the source).
+	// Independent of the dashboard refresh chain.
+	if m.checkForUpdates && !m.client.PublicOnly() {
 		cmds = append(cmds, updateCheckCmd(m.client), updateTickCmd())
 	}
 	return tea.Batch(cmds...)
@@ -971,8 +974,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case updateTickMsg:
 		// Hourly re-check. Re-arm the (single, fixed-interval) chain and
-		// fire another cache-aware check.
-		if !m.checkForUpdates {
+		// fire another cache-aware check. Self-terminates if the feature
+		// is off or public-only is on (e.g. toggled on at runtime) so a
+		// public-only session stops polling and writing the cache.
+		if !m.checkForUpdates || m.client.PublicOnly() {
 			return m, nil
 		}
 		return m, tea.Batch(updateCheckCmd(m.client), updateTickCmd())

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/config"
 	"github.com/gfazioli/octoscope/internal/github"
 	"github.com/gfazioli/octoscope/internal/notify"
+	"github.com/gfazioli/octoscope/internal/update"
 )
 
 // Tab identifies one of the top-level views. Values are stable so the
@@ -207,6 +208,20 @@ type Model struct {
 	// any future inline notification can pipe through here too.
 	toastMsg   string
 	toastUntil time.Time
+
+	// checkForUpdates gates the in-app update check (v0.19.0). When
+	// false (config check_for_updates=false) Init fires neither the
+	// startup check nor the hourly tick, and no notice ever renders.
+	checkForUpdates bool
+
+	// updateLatest is the latest octoscope release tag seen by the
+	// update check (e.g. "v0.19.0"); updateAvailable is true when it's
+	// strictly newer than the running version. updateChannel is how
+	// this binary was installed, so the notice can suggest the right
+	// upgrade command (octoscope never self-updates). See internal/update.
+	updateLatest    string
+	updateAvailable bool
+	updateChannel   update.Channel
 }
 
 // toastDuration is how long a transient footer toast stays visible
@@ -250,6 +265,18 @@ type clockTickMsg time.Time
 // accent borders on "recently changed" cards revert to muted without
 // waiting for the next auto-refresh tick (60s).
 type pulseExpireMsg struct{}
+
+// updateCheckMsg carries the latest octoscope release tag back from a
+// (cache-aware) update check. It never carries an error: a failed
+// check stays silent — surfacing "couldn't check for updates" would be
+// noise. An empty latest just means "nothing to compare against".
+type updateCheckMsg struct{ latest string }
+
+// updateTickMsg fires on the slow (hourly) update-check chain, separate
+// from the dashboard refresh tick. Fixed interval (it never changes),
+// so unlike tickMsg it needs no generation guard — there's only ever
+// one chain, started in Init when checkForUpdates is on.
+type updateTickMsg struct{}
 
 // diffIDs maps a Stats field to the card id used by the view. Only
 // the integer fields that appear as cards are tracked; profile-text
@@ -404,6 +431,11 @@ type Options struct {
 	// opts out — set via config show_sponsor or the --no-sponsor flag,
 	// already resolved by main.go before reaching here.
 	ShowSponsor bool
+
+	// CheckForUpdates gates the v0.19.0 in-app update check (config
+	// check_for_updates). When true, NewModel records the install
+	// channel and Init starts the check + hourly poll.
+	CheckForUpdates bool
 }
 
 // NewModel returns a Model ready for tea.NewProgram. The first fetch
@@ -433,21 +465,31 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 		sponsor = sponsor.Open(sponsorURL)
 	}
 
+	// Detect the install channel once at startup (cheap, but only
+	// meaningful when the update check is on) so the update notice can
+	// suggest the right upgrade command without re-probing each render.
+	var updateChannel update.Channel
+	if opts.CheckForUpdates {
+		updateChannel = update.DetectChannel()
+	}
+
 	return Model{
-		client:      client,
-		loading:     true,
-		interval:    interval,
-		compact:     opts.Compact,
-		configPath:  opts.ConfigPath,
-		theme:       themeName,
-		accentColor: opts.AccentColor,
-		pinned:      append([]string(nil), opts.PinnedRepos...),
-		version:     version,
-		spinner:     sp,
-		pulseMap:    make(map[string]time.Time),
-		overviewVP:  viewport.New(0, 0),
-		activityVP:  viewport.New(0, 0),
-		sponsor:     sponsor,
+		client:          client,
+		loading:         true,
+		interval:        interval,
+		compact:         opts.Compact,
+		configPath:      opts.ConfigPath,
+		theme:           themeName,
+		accentColor:     opts.AccentColor,
+		pinned:          append([]string(nil), opts.PinnedRepos...),
+		version:         version,
+		spinner:         sp,
+		pulseMap:        make(map[string]time.Time),
+		overviewVP:      viewport.New(0, 0),
+		activityVP:      viewport.New(0, 0),
+		sponsor:         sponsor,
+		checkForUpdates: opts.CheckForUpdates,
+		updateChannel:   updateChannel,
 	}
 }
 
@@ -456,7 +498,7 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 // and kicks off the spinner animation — we're in the loading state
 // on first paint so the spinner is already visible.
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(
+	cmds := []tea.Cmd{
 		// Startup fetch is a one-shot paint (manual=true): it must not
 		// seed a second chain. The lone tickCmd below is the single
 		// auto-refresh chain (generation 0).
@@ -464,7 +506,14 @@ func (m Model) Init() tea.Cmd {
 		tickCmd(m.interval, m.refreshGen),
 		clockTickCmd(),
 		m.spinner.Tick,
-	)
+	}
+	// Update check (v0.19.0): an immediate cache-aware check plus the
+	// hourly poll. Gated on the config knob — off means zero extra
+	// network and no notice. Independent of the dashboard refresh chain.
+	if m.checkForUpdates {
+		cmds = append(cmds, updateCheckCmd(m.client), updateTickCmd())
+	}
+	return tea.Batch(cmds...)
 }
 
 // Update routes keyboard, resize, and network messages.
@@ -911,6 +960,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// re-render the view against the fresh time.Now().
 		return m, clockTickCmd()
 
+	case updateCheckMsg:
+		// Store the latest release and flag whether it's newer than the
+		// running build. Gated on checkForUpdates as belt-and-braces
+		// (Init wouldn't have fired the check otherwise). A failed/empty
+		// check leaves updateAvailable false — silent by design.
+		m.updateLatest = msg.latest
+		m.updateAvailable = m.checkForUpdates && update.IsNewer(m.version, msg.latest)
+		return m, nil
+
+	case updateTickMsg:
+		// Hourly re-check. Re-arm the (single, fixed-interval) chain and
+		// fire another cache-aware check.
+		if !m.checkForUpdates {
+			return m, nil
+		}
+		return m, tea.Batch(updateCheckCmd(m.client), updateTickCmd())
+
 	case showToastMsg:
 		m.toastMsg = msg.text
 		m.toastUntil = time.Now().Add(toastDuration)
@@ -1329,6 +1395,44 @@ func tickCmd(d time.Duration, gen int) tea.Cmd {
 func clockTickCmd() tea.Cmd {
 	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
 		return clockTickMsg(t)
+	})
+}
+
+// updateCheckInterval is how often the in-app update check polls the
+// Releases API in-session, and the freshness window for the on-disk
+// cache. Hourly is plenty for a release that ships every few days, and
+// keeps the (free, unauthenticated-capable) endpoint usage negligible.
+const updateCheckInterval = time.Hour
+
+// updateCheckCmd performs one cache-aware update check off the Update
+// loop. A cache fresher than updateCheckInterval is reused without any
+// network call (so repeated short sessions don't re-poll); otherwise it
+// fetches the latest release, persists the result, and reports it. The
+// check is deliberately silent on failure — it falls back to whatever
+// was cached and never surfaces an error, because a flaky update check
+// must not nag the user.
+func updateCheckCmd(client *github.Client) tea.Cmd {
+	return func() tea.Msg {
+		cached := update.LoadCache()
+		if cached.Fresh(updateCheckInterval) {
+			return updateCheckMsg{latest: cached.LatestTag}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		latest, err := client.FetchLatestRelease(ctx)
+		if err != nil || latest == "" {
+			return updateCheckMsg{latest: cached.LatestTag}
+		}
+		_ = update.SaveCache(update.Cache{LastCheck: time.Now(), LatestTag: latest})
+		return updateCheckMsg{latest: latest}
+	}
+}
+
+// updateTickCmd schedules the next hourly update check. Fixed interval,
+// single chain — no generation guard needed (see updateTickMsg).
+func updateTickCmd() tea.Cmd {
+	return tea.Tick(updateCheckInterval, func(t time.Time) tea.Msg {
+		return updateTickMsg{}
 	})
 }
 

--- a/internal/ui/update_notice_test.go
+++ b/internal/ui/update_notice_test.go
@@ -21,7 +21,7 @@ func TestRenderUpdateNotice(t *testing.T) {
 		{update.ChannelHomebrew, "brew upgrade gfazioli/tap/octoscope", "homebrew"},
 		{update.ChannelGo, "go install github.com/gfazioli/octoscope@latest", "go"},
 		{update.ChannelGhExtension, "gh extension upgrade octoscope", "gh"},
-		{update.ChannelManual, "github.com/gfazioli/octoscope/releases/latest", "manual"},
+		{update.ChannelManual, "https://github.com/gfazioli/octoscope/releases/latest", "manual"},
 	}
 	for _, c := range cases {
 		out := renderUpdateNotice("v0.19.0", c.ch)

--- a/internal/ui/update_notice_test.go
+++ b/internal/ui/update_notice_test.go
@@ -1,0 +1,38 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gfazioli/octoscope/internal/update"
+)
+
+// TestRenderUpdateNotice checks the update-available line carries the
+// version and the channel-specific upgrade command, so the user always
+// sees both what's new and how to get it.
+func TestRenderUpdateNotice(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	cases := []struct {
+		ch       update.Channel
+		wantCmd  string
+		chanName string
+	}{
+		{update.ChannelHomebrew, "brew upgrade gfazioli/tap/octoscope", "homebrew"},
+		{update.ChannelGo, "go install github.com/gfazioli/octoscope@latest", "go"},
+		{update.ChannelGhExtension, "gh extension upgrade octoscope", "gh"},
+		{update.ChannelManual, "github.com/gfazioli/octoscope/releases/latest", "manual"},
+	}
+	for _, c := range cases {
+		out := renderUpdateNotice("v0.19.0", c.ch)
+		if !strings.Contains(out, "v0.19.0") {
+			t.Errorf("[%s] notice missing version: %q", c.chanName, out)
+		}
+		if !strings.Contains(out, "available") {
+			t.Errorf("[%s] notice missing 'available': %q", c.chanName, out)
+		}
+		if !strings.Contains(out, c.wantCmd) {
+			t.Errorf("[%s] notice missing upgrade command %q: %q", c.chanName, c.wantCmd, out)
+		}
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/gfazioli/octoscope/internal/github"
+	"github.com/gfazioli/octoscope/internal/update"
 )
 
 // View renders the current model. Layout for v0.3.0:
@@ -99,6 +100,13 @@ func (m Model) View() string {
 
 	b.WriteString(renderBanner(m.version))
 	b.WriteString("\n")
+	// Update-available notice (v0.19.0): a quiet line under the banner.
+	// Suppressed in --public-only so the fixed tape/screenshot geometry
+	// never shifts, same discipline as the sponsor splash.
+	if m.updateAvailable && !m.client.PublicOnly() {
+		b.WriteString(renderUpdateNotice(m.updateLatest, m.updateChannel))
+		b.WriteString("\n")
+	}
 	b.WriteString(renderProfileCard(s, available, m.client.PublicOnly()))
 	b.WriteString("\n")
 	b.WriteString(renderTabBar(m.activeTab, available))
@@ -346,6 +354,17 @@ func renderBanner(version string) string {
 		content += mutedStyle.Render("  " + version)
 	}
 	return bannerStyle.Render(content)
+}
+
+// renderUpdateNotice is the one-line "a newer octoscope is out" hint
+// shown under the banner when the update check (v0.19.0) found a newer
+// release. Deliberately quiet: the version in valueStyle to catch the
+// eye, the suggested upgrade command in muted. octoscope never
+// self-updates — this only tells the user how. The caller suppresses it
+// under --public-only so screenshots / tapes stay on the fixed geometry.
+func renderUpdateNotice(latest string, ch update.Channel) string {
+	return valueStyle.Render("↑ octoscope "+latest+" available") +
+		mutedStyle.Render("  ·  "+update.UpgradeCommand(ch))
 }
 
 // renderProfileCard renders the user's profile (name/login/pronouns,

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,19 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.19.0": {
+		headline: "Freshness & correctness — stay current, count everything.",
+		items: []whatsNewItem{
+			{
+				title: "Update notice",
+				desc:  "octoscope now checks on launch (and hourly) whether a newer release is out, and shows a quiet line under the banner with the right upgrade command for how you installed it — brew, go install, gh extension or download. It never self-updates. Disable with check_for_updates = false.",
+			},
+			{
+				title: "Accurate totals past 100 repos",
+				desc:  "The dashboard used to count only your first 100 repositories, under-counting stars, forks, open issues/PRs and language bytes on prolific accounts. It now paginates through them all (up to 500), so the aggregates — and the Repos list — are complete.",
+			},
+		},
+	},
 	"0.18.0": {
 		headline: "Insight — see further without leaving the terminal.",
 		items: []whatsNewItem{

--- a/internal/update/cache.go
+++ b/internal/update/cache.go
@@ -1,0 +1,76 @@
+package update
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Cache is the on-disk record of the last update check. It lets a
+// fresh launch reuse a recent result instead of hitting the network
+// every time octoscope starts — the in-session hourly tick keeps it
+// current after that.
+type Cache struct {
+	// LastCheck is when the Releases API was last queried.
+	LastCheck time.Time `json:"last_check"`
+	// LatestTag is the tag returned by that query (e.g. "v0.19.0").
+	LatestTag string `json:"latest_tag"`
+}
+
+// cachePath is <user cache dir>/octoscope/update.json. Honours
+// $XDG_CACHE_HOME on Linux via os.UserCacheDir.
+func cachePath() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "octoscope", "update.json"), nil
+}
+
+// LoadCache reads the cached check. A missing or unreadable file
+// returns a zero Cache and no error — the caller treats a zero
+// LastCheck as "never checked", which is the correct first-run state.
+func LoadCache() Cache {
+	path, err := cachePath()
+	if err != nil {
+		return Cache{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Cache{}
+	}
+	var c Cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Cache{}
+	}
+	return c
+}
+
+// SaveCache persists the check result, creating the parent directory
+// if needed. Errors are returned but are non-fatal for the caller — a
+// failed cache write just means the next launch re-checks over the
+// network.
+func SaveCache(c Cache) error {
+	path, err := cachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// Fresh reports whether c was checked within d of now — i.e. recent
+// enough to reuse without re-querying the network.
+func (c Cache) Fresh(d time.Duration) bool {
+	if c.LastCheck.IsZero() {
+		return false
+	}
+	return time.Since(c.LastCheck) < d
+}

--- a/internal/update/channel.go
+++ b/internal/update/channel.go
@@ -85,6 +85,9 @@ func UpgradeCommand(ch Channel) string {
 	case ChannelGhExtension:
 		return "gh extension upgrade octoscope"
 	default:
-		return "github.com/gfazioli/octoscope/releases/latest"
+		// Fully-qualified https:// so terminals that auto-link only
+		// schemed URLs make it clickable, matching the URLs elsewhere
+		// in the UI (e.g. whatsnew.go).
+		return "https://github.com/gfazioli/octoscope/releases/latest"
 	}
 }

--- a/internal/update/channel.go
+++ b/internal/update/channel.go
@@ -1,0 +1,90 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Channel is how the running octoscope binary was most likely
+// installed. It drives the upgrade command suggested in the
+// update-available notice — octoscope must never overwrite itself,
+// because the package manager owns the binary (auto-update would fight
+// brew/gh/go and break the read-only trust model).
+type Channel int
+
+const (
+	ChannelUnknown Channel = iota
+	ChannelHomebrew
+	ChannelGo
+	ChannelGhExtension
+	ChannelManual
+)
+
+// DetectChannel infers the install channel from the running
+// executable's path (and how it was invoked). Best-effort: any
+// ambiguity falls back to ChannelManual, whose hint just points at the
+// releases page — always correct, if generic.
+func DetectChannel() Channel {
+	// argv[0] basename: a gh extension is invoked as "gh-octoscope".
+	if base := filepath.Base(os.Args[0]); strings.HasPrefix(base, "gh-") {
+		return ChannelGhExtension
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return ChannelManual
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	p := filepath.ToSlash(exe)
+
+	switch {
+	case strings.Contains(p, "/gh/extensions/"), strings.Contains(p, "/gh-octoscope/"):
+		return ChannelGhExtension
+	case strings.Contains(p, "/Cellar/"), strings.Contains(p, "/homebrew/"), strings.Contains(p, "/Homebrew/"):
+		return ChannelHomebrew
+	case strings.Contains(p, "/go/bin/"), strings.HasSuffix(filepath.Dir(p), "/bin") && goPathBin(p):
+		return ChannelGo
+	default:
+		return ChannelManual
+	}
+}
+
+// goPathBin reports whether p sits under $GOPATH/bin or $GOBIN, the
+// install targets used by `go install`.
+func goPathBin(p string) bool {
+	if gobin := os.Getenv("GOBIN"); gobin != "" {
+		if strings.HasPrefix(p, filepath.ToSlash(gobin)+"/") {
+			return true
+		}
+	}
+	if gopath := os.Getenv("GOPATH"); gopath != "" {
+		if strings.HasPrefix(p, filepath.ToSlash(filepath.Join(gopath, "bin"))+"/") {
+			return true
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if strings.HasPrefix(p, filepath.ToSlash(filepath.Join(home, "go", "bin"))+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// UpgradeCommand returns the shell command (or instruction) that
+// upgrades octoscope for the given channel. The string is rendered
+// verbatim in the update-available notice.
+func UpgradeCommand(ch Channel) string {
+	switch ch {
+	case ChannelHomebrew:
+		return "brew upgrade gfazioli/tap/octoscope"
+	case ChannelGo:
+		return "go install github.com/gfazioli/octoscope@latest"
+	case ChannelGhExtension:
+		return "gh extension upgrade octoscope"
+	default:
+		return "github.com/gfazioli/octoscope/releases/latest"
+	}
+}

--- a/internal/update/version.go
+++ b/internal/update/version.go
@@ -1,0 +1,106 @@
+// Package update powers octoscope's in-app "a newer version is
+// available" check: comparing the running version against the latest
+// published release, detecting how the binary was installed so the
+// right upgrade command can be suggested, and caching the last check
+// on disk so the network isn't hit on every launch.
+//
+// It is deliberately decoupled from the github client (the HTTP fetch
+// lives in internal/github) and from the TUI (orchestration lives in
+// internal/ui) — this package is pure logic plus a small on-disk cache.
+package update
+
+import (
+	"strconv"
+	"strings"
+)
+
+// IsNewer reports whether latest is a strictly newer version than
+// current. Both accept an optional leading "v" (so "0.19.0" and
+// "v0.19.0" compare equal). Comparison is numeric per dotted component
+// — crucially NOT lexicographic, which would wrongly rank "0.9.0" above
+// "0.10.0". A pre-release suffix ("-rc1", "-beta") makes a version
+// lower than the same core version without one (0.19.0-rc1 < 0.19.0),
+// matching semver precedence closely enough for an upgrade hint.
+//
+// Unparseable input is treated conservatively: if either side can't be
+// read as a version, IsNewer returns false (no spurious "update
+// available" prompt on garbage).
+func IsNewer(current, latest string) bool {
+	return compare(current, latest) < 0
+}
+
+// compare returns -1 if a < b, 0 if equal, +1 if a > b. Returns 0
+// (treated as "not newer") when either side is unparseable.
+func compare(a, b string) int {
+	ac, ap, aok := parse(a)
+	bc, bp, bok := parse(b)
+	if !aok || !bok {
+		return 0
+	}
+
+	// Compare the numeric core component by component. Missing
+	// components count as 0 so "0.19" == "0.19.0".
+	n := len(ac)
+	if len(bc) > n {
+		n = len(bc)
+	}
+	for i := 0; i < n; i++ {
+		av, bv := 0, 0
+		if i < len(ac) {
+			av = ac[i]
+		}
+		if i < len(bc) {
+			bv = bc[i]
+		}
+		if av != bv {
+			if av < bv {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	// Equal core: a version WITH a pre-release ranks below one
+	// without (1.0.0-rc1 < 1.0.0). Between two pre-releases, fall
+	// back to a plain string compare for a stable, if approximate,
+	// ordering.
+	switch {
+	case ap == "" && bp == "":
+		return 0
+	case ap == "" && bp != "":
+		return 1
+	case ap != "" && bp == "":
+		return -1
+	case ap < bp:
+		return -1
+	case ap > bp:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// parse splits "v1.2.3-rc1" into ([]int{1,2,3}, "rc1", true). The bool
+// is false when no numeric component can be read at all.
+func parse(v string) (core []int, pre string, ok bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return nil, "", false
+	}
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		pre = v[i+1:]
+		v = v[:i]
+	}
+	for _, part := range strings.Split(v, ".") {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, "", false
+		}
+		core = append(core, n)
+	}
+	if len(core) == 0 {
+		return nil, "", false
+	}
+	return core, pre, true
+}

--- a/internal/update/version.go
+++ b/internal/update/version.go
@@ -60,47 +60,107 @@ func compare(a, b string) int {
 		}
 	}
 
-	// Equal core: a version WITH a pre-release ranks below one
-	// without (1.0.0-rc1 < 1.0.0). Between two pre-releases, fall
-	// back to a plain string compare for a stable, if approximate,
-	// ordering.
-	switch {
-	case ap == "" && bp == "":
-		return 0
-	case ap == "" && bp != "":
-		return 1
-	case ap != "" && bp == "":
-		return -1
-	case ap < bp:
-		return -1
-	case ap > bp:
-		return 1
-	default:
-		return 0
-	}
+	// Equal core: precedence is decided by the pre-release identifiers
+	// (build metadata was already dropped in parse — semver ignores it).
+	return comparePre(ap, bp)
 }
 
-// parse splits "v1.2.3-rc1" into ([]int{1,2,3}, "rc1", true). The bool
-// is false when no numeric component can be read at all.
-func parse(v string) (core []int, pre string, ok bool) {
+// comparePre orders two pre-release identifier lists by semver
+// precedence: a version WITHOUT a pre-release outranks one WITH
+// (1.0.0 > 1.0.0-rc1). Identifiers compare left to right — numeric ones
+// numerically (so rc.2 < rc.10), a numeric identifier below an
+// alphanumeric one, and a longer list wins when all shared identifiers
+// are equal.
+func comparePre(a, b []string) int {
+	switch {
+	case len(a) == 0 && len(b) == 0:
+		return 0
+	case len(a) == 0: // no pre-release outranks a pre-release
+		return 1
+	case len(b) == 0:
+		return -1
+	}
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		ai, aNum := atoi(a[i])
+		bi, bNum := atoi(b[i])
+		switch {
+		case aNum && bNum:
+			if ai != bi {
+				if ai < bi {
+					return -1
+				}
+				return 1
+			}
+		case aNum != bNum:
+			// A numeric identifier has lower precedence than an
+			// alphanumeric one.
+			if aNum {
+				return -1
+			}
+			return 1
+		default:
+			if a[i] != b[i] {
+				if a[i] < b[i] {
+					return -1
+				}
+				return 1
+			}
+		}
+	}
+	if len(a) != len(b) {
+		if len(a) < len(b) {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// atoi reports whether s is all digits and, if so, its integer value.
+func atoi(s string) (int, bool) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// parse splits "v1.2.3-rc.1+build" into ([]int{1,2,3},
+// []string{"rc","1"}, true). Build metadata (the "+…" part) is dropped
+// entirely — semver ignores it for precedence, so 1.0.0+a == 1.0.0+b ==
+// 1.0.0. The bool is false when no numeric core can be read.
+func parse(v string) (core []int, pre []string, ok bool) {
 	v = strings.TrimSpace(v)
 	v = strings.TrimPrefix(v, "v")
 	if v == "" {
-		return nil, "", false
+		return nil, nil, false
 	}
-	if i := strings.IndexAny(v, "-+"); i >= 0 {
-		pre = v[i+1:]
+	// Drop build metadata before anything else (ignored for precedence).
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	// Split off the pre-release (everything after the first '-').
+	var preStr string
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		preStr = v[i+1:]
 		v = v[:i]
 	}
 	for _, part := range strings.Split(v, ".") {
 		n, err := strconv.Atoi(part)
 		if err != nil {
-			return nil, "", false
+			return nil, nil, false
 		}
 		core = append(core, n)
 	}
 	if len(core) == 0 {
-		return nil, "", false
+		return nil, nil, false
+	}
+	if preStr != "" {
+		pre = strings.Split(preStr, ".")
 	}
 	return core, pre, true
 }

--- a/internal/update/version_test.go
+++ b/internal/update/version_test.go
@@ -30,6 +30,16 @@ func TestIsNewer(t *testing.T) {
 		{"0.19.0-rc1", "0.19.0", true},
 		{"0.19.0", "0.19.0-rc1", false},
 		{"0.19.0-rc1", "0.19.0-rc2", true},
+		// Dot-separated numeric pre-release identifiers compare
+		// numerically, not lexicographically: rc.2 < rc.10.
+		{"0.19.0-rc.2", "0.19.0-rc.10", true},
+		{"0.19.0-rc.10", "0.19.0-rc.2", false},
+		{"0.19.0-rc.2", "0.19.0-rc.2", false},
+		// Build metadata is ignored for precedence (semver §10).
+		{"0.19.0+build.5", "0.19.0", false},
+		{"0.19.0", "0.19.0+build.5", false},
+		{"0.19.0+a", "0.19.0+b", false},
+		{"0.18.0+meta", "0.19.0", true},
 		// Garbage in → conservative false (no spurious prompt).
 		{"", "0.19.0", false},
 		{"0.18.0", "", false},

--- a/internal/update/version_test.go
+++ b/internal/update/version_test.go
@@ -1,0 +1,44 @@
+package update
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		// Plain upgrades.
+		{"0.18.0", "0.19.0", true},
+		{"0.18.0", "0.18.1", true},
+		{"0.18.0", "1.0.0", true},
+		// Equal / older — no prompt.
+		{"0.18.0", "0.18.0", false},
+		{"0.19.0", "0.18.0", false},
+		{"1.0.0", "0.19.0", false},
+		// The v-prefix must not matter.
+		{"v0.18.0", "0.19.0", true},
+		{"0.18.0", "v0.19.0", true},
+		{"v0.18.0", "v0.18.0", false},
+		// Numeric, not lexicographic: 0.9.0 < 0.10.0.
+		{"0.9.0", "0.10.0", true},
+		{"0.10.0", "0.9.0", false},
+		// Missing components count as zero.
+		{"0.19", "0.19.0", false},
+		{"0.19.0", "0.19", false},
+		{"0.19.0", "0.19.1", true},
+		// Pre-releases rank below their core version.
+		{"0.19.0-rc1", "0.19.0", true},
+		{"0.19.0", "0.19.0-rc1", false},
+		{"0.19.0-rc1", "0.19.0-rc2", true},
+		// Garbage in → conservative false (no spurious prompt).
+		{"", "0.19.0", false},
+		{"0.18.0", "", false},
+		{"0.18.0", "not-a-version", false},
+		{"dev", "0.19.0", false},
+	}
+	for _, c := range cases {
+		if got := IsNewer(c.current, c.latest); got != c.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", c.current, c.latest, got, c.want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -81,13 +81,14 @@ func main() {
 	client.SetWatchRepos(cfg.WatchRepos)
 
 	model := ui.NewModel(client, version, ui.Options{
-		Interval:    cfg.RefreshInterval,
-		Compact:     cfg.Compact,
-		ConfigPath:  configPath,
-		Theme:       cfg.Theme,
-		AccentColor: cfg.AccentColor,
-		PinnedRepos: cfg.PinnedRepos,
-		ShowSponsor: cfg.ShowSponsor,
+		Interval:        cfg.RefreshInterval,
+		Compact:         cfg.Compact,
+		ConfigPath:      configPath,
+		Theme:           cfg.Theme,
+		AccentColor:     cfg.AccentColor,
+		PinnedRepos:     cfg.PinnedRepos,
+		ShowSponsor:     cfg.ShowSponsor,
+		CheckForUpdates: cfg.CheckForUpdates,
 	})
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.18.0"
+const version = "0.19.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Second and final item of the **0.19.0 "freshness & correctness"** scope. Carries the release-prep in its last commit, so merging this leaves `main` immediately taggable.

## Update check

On launch and on an hourly tick (independent of the dashboard refresh chain), octoscope polls the public Releases API and, when a newer version exists, shows a quiet one-line notice under the banner:

```
↑ octoscope v0.20.0 available  ·  brew upgrade gfazioli/tap/octoscope
```

- **Notify, never self-update.** The upgrade command is **context-aware** — detected from the install path: `brew upgrade …`, `go install …@latest`, `gh extension upgrade …`, or a download link. octoscope never overwrites itself: the package manager owns the binary, and auto-update would fight brew/gh/go and break the read-only trust model.
- **Cheap & quiet.** One public `GET /releases/latest` (works unauthenticated), cached under the XDG cache dir so repeated short sessions don't re-poll; the hourly tick refreshes it in-session. A failed/empty check stays silent — no nagging.
- **Gated** by `check_for_updates` (default true), and **suppressed under `--public-only`** so tape/screenshot geometry stays fixed.

## Layout

- `internal/github/release.go` — `FetchLatestRelease` (REST, mirrors `FetchRateLimits`).
- `internal/update/` — numeric (not lexicographic) semver compare, install-channel detection, on-disk cache. Pure logic + cache, decoupled from the client and the TUI.
- `internal/config` — `check_for_updates` key.
- `internal/ui` — model fields + a second slow tick + `updateCheckCmd`; the notice renders under the banner.

## Release-prep (last commit)

`main.go` → 0.19.0 · `whatsnew.go` 0.19.0 entry · README (`check_for_updates` + Live-feedback note) · landing version pill + "At a glance" card. Includes the **100-repo pagination fix** (#18, already merged) under the same 0.19.0 theme.

## Tests

`internal/update` version-compare table + the notice-render test; `go vet`, `gofmt -l .` and the hermetic `go test ./...` all pass. `FetchLatestRelease` verified against the real API via a gated smoke test (returned `v0.18.0`; removed before commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic update checks on launch and hourly; displays a quiet upgrade notice under the banner with channel-specific install instructions when a newer release is available
  * Dashboard totals now accurately count repositories beyond the first 100 (pagination up to 500)

* **Configuration**
  * New check_for_updates setting (enabled by default); can be disabled and is suppressed in public-only mode

* **Documentation**
  * Updated UI version pill and "What's New" highlights for the release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->