### PR TITLE
feat: supply-chain integrity scan (Shai-Hulud / Miasma) + buy-me-a-coffee link

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ direct shortcut you can press from inside the menu to skip selection.
   clipboard (uses `pbcopy` on macOS, `clip` on Windows,
   `wl-copy` / `xclip` / `xsel` on Linux). A `URL copied` toast
   confirms in the footer.
+- **Security scan** (`s`, Repos only, v0.20.0+) — runs an on-demand
+  **supply-chain integrity scan** of the repo and opens a read-only
+  report with a weighted, explainable verdict (*clean / watch /
+  suspicious / likely compromised*) for the **Shai-Hulud / Miasma**
+  class of attack — an implant pushed to your repos that auto-runs
+  when you open them in an AI editor or install them. It flags
+  auto-execution surfaces, oversized / obfuscated payloads and forged
+  or unsigned commit tips — matching the *invariant* of the attack,
+  not a single filename, so renamed variants still trip it — lists
+  every auto-executing file it found, and shows per-branch commit-tip
+  provenance. When something looks wrong it offers a copy-paste
+  remediation script (`y`) and the right OAuth-grant revoke links.
+  **octoscope never mutates the repo.**
 
 ### Rate-limit awareness
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -998,7 +998,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.19.0</span>
+                <span class="version-tag" id="version-pill">0.20.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1171,6 +1171,11 @@
                     <div class="feature-label">Freshness &amp; correctness</div>
                     <h3>Update notice &middot; full repo totals</h3>
                     <p>Since v0.19.0. A quiet <strong style="color: var(--text);">update notice</strong> with the right upgrade command for how you installed it (it never self-updates), and the dashboard now <strong style="color: var(--text);">counts all your repos</strong> instead of just the first 100.</p>
+                </div>
+                <div class="feature">
+                    <div class="feature-label">Integrity scan</div>
+                    <h3>Catch the supply-chain worm</h3>
+                    <p>Since v0.20.0. On a repo's action menu, <code class="inline">s</code> runs a read-only <strong style="color: var(--text);">supply-chain integrity scan</strong> for the Shai-Hulud / Miasma class of attack &mdash; scoring auto-execution surfaces, oversized / obfuscated payloads and forged or unsigned commit tips, not a single filename, so renamed variants still trip it. It explains every finding and hands you a fix script plus the right revoke links; it never touches the repo.</p>
                 </div>
                 <div class="feature">
                     <div class="feature-label">Configurable</div>

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1,0 +1,1260 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// This file implements octoscope's supply-chain integrity scan — a
+// generic detector for the Shai-Hulud / Miasma class of attack
+// (self-replicating implant pushed to repos you own via a stolen
+// token, auto-executing when the repo is opened in an AI editor or
+// installed, then harvesting credentials). See the design section in
+// ROADMAP.md for the full rationale.
+//
+// The detector deliberately does NOT match a single payload filename
+// (that signature rots the moment the worm renames its dropper).
+// Instead it scores the *invariant* of the attack across four
+// filename-agnostic axes:
+//
+//	Axis 1 — auto-execution surface ("ignition points"): a
+//	         data-driven catalog of path globs that run by themselves
+//	         when a repo is opened / built (ignitionCatalog).
+//	Axis 2 — blob anomaly: a matched ignition file that is oversized,
+//	         high-entropy, or carries obfuscation markers — regardless
+//	         of its name (blobAnalysis / looksObfuscated).
+//	Axis 3 — provenance anomaly: branch tips that are unsigned against
+//	         an otherwise-signed history, or forged under a bot /
+//	         maintainer identity (BranchProvenance scoring).
+//	Axis 4 — capability escalation (self-hosted runners, deploy keys,
+//	         contents:write workflows) is intentionally left for a
+//	         follow-up; the ignition catalog already lists workflow
+//	         files so they show in the inventory.
+//
+// Scoring is weighted and explainable: every Finding carries the
+// human reason it fired, and no single axis is enough to reach the
+// high verdict tiers — the combination is what escalates. octoscope
+// is read-only: the scan flags and explains, it never mutates the
+// repository.
+
+// ---------------------------------------------------------------------------
+// Tier A — push-burst heuristic (pure, no network)
+// ---------------------------------------------------------------------------
+
+// pushBurstMinRepos / pushBurstWindow define the push-burst heuristic
+// (Axis 3, account-wide). The reference worm pushed to five repos in a
+// 49-second window from a single IP — humans almost never push to
+// three *distinct* repos inside a two-minute window, but a fan-out
+// script does. Kept tight so the dashboard banner stays a rare,
+// meaningful signal rather than firing on a normal cross-repo work
+// session.
+const (
+	pushBurstMinRepos = 3
+	pushBurstWindow   = 2 * time.Minute
+)
+
+// PushBurst describes the tightest cluster of repositories pushed
+// within pushBurstWindow of one another. It's the cheapest signal of
+// the worm's "re-push myself to every repo I can reach" behaviour:
+// pure arithmetic over the PushedAt timestamps octoscope already holds
+// after a dashboard refresh, so it costs zero extra API calls.
+type PushBurst struct {
+	Count  int           // repos in the cluster (>= pushBurstMinRepos when detected)
+	Span   time.Duration // wall-clock span between the oldest and newest push in the cluster
+	Newest time.Time     // most recent push in the cluster
+	Repos  []string      // repo names in the cluster, newest push first
+}
+
+// DetectPushBurst returns the tightest cluster of >= minRepos repos
+// whose PushedAt timestamps all fall within `window` of the cluster's
+// newest push, and reports whether such a cluster exists. Repos with a
+// zero PushedAt (never pushed) are ignored.
+//
+// Pure function — the caller passes the thresholds so the heuristic is
+// table-testable.
+//
+// NOT currently wired into the UI. It shipped as an always-on dashboard
+// banner but was pulled: timing alone can't tell a worm's fan-out from
+// an ordinary batch push (a maintainer scripting an update across N
+// repos, Dependabot, a CI sweep), and — critically — this finds *any*
+// historical cluster, so without a recency gate a months-old batch
+// re-alarms on every launch. Retained as a tested building block: a
+// future use should fold it into the on-demand scan as one input
+// (e.g. "this repo was part of a push burst in the last hour"),
+// gated on recency and combined with the stronger Axis 1-3 signals
+// rather than standing alone.
+func DetectPushBurst(repos []Repo, minRepos int, window time.Duration) (PushBurst, bool) {
+	pushed := make([]Repo, 0, len(repos))
+	for _, r := range repos {
+		if !r.PushedAt.IsZero() {
+			pushed = append(pushed, r)
+		}
+	}
+	if len(pushed) < minRepos {
+		return PushBurst{}, false
+	}
+	// Sort newest-first so a window anchored on entry i covers every
+	// later entry pushed within `window` before it.
+	sort.Slice(pushed, func(i, j int) bool {
+		return pushed[i].PushedAt.After(pushed[j].PushedAt)
+	})
+
+	var best PushBurst
+	for i := range pushed {
+		anchor := pushed[i].PushedAt
+		cluster := []string{pushed[i].Name}
+		oldest := anchor
+		for j := i + 1; j < len(pushed); j++ {
+			if anchor.Sub(pushed[j].PushedAt) <= window {
+				cluster = append(cluster, pushed[j].Name)
+				oldest = pushed[j].PushedAt
+			} else {
+				// Sorted desc: once one falls outside the window every
+				// later one does too.
+				break
+			}
+		}
+		if len(cluster) > best.Count {
+			best = PushBurst{
+				Count:  len(cluster),
+				Span:   anchor.Sub(oldest),
+				Newest: anchor,
+				Repos:  cluster,
+			}
+		}
+	}
+	if best.Count < minRepos {
+		return PushBurst{}, false
+	}
+	return best, true
+}
+
+// ---------------------------------------------------------------------------
+// Axis 1 — ignition catalog
+// ---------------------------------------------------------------------------
+
+// ignitionClass groups auto-execution surfaces by how they fire, so
+// the report can explain *why* a path is dangerous rather than just
+// listing it.
+type ignitionClass string
+
+const (
+	classAgentHook  ignitionClass = "AI-agent / editor session hook"
+	classAgentInstr ignitionClass = "AI-agent instruction / rules file"
+	classEditorTask ignitionClass = "editor auto-run task"
+	classDevcontain ignitionClass = "devcontainer lifecycle hook"
+	classPackage    ignitionClass = "package lifecycle script"
+	classVCSHook    ignitionClass = "committed VCS hook"
+	classCI         ignitionClass = "CI workflow"
+	classDropper    ignitionClass = "known dropper filename"
+)
+
+// ignitionRule is one entry in the data-driven ignition catalog. Glob
+// is matched against repo-root-relative tree paths via path.Match
+// (so `*` never crosses a `/`). Weight is the *base* score a bare
+// match contributes — deliberately low (or zero) for ubiquitous,
+// usually-legitimate surfaces, because Axis 2/3 are what escalate.
+// Adding a future ignition location is a one-line edit here, not a
+// code change — this is the generic-detection contract from the
+// ROADMAP design.
+type ignitionRule struct {
+	Glob   string
+	Class  ignitionClass
+	Weight int
+	Note   string
+}
+
+// ignitionCatalog is the seed list of auto-execution surfaces. The
+// weights encode "how surprising is this in an established repo":
+//
+//   - wIgnitionNamedIOC for the literal Shai-Hulud dropper name (a
+//     strong, specific seed — but still just one row).
+//   - wIgnitionAgentHook for AI-agent / editor hooks that can auto-run
+//     a command or process (Claude/Gemini session hooks, MCP, Aider,
+//     Continue): rarer than package manifests, and the code-execution
+//     vector in the reference incident.
+//   - 0 for ubiquitous or prompt-only surfaces (package.json, .vscode,
+//     workflows, husky, AND instruction/rules files like
+//     copilot-instructions.md / .cursor/rules / .windsurfrules /
+//     AGENTS.md): listed in the inventory so the user sees their
+//     attack surface, but they don't inflate the score on their own —
+//     otherwise every modern repo would cry "watch". They escalate
+//     only when Axis 2 (oversized / obfuscated blob) fires on them.
+var ignitionCatalog = []ignitionRule{
+	// Known dropper filename — the 2026-06 reference IOC. One row,
+	// high weight; the rest of the engine is name-agnostic.
+	{Glob: ".github/setup.js", Class: classDropper, Weight: wIgnitionNamedIOC, Note: "matches the reference Miasma / Shai-Hulud dropper filename"},
+
+	// AI-agent / editor session hooks that can auto-run a shell command
+	// or launch a process on repo open — the real code-execution
+	// vector. Weight 1 (a mild heads-up; Axis 2/3 escalate).
+	{Glob: ".claude/settings.json", Class: classAgentHook, Weight: wIgnitionAgentHook, Note: "Claude session hooks run on SessionStart"},
+	{Glob: ".claude/settings.local.json", Class: classAgentHook, Weight: wIgnitionAgentHook, Note: "Claude session hooks run on SessionStart"},
+	{Glob: ".gemini/settings.json", Class: classAgentHook, Weight: wIgnitionAgentHook, Note: "Gemini session hooks run on open"},
+	{Glob: ".aider.conf.yml", Class: classAgentHook, Weight: wIgnitionAgentHook, Note: "Aider config may run commands"},
+	{Glob: ".mcp.json", Class: classAgentHook, Weight: wIgnitionAgentHook, Note: "MCP server config — may launch processes"},
+	{Glob: ".vscode/mcp.json", Class: classAgentHook, Weight: wIgnitionAgentHook, Note: "MCP server config — may launch processes"},
+	{Glob: ".continue/*.json", Class: classAgentHook, Weight: wIgnitionAgentHook, Note: "Continue config may run commands"},
+
+	// AI-agent instruction / rules files — prompt-injection surface,
+	// NOT direct code execution, and increasingly ubiquitous (GitHub
+	// promotes copilot-instructions.md). Weight 0: listed in the
+	// inventory so the user sees the surface, but they never drive the
+	// verdict on their own — that's what kept the real (now-cleaned)
+	// victim repos out of a spurious "watch".
+	{Glob: ".cursor/rules/*.mdc", Class: classAgentInstr, Weight: 0, Note: "Cursor rules auto-applied into agent context"},
+	{Glob: ".github/copilot-instructions.md", Class: classAgentInstr, Weight: 0, Note: "Copilot instructions auto-loaded into context"},
+	{Glob: ".windsurfrules", Class: classAgentInstr, Weight: 0, Note: "Windsurf rules auto-loaded into context"},
+	{Glob: "AGENTS.md", Class: classAgentInstr, Weight: 0, Note: "agent instructions auto-loaded into context"},
+
+	// Editor auto-run.
+	{Glob: ".vscode/tasks.json", Class: classEditorTask, Weight: 0, Note: "may carry runOn: folderOpen"},
+	{Glob: ".vscode/settings.json", Class: classEditorTask, Weight: 0, Note: "editor settings"},
+	{Glob: ".vscode/launch.json", Class: classEditorTask, Weight: 0, Note: "debug launch config"},
+
+	// Devcontainer lifecycle (postCreate / onCreate / postStart).
+	{Glob: ".devcontainer/devcontainer.json", Class: classDevcontain, Weight: 0, Note: "lifecycle commands run on container build"},
+	{Glob: ".devcontainer/*/devcontainer.json", Class: classDevcontain, Weight: 0, Note: "lifecycle commands run on container build"},
+
+	// Package lifecycle scripts (preinstall / postinstall / prepare).
+	{Glob: "package.json", Class: classPackage, Weight: 0, Note: "inspect lifecycle scripts (pre/post-install, prepare)"},
+
+	// Committed VCS hooks.
+	{Glob: ".husky/*", Class: classVCSHook, Weight: 0, Note: "git hook runs on commit / install"},
+
+	// CI workflows — the home of capability escalation (Axis 4).
+	{Glob: ".github/workflows/*.yml", Class: classCI, Weight: 0, Note: "runs in CI; inspect permissions / triggers"},
+	{Glob: ".github/workflows/*.yaml", Class: classCI, Weight: 0, Note: "runs in CI; inspect permissions / triggers"},
+}
+
+// matchIgnition returns the first catalog rule whose glob matches the
+// given repo-root-relative path. The boolean is false when nothing
+// matches. path.Match treats `*` as not crossing `/`, which is exactly
+// per-segment matching — so ".github/workflows/*.yml" matches
+// ".github/workflows/ci.yml" but not a nested path.
+func matchIgnition(p string) (ignitionRule, bool) {
+	for _, rule := range ignitionCatalog {
+		if ok, _ := path.Match(rule.Glob, p); ok {
+			return rule, true
+		}
+	}
+	return ignitionRule{}, false
+}
+
+// ---------------------------------------------------------------------------
+// Scoring weights & verdict thresholds
+// ---------------------------------------------------------------------------
+
+const (
+	// Axis 1 base weights.
+	wIgnitionAgentHook      = 1
+	wIgnitionNamedIOC       = 4
+	wIgnitionNonDefaultOnly = 2 // ignition file on a side branch but not the default branch (divergence)
+
+	// Axis 2 — blob anomaly.
+	wBlobOversized    = 4
+	wBlobObfuscated   = 5
+	oversizeThreshold = 256 * 1024 // 256 KiB: absurd for a config / hook file (reference dropper was 4.3 MB)
+
+	// Axis 3 — provenance anomaly.
+	wProvUnsignedDelta = 3 // unsigned tip on a branch carrying an ignition file, in a repo that otherwise signs
+	wProvSpoofIdentity = 5 // tip forged under a bot / GitHub-Actions identity but not signed by GitHub
+
+	// Cross-axis bonus — the smoking gun: ignition + blob anomaly +
+	// provenance anomaly all on the same branch.
+	wCombinedSmokingGun = 4
+)
+
+// Verdict thresholds. A lone agent-hook config (weight 1) stays Clean
+// but listed in the inventory; multiple hooks reach Watch; an
+// oversized/obfuscated dropper with a forged tip lands in Compromised.
+const (
+	tWatch       = 2
+	tSuspicious  = 5
+	tCompromised = 10
+)
+
+// ---------------------------------------------------------------------------
+// Result model
+// ---------------------------------------------------------------------------
+
+// ScanVerdict is the severity tier the engine assigns to a repo.
+type ScanVerdict int
+
+const (
+	VerdictClean ScanVerdict = iota
+	VerdictWatch
+	VerdictSuspicious
+	VerdictCompromised
+)
+
+// String renders the verdict as a short label for the UI / logs.
+func (v ScanVerdict) String() string {
+	switch v {
+	case VerdictClean:
+		return "clean"
+	case VerdictWatch:
+		return "watch"
+	case VerdictSuspicious:
+		return "suspicious"
+	case VerdictCompromised:
+		return "likely compromised"
+	default:
+		return "unknown"
+	}
+}
+
+// verdictFor maps a total score to its tier.
+func verdictFor(score int) ScanVerdict {
+	switch {
+	case score >= tCompromised:
+		return VerdictCompromised
+	case score >= tSuspicious:
+		return VerdictSuspicious
+	case score >= tWatch:
+		return VerdictWatch
+	default:
+		return VerdictClean
+	}
+}
+
+// FindingAxis names which detection axis produced a Finding, so the
+// report can group evidence and the user can reason about it.
+type FindingAxis string
+
+const (
+	AxisIgnition   FindingAxis = "ignition"
+	AxisBlob       FindingAxis = "blob"
+	AxisProvenance FindingAxis = "provenance"
+)
+
+// Finding is one piece of explainable evidence. Weight is the score it
+// contributed (0 for inventory-only entries). Reason is a
+// human-readable, already-sanitized sentence — the user audits the
+// evidence, never a black-box number.
+type Finding struct {
+	Axis   FindingAxis
+	Branch string // "" when repo-wide
+	Path   string // "" when not file-specific
+	Weight int
+	Reason string
+}
+
+// BranchProvenance carries the tip-commit facts the engine reasons
+// about for Axis 3. Identity fields fall back to the raw git name when
+// GitHub can't link the commit to a user account.
+type BranchProvenance struct {
+	Name      string
+	IsDefault bool
+
+	TipOID      string
+	TipHeadline string
+	CommittedAt time.Time
+
+	AuthorName    string
+	AuthorLogin   string
+	CommitterName string
+
+	// Signed is true when the tip carries a valid signature; Bot is
+	// true when the author/committer identity looks like the
+	// GitHub-Actions bot; SignedByGitHub distinguishes a *genuine*
+	// Actions commit (GitHub-signed) from a forgery that merely wears
+	// the bot's name.
+	SignatureState string
+	Signed         bool
+	Bot            bool
+	SignedByGitHub bool
+}
+
+// RepoScan is the full, UI-facing result of FetchRepoScan.
+type RepoScan struct {
+	Owner string
+	Name  string
+	URL   string
+
+	DefaultBranch   string
+	BranchesScanned int
+	BranchesTotal   int
+	Truncated       bool // some branches / trees were not fully walked (bounded fan-out)
+
+	Findings []Finding
+	Branches []BranchProvenance
+
+	Score   int
+	Verdict ScanVerdict
+}
+
+// IgnitionInventory returns the auto-execution surface (Axis 1),
+// de-duplicated to one entry per path — the report always lists this,
+// even on a Clean verdict, so the user sees what auto-executes in the
+// repo regardless of detection. The base ignition finding for a path
+// is emitted before any divergence finding for the same path, so the
+// first-seen entry is the surface description rather than the anomaly.
+func (s *RepoScan) IgnitionInventory() []Finding {
+	seen := map[string]bool{}
+	var out []Finding
+	for _, f := range s.Findings {
+		if f.Axis != AxisIgnition || f.Path == "" || seen[f.Path] {
+			continue
+		}
+		seen[f.Path] = true
+		out = append(out, f)
+	}
+	return out
+}
+
+// ScoredFindings returns the findings that contributed to the score
+// (Weight > 0), i.e. the actual evidence behind the verdict.
+func (s *RepoScan) ScoredFindings() []Finding {
+	var out []Finding
+	for _, f := range s.Findings {
+		if f.Weight > 0 {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Axis 2 — blob heuristics (pure)
+// ---------------------------------------------------------------------------
+
+// blobAnalysis holds the Axis-2 verdict for one matched ignition blob,
+// keyed by its git blob SHA so identical content shared across
+// branches is fetched and analysed once.
+type blobAnalysis struct {
+	Size    int
+	Fetched bool // content was actually pulled (within the size cap)
+	IsText  bool
+	Entropy float64
+	Markers []string // human-readable obfuscation markers, already plain ASCII
+}
+
+// maxBlobScanBytes caps how large a matched ignition blob we'll pull
+// for content analysis. Above it we still flag "oversized" (a strong
+// signal on its own) but skip entropy/marker inspection — no point
+// downloading a multi-megabyte dropper to confirm what its size
+// already told us.
+const maxBlobScanBytes = 1536 * 1024 // 1.5 MiB
+
+// shannonEntropy returns the Shannon entropy of b in bits per byte
+// (0..8). Minified / encrypted / packed payloads sit high (> ~5);
+// ordinary source and config sit lower.
+func shannonEntropy(b []byte) float64 {
+	if len(b) == 0 {
+		return 0
+	}
+	var counts [256]int
+	for _, c := range b {
+		counts[c]++
+	}
+	n := float64(len(b))
+	var h float64
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / n
+		h -= p * math.Log2(p)
+	}
+	return h
+}
+
+// looksObfuscated inspects content (a matched ignition file's bytes)
+// for the filename-agnostic tells of a packed / encoded payload, and
+// returns the human-readable markers it found. This is the axis that
+// catches *future* variants: rename the dropper all you like, an
+// obfuscated blob wired into an ignition point still trips here.
+func looksObfuscated(content []byte) []string {
+	var markers []string
+	lower := strings.ToLower(string(content))
+
+	add := func(m string) { markers = append(markers, m) }
+
+	// Dynamic-evaluation / decode primitives.
+	if strings.Contains(lower, "eval(") {
+		add("eval() call")
+	}
+	if strings.Contains(lower, "new function(") {
+		add("dynamic Function() constructor")
+	}
+	if strings.Contains(lower, "atob(") || (strings.Contains(lower, "buffer.from(") && strings.Contains(lower, "base64")) {
+		add("base64 decode at runtime")
+	}
+	if strings.Contains(lower, "fromcharcode") {
+		add("String.fromCharCode packing")
+	}
+	if strings.Contains(lower, "child_process") || strings.Contains(lower, "execsync(") || strings.Contains(lower, "spawnsync(") {
+		add("spawns a child process")
+	}
+	// Alternate-runtime loader to dodge Node-based monitoring (seen
+	// in the reference payload). Specific tokens only — a bare "bun"
+	// substring would false-positive on "bundle" etc.
+	if strings.Contains(lower, "bunx") || strings.Contains(lower, "bun run") || strings.Contains(lower, "bun install") {
+		add("invokes the Bun runtime")
+	}
+
+	// Dense hex / unicode escapes (\x41\x42… style packing).
+	if escapeRuns := strings.Count(lower, `\x`) + strings.Count(lower, `\u`); escapeRuns >= 16 {
+		add(fmt.Sprintf("dense \\x/\\u escapes (%d)", escapeRuns))
+	}
+
+	// A single very long line is the classic minified / one-blob tell.
+	if longestLine(content) >= 2000 {
+		add("very long single line (minified / one-blob payload)")
+	}
+
+	// High entropy over a non-trivial body — encrypted / packed.
+	if len(content) >= 512 {
+		if e := shannonEntropy(content); e >= 5.3 {
+			add(fmt.Sprintf("high entropy (%.1f bits/byte)", e))
+		}
+	}
+
+	return markers
+}
+
+// longestLine returns the length in bytes of the longest line in b.
+func longestLine(b []byte) int {
+	longest, cur := 0, 0
+	for _, c := range b {
+		if c == '\n' {
+			if cur > longest {
+				longest = cur
+			}
+			cur = 0
+			continue
+		}
+		cur++
+	}
+	if cur > longest {
+		longest = cur
+	}
+	return longest
+}
+
+// isTextContent reports whether b looks like text (valid UTF-8 with a
+// low proportion of C0 control bytes). A config / hook file that
+// decodes as binary is itself suspicious.
+func isTextContent(b []byte) bool {
+	if !utf8.Valid(b) {
+		return false
+	}
+	ctrl := 0
+	for _, c := range b {
+		if c < 0x09 || (c > 0x0d && c < 0x20) {
+			ctrl++
+		}
+	}
+	return len(b) == 0 || float64(ctrl)/float64(len(b)) < 0.01
+}
+
+// ---------------------------------------------------------------------------
+// Engine — pure scoring over gathered facts
+// ---------------------------------------------------------------------------
+
+// ignitionMatch records one catalog hit found while walking a branch's
+// tree: the path, its blob size + SHA (from the tree entry), and the
+// rule it matched.
+type ignitionMatch struct {
+	Path    string
+	Size    int
+	BlobSHA string
+	Rule    ignitionRule
+}
+
+// scanBranch bundles a branch's tip provenance with the ignition
+// matches found in its tree.
+type scanBranch struct {
+	Prov    BranchProvenance
+	Matches []ignitionMatch
+}
+
+// scanInput is the gathered, network-sourced intermediate that
+// evaluateScan reduces to a RepoScan. Splitting gather (FetchRepoScan)
+// from score (evaluateScan) keeps the scoring engine a pure,
+// table-testable function.
+type scanInput struct {
+	Owner, Name, URL string
+	DefaultBranch    string
+	BranchesTotal    int
+	Truncated        bool
+	Branches         []scanBranch
+	Blobs            map[string]blobAnalysis // keyed by blob SHA
+}
+
+// evaluateScan is the pure heart of the detector: it turns gathered
+// facts into weighted, explainable findings and a verdict. No I/O — so
+// the whole scoring matrix is unit-tested without touching the
+// network (see scan_test.go).
+func evaluateScan(in scanInput) *RepoScan {
+	s := &RepoScan{
+		Owner:         in.Owner,
+		Name:          in.Name,
+		URL:           in.URL,
+		DefaultBranch: in.DefaultBranch,
+		BranchesTotal: in.BranchesTotal,
+		Truncated:     in.Truncated,
+	}
+
+	// Signed-history baseline: only penalise an unsigned tip when the
+	// repo otherwise signs (an all-unsigned repo just doesn't sign —
+	// not a signal). Also note which branches carry any ignition file.
+	// anySigned establishes the "this repo signs its commits" baseline
+	// for the unsigned-delta signal — but ONLY genuine author
+	// signatures count (Signed && !SignedByGitHub). A GitHub-signed tip
+	// (a web-UI commit / squash-merge GitHub auto-signs) does NOT mean
+	// the maintainer GPG-signs, so a gh-signed `main` next to an
+	// ordinary unsigned feature branch must not read as a signing
+	// delta — that was the false-positive the real (cleaned) victim
+	// repo exposed.
+	anySigned := false
+	// branchHasWeighted tracks branches carrying a *meaningful* ignition
+	// file (rule weight > 0 — a code-executing agent hook or a known
+	// dropper), NOT a ubiquitous / prompt-only weight-0 surface.
+	// Provenance anomalies (unsigned-delta) gate on this so an ordinary
+	// unsigned feature branch doesn't trip the scan just because it
+	// also carries the repo's CI workflows or a copilot-instructions
+	// file.
+	branchHasWeighted := map[string]bool{}
+	for _, b := range in.Branches {
+		s.Branches = append(s.Branches, b.Prov)
+		if b.Prov.Signed && !b.Prov.SignedByGitHub {
+			anySigned = true
+		}
+		for _, m := range b.Matches {
+			if m.Rule.Weight > 0 {
+				branchHasWeighted[b.Prov.Name] = true
+			}
+		}
+	}
+	s.BranchesScanned = len(in.Branches)
+
+	add := func(f Finding) {
+		f.Reason = Sanitize(f.Reason)
+		f.Path = Sanitize(f.Path)
+		f.Branch = Sanitize(f.Branch)
+		s.Findings = append(s.Findings, f)
+		s.Score += f.Weight
+	}
+
+	// Aggregate matches by path so a file present on many branches is
+	// listed (and base-weighted) once, not once per branch. Without
+	// this, a repo like bubbletea (8 workflows × 20 branches) emits 160
+	// findings and a dropper on N branches would multiply its base
+	// weight by N — both meaningless. Blob anomaly is then evaluated
+	// per distinct content (blob SHA), provenance per branch.
+	type matchAgg struct {
+		rule      ignitionRule
+		onDefault bool
+		size      int
+		bySHA     map[string][]string // blob SHA -> branches carrying that content
+	}
+	aggs := map[string]*matchAgg{}
+	var pathOrder []string
+	for _, b := range in.Branches {
+		for _, m := range b.Matches {
+			a := aggs[m.Path]
+			if a == nil {
+				a = &matchAgg{rule: m.Rule, bySHA: map[string][]string{}}
+				aggs[m.Path] = a
+				pathOrder = append(pathOrder, m.Path)
+			}
+			a.bySHA[m.BlobSHA] = append(a.bySHA[m.BlobSHA], b.Prov.Name)
+			if m.Size > a.size {
+				a.size = m.Size
+			}
+			if b.Prov.IsDefault {
+				a.onDefault = true
+			}
+		}
+	}
+
+	branchHasBlobAnomaly := map[string]bool{}
+	for _, p := range pathOrder {
+		a := aggs[p]
+
+		// Axis 1 — base ignition (one inventory entry per path).
+		add(Finding{
+			Axis:   AxisIgnition,
+			Path:   p,
+			Weight: a.rule.Weight,
+			Reason: fmt.Sprintf("%s — %s", a.rule.Class, a.rule.Note),
+		})
+
+		// Axis 1 — side-branch divergence: a *meaningful* file (weight
+		// > 0) that lives on side branches but never on the default
+		// branch. A workflow added on a feature branch is normal and
+		// must not score; a dropper that exists only on `next` is the
+		// real signal.
+		if !a.onDefault && a.rule.Weight > 0 {
+			add(Finding{
+				Axis:   AxisIgnition,
+				Path:   p,
+				Weight: wIgnitionNonDefaultOnly,
+				Reason: fmt.Sprintf("present on %s but not on the default branch %q (divergence)", branchList(uniqueBranches(a.bySHA)), in.DefaultBranch),
+			})
+		}
+
+		// Axis 2 — blob anomaly, once per distinct content.
+		for sha, carriers := range a.bySHA {
+			ba := in.Blobs[sha]
+			anomalous := false
+			if ba.Size > oversizeThreshold || a.size > oversizeThreshold {
+				sz := ba.Size
+				if sz == 0 {
+					sz = a.size
+				}
+				add(Finding{Axis: AxisBlob, Path: p, Weight: wBlobOversized,
+					Reason: fmt.Sprintf("oversized for its type: %s", humanBytes(sz))})
+				anomalous = true
+			}
+			if len(ba.Markers) > 0 {
+				add(Finding{Axis: AxisBlob, Path: p, Weight: wBlobObfuscated,
+					Reason: "obfuscation markers: " + strings.Join(ba.Markers, ", ")})
+				anomalous = true
+			}
+			if ba.Fetched && !ba.IsText {
+				add(Finding{Axis: AxisBlob, Path: p, Weight: wBlobObfuscated,
+					Reason: "binary content inside a text-config file"})
+				anomalous = true
+			}
+			if anomalous {
+				for _, br := range carriers {
+					branchHasBlobAnomaly[br] = true
+				}
+			}
+		}
+	}
+
+	// Axis 3 — provenance anomaly + the cross-axis smoking gun, per
+	// branch (each forged / unsigned tip is its own evidence).
+	for _, b := range in.Branches {
+		provAnomaly := false
+		switch {
+		case b.Prov.Bot && !b.Prov.SignedByGitHub:
+			// Forged: wears the GitHub-Actions identity but GitHub
+			// didn't sign it. A real Actions commit is GitHub-signed.
+			add(Finding{
+				Axis:   AxisProvenance,
+				Branch: b.Prov.Name,
+				Weight: wProvSpoofIdentity,
+				Reason: fmt.Sprintf("tip %s forged as %q but not signed by GitHub", shortOID(b.Prov.TipOID), identityOf(b.Prov)),
+			})
+			provAnomaly = true
+		case anySigned && !b.Prov.Signed && (branchHasWeighted[b.Prov.Name] || branchHasBlobAnomaly[b.Prov.Name]):
+			// Unsigned tip on a branch that carries a *meaningful*
+			// ignition file or an anomalous blob, in a repo that
+			// otherwise signs its commits. Gating on weight>0 / anomaly
+			// keeps ordinary unsigned feature branches from scoring.
+			add(Finding{
+				Axis:   AxisProvenance,
+				Branch: b.Prov.Name,
+				Weight: wProvUnsignedDelta,
+				Reason: fmt.Sprintf("tip %s is unsigned while the repo otherwise signs its commits", shortOID(b.Prov.TipOID)),
+			})
+			provAnomaly = true
+		}
+
+		if branchHasBlobAnomaly[b.Prov.Name] && provAnomaly {
+			add(Finding{
+				Axis:   AxisProvenance,
+				Branch: b.Prov.Name,
+				Weight: wCombinedSmokingGun,
+				Reason: fmt.Sprintf("an anomalous payload and an anomalous commit tip coincide on branch %q", b.Prov.Name),
+			})
+		}
+	}
+
+	s.Verdict = verdictFor(s.Score)
+	return s
+}
+
+// uniqueBranches returns the sorted, de-duplicated set of branch names
+// across every content SHA of an aggregated path match.
+func uniqueBranches(bySHA map[string][]string) []string {
+	set := map[string]bool{}
+	for _, branches := range bySHA {
+		for _, b := range branches {
+			set[b] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for b := range set {
+		out = append(out, b)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// branchList renders a branch-name set for a finding reason: a single
+// name reads "branch \"x\"", several read "branches x, y, z".
+func branchList(names []string) string {
+	switch len(names) {
+	case 0:
+		return "a side branch"
+	case 1:
+		return fmt.Sprintf("branch %q", names[0])
+	default:
+		return "branches " + strings.Join(names, ", ")
+	}
+}
+
+// identityOf returns the most specific identity string for a branch
+// tip — login if GitHub linked one, else the raw committer/author
+// name.
+func identityOf(p BranchProvenance) string {
+	switch {
+	case p.AuthorLogin != "":
+		return p.AuthorLogin
+	case p.AuthorName != "":
+		return p.AuthorName
+	case p.CommitterName != "":
+		return p.CommitterName
+	default:
+		return "unknown"
+	}
+}
+
+// looksLikeBot reports whether any identity field on a tip looks like
+// the GitHub-Actions bot — the identity the reference worm forged.
+func looksLikeBot(authorName, committerName, authorLogin string) bool {
+	for _, id := range []string{authorName, committerName, authorLogin} {
+		l := strings.ToLower(strings.TrimSpace(id))
+		if l == "github-actions" || l == "github-actions[bot]" || strings.HasPrefix(l, "github-actions") {
+			return true
+		}
+	}
+	return false
+}
+
+// shortOID truncates a git OID to the conventional 7-char short form.
+func shortOID(oid string) string {
+	if len(oid) > 7 {
+		return oid[:7]
+	}
+	return oid
+}
+
+// humanBytes renders a byte count compactly (KiB / MiB) for findings.
+func humanBytes(n int) string {
+	switch {
+	case n >= 1024*1024:
+		return fmt.Sprintf("%.1f MiB", float64(n)/(1024*1024))
+	case n >= 1024:
+		return fmt.Sprintf("%.0f KiB", float64(n)/1024)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tier B — network gather (GraphQL refs + REST trees/blobs)
+// ---------------------------------------------------------------------------
+
+// scanBranchConcurrency bounds the per-branch REST tree fan-out, same
+// discipline as watchedRepoConcurrency: enough to amortise serial
+// latency, small enough that a many-branched repo can't burst-flood
+// GitHub.
+const scanBranchConcurrency = 8
+
+// maxScanBranches caps how many branches we walk trees for. The
+// default branch is always included; if a repo has more branches than
+// this we scan the first maxScanBranches (default first) and flag the
+// result Truncated. Most personal repos have a handful of branches;
+// the cap is a safety net for fork-heavy or bot-managed repos.
+const maxScanBranches = 20
+
+// maxBlobFetches caps how many distinct matched-ignition blobs we pull
+// for content analysis in a single scan.
+const maxBlobFetches = 12
+
+// scanRefsQuery enumerates a repository's branches with each tip's
+// provenance (Axis 3) plus the tip's tree OID, which feeds the REST
+// get-a-tree call (a real tree SHA, avoiding any ref-resolution
+// ambiguity). One GraphQL round-trip regardless of branch count.
+type scanRefsQuery struct {
+	Repository struct {
+		NameWithOwner    githubv4.String
+		URL              githubv4.String `graphql:"url"`
+		DefaultBranchRef *struct {
+			Name githubv4.String
+		}
+		Refs struct {
+			TotalCount githubv4.Int
+			Nodes      []struct {
+				Name   githubv4.String
+				Target struct {
+					Commit struct {
+						OID             githubv4.GitObjectID `graphql:"oid"`
+						MessageHeadline githubv4.String
+						CommittedDate   githubv4.DateTime
+						Tree            struct {
+							OID githubv4.GitObjectID `graphql:"oid"`
+						}
+						Author struct {
+							Name githubv4.String
+							User *struct {
+								Login githubv4.String
+							}
+						}
+						Committer struct {
+							Name githubv4.String
+						}
+						// Signature is null on unsigned commits. State is the
+						// GitSignatureState enum (VALID / UNSIGNED / INVALID /
+						// …) decoded as a string; WasSignedByGitHub separates a
+						// genuine Actions commit from a forgery wearing its name.
+						Signature *struct {
+							IsValid           githubv4.Boolean
+							State             githubv4.String
+							WasSignedByGitHub githubv4.Boolean
+						}
+					} `graphql:"... on Commit"`
+				}
+			}
+		} `graphql:"refs(refPrefix: \"refs/heads/\", first: 100, orderBy: {field: ALPHABETICAL, direction: ASC})"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// FetchRepoScan runs the on-demand supply-chain integrity scan for one
+// repository and returns a scored, explainable RepoScan. Read-only:
+// it inspects branches, file trees and matched-ignition blobs but
+// never mutates the repo.
+//
+// Shape (one GraphQL branch + a bounded REST fan-out, the same idiom
+// as FetchRepoDetail's GraphQL+REST split):
+//
+//  1. GraphQL scanRefsQuery — every branch tip's provenance + tree OID
+//     in a single cheap round-trip (Axis 3).
+//  2. REST get-a-tree per branch (recursive), bounded by
+//     scanBranchConcurrency and maxScanBranches — match the ignition
+//     catalog client-side, which is inherently generic (Axis 1) and
+//     yields blob sizes for free (Axis 2 size).
+//  3. REST get-a-blob for each distinct matched ignition file, bounded
+//     by maxBlobFetches — entropy / obfuscation markers (Axis 2
+//     content).
+//
+// Then the pure evaluateScan reduces the gathered facts to findings +
+// verdict.
+func (c *Client) FetchRepoScan(ctx context.Context, owner, name string) (*RepoScan, error) {
+	var q scanRefsQuery
+	vars := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(name),
+	}
+	if err := c.gql.Query(ctx, &q, vars); err != nil {
+		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+
+	repoURL := Sanitize(string(q.Repository.URL))
+	defaultBranch := ""
+	if q.Repository.DefaultBranchRef != nil {
+		defaultBranch = Sanitize(string(q.Repository.DefaultBranchRef.Name))
+	}
+
+	// Build the provenance list and pick which branches to walk: the
+	// default branch first, then the rest up to maxScanBranches.
+	type branchPlan struct {
+		prov    BranchProvenance
+		treeOID string
+	}
+	var plans []branchPlan
+	branchesTotal := int(q.Repository.Refs.TotalCount)
+	for _, n := range q.Repository.Refs.Nodes {
+		cm := n.Target.Commit
+		bname := Sanitize(string(n.Name))
+		prov := BranchProvenance{
+			Name:          bname,
+			IsDefault:     bname == defaultBranch,
+			TipOID:        string(cm.OID),
+			TipHeadline:   Sanitize(string(cm.MessageHeadline)),
+			CommittedAt:   cm.CommittedDate.Time,
+			AuthorName:    Sanitize(string(cm.Author.Name)),
+			CommitterName: Sanitize(string(cm.Committer.Name)),
+		}
+		if cm.Author.User != nil {
+			prov.AuthorLogin = Sanitize(string(cm.Author.User.Login))
+		}
+		if cm.Signature != nil {
+			prov.SignatureState = Sanitize(string(cm.Signature.State))
+			prov.Signed = bool(cm.Signature.IsValid)
+			prov.SignedByGitHub = bool(cm.Signature.WasSignedByGitHub)
+		}
+		prov.Bot = looksLikeBot(prov.AuthorName, prov.CommitterName, prov.AuthorLogin)
+		plans = append(plans, branchPlan{prov: prov, treeOID: string(cm.Tree.OID)})
+	}
+
+	// Default branch first so a truncated scan always covers it.
+	sort.SliceStable(plans, func(i, j int) bool {
+		if plans[i].prov.IsDefault != plans[j].prov.IsDefault {
+			return plans[i].prov.IsDefault
+		}
+		return false
+	})
+
+	truncated := false
+	if len(plans) > maxScanBranches {
+		plans = plans[:maxScanBranches]
+		truncated = true
+	}
+
+	// REST get-a-tree per branch, bounded fan-out. Dedupe by tree OID
+	// so branches that share a tree (no divergence) are walked once.
+	type treeResult struct {
+		entries   []treeEntry
+		truncated bool
+	}
+	treeCache := map[string]treeResult{}
+	var treeMu sync.Mutex
+	branches := make([]scanBranch, len(plans))
+
+	sem := make(chan struct{}, scanBranchConcurrency)
+	var wg sync.WaitGroup
+	var fetchErr error
+	var errMu sync.Mutex
+	for i := range plans {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			p := plans[idx]
+			treeMu.Lock()
+			tr, cached := treeCache[p.treeOID]
+			treeMu.Unlock()
+			if !cached {
+				entries, treeTrunc, err := c.fetchTree(ctx, owner, name, p.treeOID)
+				if err != nil {
+					errMu.Lock()
+					if fetchErr == nil {
+						fetchErr = err
+					}
+					errMu.Unlock()
+					return
+				}
+				tr = treeResult{entries: entries, truncated: treeTrunc}
+				treeMu.Lock()
+				treeCache[p.treeOID] = tr
+				treeMu.Unlock()
+			}
+
+			var matches []ignitionMatch
+			for _, e := range tr.entries {
+				if e.typ != "blob" {
+					continue
+				}
+				if rule, ok := matchIgnition(e.path); ok {
+					matches = append(matches, ignitionMatch{
+						Path:    Sanitize(e.path),
+						Size:    e.size,
+						BlobSHA: e.sha,
+						Rule:    rule,
+					})
+				}
+			}
+			branches[idx] = scanBranch{Prov: p.prov, Matches: matches}
+		}(i)
+	}
+	wg.Wait()
+	if fetchErr != nil {
+		return nil, fetchErr
+	}
+
+	// A truncated tree means we may have missed a deeply-nested
+	// ignition file; surface that honestly rather than implying full
+	// coverage.
+	for _, tr := range treeCache {
+		if tr.truncated {
+			truncated = true
+		}
+	}
+
+	// REST get-a-blob for each distinct matched ignition file, bounded.
+	blobs := map[string]blobAnalysis{}
+	seen := map[string]bool{}
+	fetched := 0
+	for _, b := range branches {
+		for _, m := range b.Matches {
+			if seen[m.BlobSHA] {
+				continue
+			}
+			seen[m.BlobSHA] = true
+			ba := blobAnalysis{Size: m.Size}
+			if m.Size <= maxBlobScanBytes && fetched < maxBlobFetches {
+				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
+				if err == nil {
+					fetched++
+					ba.Fetched = true
+					ba.IsText = isTextContent(content)
+					ba.Entropy = shannonEntropy(content)
+					ba.Markers = looksObfuscated(content)
+				}
+				// A blob fetch failure is non-fatal: we still have the
+				// size signal from the tree entry.
+			}
+			blobs[m.BlobSHA] = ba
+		}
+	}
+
+	in := scanInput{
+		Owner:         Sanitize(owner),
+		Name:          Sanitize(name),
+		URL:           repoURL,
+		DefaultBranch: defaultBranch,
+		BranchesTotal: branchesTotal,
+		Truncated:     truncated,
+		Branches:      branches,
+		Blobs:         blobs,
+	}
+	return evaluateScan(in), nil
+}
+
+// treeEntry is one node from GitHub's get-a-tree response, reshaped.
+type treeEntry struct {
+	path string
+	typ  string // "blob" | "tree"
+	size int
+	sha  string
+}
+
+// restTree mirrors the get-a-tree response shape.
+type restTree struct {
+	Tree []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+		Size int    `json:"size"`
+		SHA  string `json:"sha"`
+	} `json:"tree"`
+	Truncated bool `json:"truncated"`
+}
+
+// fetchTree pulls a repository tree recursively by its tree SHA and
+// returns the reshaped entries plus GitHub's own truncation flag
+// (set when the tree exceeds the API's entry/size limits). Errors are
+// wrapped in *FetchError with the shared classifyErr reasons so the
+// scan surfaces the same actionable error screens as the rest of the
+// app.
+func (c *Client) fetchTree(ctx context.Context, owner, name, treeSHA string) ([]treeEntry, bool, error) {
+	reqURL := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1",
+		url.PathEscape(owner), url.PathEscape(name), url.PathEscape(treeSHA),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, false, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.rest.Do(req)
+	if err != nil {
+		return nil, false, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	defer resp.Body.Close()
+	if err := restStatusError(resp); err != nil {
+		return nil, false, err
+	}
+
+	var tree restTree
+	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
+		return nil, false, &FetchError{Reason: ReasonServer, Err: err}
+	}
+	entries := make([]treeEntry, 0, len(tree.Tree))
+	for _, t := range tree.Tree {
+		entries = append(entries, treeEntry{
+			path: t.Path,
+			typ:  t.Type,
+			size: t.Size,
+			sha:  t.SHA,
+		})
+	}
+	return entries, tree.Truncated, nil
+}
+
+// restBlob mirrors the get-a-blob response (base64-encoded content).
+type restBlob struct {
+	Content  string `json:"content"`
+	Encoding string `json:"encoding"`
+	Size     int    `json:"size"`
+}
+
+// fetchBlob pulls one blob's content by SHA and returns the decoded
+// bytes. Only called for matched ignition files within the size cap,
+// so the payload stays bounded.
+func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string) ([]byte, error) {
+	reqURL := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s/git/blobs/%s",
+		url.PathEscape(owner), url.PathEscape(name), url.PathEscape(sha),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.rest.Do(req)
+	if err != nil {
+		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	defer resp.Body.Close()
+	if err := restStatusError(resp); err != nil {
+		return nil, err
+	}
+
+	var blob restBlob
+	if err := json.NewDecoder(resp.Body).Decode(&blob); err != nil {
+		return nil, &FetchError{Reason: ReasonServer, Err: err}
+	}
+	if blob.Encoding != "base64" {
+		// Unexpected encoding — treat as empty rather than guessing.
+		return nil, nil
+	}
+	// GitHub wraps the base64 in newlines; strip them before decoding.
+	decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(blob.Content, "\n", ""))
+	if err != nil {
+		return nil, &FetchError{Reason: ReasonServer, Err: err}
+	}
+	return decoded, nil
+}
+
+// restStatusError classifies a non-2xx REST response into the shared
+// FetchError reasons, mirroring decodePRFilesPage so the scan's error
+// screens stay consistent with the diff viewer's. Returns nil on 2xx.
+func restStatusError(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	msg := Sanitize(strings.TrimSpace(string(body)))
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return &FetchError{Reason: ReasonRateLimitSecondary, Err: fmt.Errorf("github rest %s: %s", resp.Status, msg)}
+	case resp.StatusCode == http.StatusForbidden:
+		reason := ReasonRateLimitPrimary
+		if remaining := resp.Header.Get("X-RateLimit-Remaining"); remaining != "" && remaining != "0" {
+			reason = ReasonRateLimitSecondary
+		}
+		return &FetchError{Reason: reason, Err: fmt.Errorf("github rest %s: %s", resp.Status, msg)}
+	case resp.StatusCode == http.StatusUnauthorized:
+		return &FetchError{Reason: ReasonAuth, Err: fmt.Errorf("github rest %s: %s", resp.Status, msg)}
+	default:
+		return &FetchError{Reason: ReasonServer, Err: fmt.Errorf("github rest %s: %s", resp.Status, msg)}
+	}
+}

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -55,13 +55,14 @@ import (
 // Tier A — push-burst heuristic (pure, no network)
 // ---------------------------------------------------------------------------
 
-// pushBurstMinRepos / pushBurstWindow define the push-burst heuristic
-// (Axis 3, account-wide). The reference worm pushed to five repos in a
-// 49-second window from a single IP — humans almost never push to
-// three *distinct* repos inside a two-minute window, but a fan-out
-// script does. Kept tight so the dashboard banner stays a rare,
-// meaningful signal rather than firing on a normal cross-repo work
-// session.
+// pushBurstMinRepos / pushBurstWindow define the push-burst heuristic —
+// a separate, account-wide timing signal, NOT one of the per-repo
+// scoring axes (Axis 1-3). The reference worm pushed to five repos in a
+// 49-second window from a single IP — humans almost never push to three
+// *distinct* repos inside a two-minute window, but a fan-out script
+// does. Kept tight so the signal stays rare and meaningful rather than
+// firing on a normal cross-repo work session. See DetectPushBurst for
+// why this is currently unwired.
 const (
 	pushBurstMinRepos = 3
 	pushBurstWindow   = 2 * time.Minute
@@ -1013,67 +1014,82 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string) (*RepoSc
 		truncated = true
 	}
 
-	// REST get-a-tree per branch, bounded fan-out. Dedupe by tree OID
-	// so branches that share a tree (no divergence) are walked once.
+	// REST get-a-tree, fanned out over the *unique* tree OIDs (branches
+	// that share a tree — no divergence — are walked exactly once;
+	// collecting the unique set up front removes the concurrent
+	// cache-miss double-fetch a per-branch loop would allow). Bounded
+	// by scanBranchConcurrency. Sibling-cancellation: the first fetch
+	// error cancels the rest and is preserved, per the package's
+	// context.WithCancel + sync.Once fetch-error discipline.
 	type treeResult struct {
 		entries   []treeEntry
 		truncated bool
 	}
+	uniqueOIDs := make([]string, 0, len(plans))
+	seenOID := map[string]bool{}
+	for _, p := range plans {
+		if p.treeOID == "" || seenOID[p.treeOID] {
+			continue
+		}
+		seenOID[p.treeOID] = true
+		uniqueOIDs = append(uniqueOIDs, p.treeOID)
+	}
+
 	treeCache := map[string]treeResult{}
 	var treeMu sync.Mutex
-	branches := make([]scanBranch, len(plans))
 
+	fetchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var (
+		wg       sync.WaitGroup
+		errOnce  sync.Once
+		fetchErr error
+	)
 	sem := make(chan struct{}, scanBranchConcurrency)
-	var wg sync.WaitGroup
-	var fetchErr error
-	var errMu sync.Mutex
-	for i := range plans {
+	for _, oid := range uniqueOIDs {
 		wg.Add(1)
-		go func(idx int) {
+		go func(oid string) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-
-			p := plans[idx]
+			entries, treeTrunc, err := c.fetchTree(fetchCtx, owner, name, oid)
+			if err != nil {
+				errOnce.Do(func() {
+					fetchErr = err
+					cancel()
+				})
+				return
+			}
 			treeMu.Lock()
-			tr, cached := treeCache[p.treeOID]
+			treeCache[oid] = treeResult{entries: entries, truncated: treeTrunc}
 			treeMu.Unlock()
-			if !cached {
-				entries, treeTrunc, err := c.fetchTree(ctx, owner, name, p.treeOID)
-				if err != nil {
-					errMu.Lock()
-					if fetchErr == nil {
-						fetchErr = err
-					}
-					errMu.Unlock()
-					return
-				}
-				tr = treeResult{entries: entries, truncated: treeTrunc}
-				treeMu.Lock()
-				treeCache[p.treeOID] = tr
-				treeMu.Unlock()
-			}
-
-			var matches []ignitionMatch
-			for _, e := range tr.entries {
-				if e.typ != "blob" {
-					continue
-				}
-				if rule, ok := matchIgnition(e.path); ok {
-					matches = append(matches, ignitionMatch{
-						Path:    Sanitize(e.path),
-						Size:    e.size,
-						BlobSHA: e.sha,
-						Rule:    rule,
-					})
-				}
-			}
-			branches[idx] = scanBranch{Prov: p.prov, Matches: matches}
-		}(i)
+		}(oid)
 	}
 	wg.Wait()
 	if fetchErr != nil {
 		return nil, fetchErr
+	}
+
+	// Map tree results back onto branches and match the ignition
+	// catalog (pure, serial — no contention).
+	branches := make([]scanBranch, len(plans))
+	for i, p := range plans {
+		tr := treeCache[p.treeOID]
+		var matches []ignitionMatch
+		for _, e := range tr.entries {
+			if e.typ != "blob" {
+				continue
+			}
+			if rule, ok := matchIgnition(e.path); ok {
+				matches = append(matches, ignitionMatch{
+					Path:    Sanitize(e.path),
+					Size:    e.size,
+					BlobSHA: e.sha,
+					Rule:    rule,
+				})
+			}
+		}
+		branches[i] = scanBranch{Prov: p.prov, Matches: matches}
 	}
 
 	// A truncated tree means we may have missed a deeply-nested

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -1,0 +1,319 @@
+package github
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectPushBurst(t *testing.T) {
+	base := time.Date(2026, 6, 3, 22, 38, 0, 0, time.UTC)
+	mk := func(name string, offset time.Duration) Repo {
+		return Repo{Name: name, PushedAt: base.Add(offset)}
+	}
+
+	tests := []struct {
+		name      string
+		repos     []Repo
+		wantBurst bool
+		wantCount int
+	}{
+		{
+			name: "five repos within 49s is a burst",
+			repos: []Repo{
+				mk("a", 0),
+				mk("b", 10*time.Second),
+				mk("c", 20*time.Second),
+				mk("d", 35*time.Second),
+				mk("e", 49*time.Second),
+			},
+			wantBurst: true,
+			wantCount: 5,
+		},
+		{
+			name: "two repos never reaches the minimum",
+			repos: []Repo{
+				mk("a", 0),
+				mk("b", 5*time.Second),
+			},
+			wantBurst: false,
+		},
+		{
+			name: "three repos spread over a day is not a burst",
+			repos: []Repo{
+				mk("a", 0),
+				mk("b", 8*time.Hour),
+				mk("c", 20*time.Hour),
+			},
+			wantBurst: false,
+		},
+		{
+			name: "tight trio inside a quiet history is a burst",
+			repos: []Repo{
+				mk("old1", -200*time.Hour),
+				mk("old2", -100*time.Hour),
+				mk("a", 0),
+				mk("b", 15*time.Second),
+				mk("c", 40*time.Second),
+			},
+			wantBurst: true,
+			wantCount: 3,
+		},
+		{
+			name: "repos with zero PushedAt are ignored",
+			repos: []Repo{
+				{Name: "never"},
+				{Name: "never2"},
+				mk("a", 0),
+				mk("b", 10*time.Second),
+			},
+			wantBurst: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := DetectPushBurst(tt.repos, pushBurstMinRepos, pushBurstWindow)
+			if ok != tt.wantBurst {
+				t.Fatalf("DetectPushBurst ok = %v, want %v (got %+v)", ok, tt.wantBurst, got)
+			}
+			if ok && got.Count != tt.wantCount {
+				t.Errorf("burst count = %d, want %d", got.Count, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestMatchIgnition(t *testing.T) {
+	tests := []struct {
+		path      string
+		wantMatch bool
+		wantClass ignitionClass
+	}{
+		{".github/setup.js", true, classDropper},
+		{".claude/settings.json", true, classAgentHook},
+		{".cursor/rules/setup.mdc", true, classAgentInstr},
+		{".github/copilot-instructions.md", true, classAgentInstr},
+		{".github/workflows/ci.yml", true, classCI},
+		{".vscode/tasks.json", true, classEditorTask},
+		{"package.json", true, classPackage},
+		{".devcontainer/devcontainer.json", true, classDevcontain},
+		// Nested path must NOT match a single-segment glob.
+		{".github/workflows/nested/ci.yml", false, ""},
+		{"src/index.js", false, ""},
+		{"README.md", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			rule, ok := matchIgnition(tt.path)
+			if ok != tt.wantMatch {
+				t.Fatalf("matchIgnition(%q) ok = %v, want %v", tt.path, ok, tt.wantMatch)
+			}
+			if ok && rule.Class != tt.wantClass {
+				t.Errorf("class = %q, want %q", rule.Class, tt.wantClass)
+			}
+		})
+	}
+}
+
+func TestShannonEntropy(t *testing.T) {
+	if e := shannonEntropy(nil); e != 0 {
+		t.Errorf("entropy(nil) = %v, want 0", e)
+	}
+	if e := shannonEntropy([]byte("aaaaaaaa")); e != 0 {
+		t.Errorf("entropy(uniform byte) = %v, want 0", e)
+	}
+	// Two equally-likely symbols → 1 bit/byte.
+	if e := shannonEntropy([]byte("abababab")); e < 0.99 || e > 1.01 {
+		t.Errorf("entropy(two symbols) = %v, want ~1.0", e)
+	}
+}
+
+func TestLooksObfuscated(t *testing.T) {
+	benign := []byte(`{"hooks":{"SessionStart":"echo hello"}}`)
+	if m := looksObfuscated(benign); len(m) != 0 {
+		t.Errorf("benign config flagged with markers %v", m)
+	}
+
+	packed := []byte(`const x = eval(atob("ZWNobyBwd25lZA==")); require("child_process").execSync(x)`)
+	m := looksObfuscated(packed)
+	joined := strings.Join(m, " | ")
+	for _, want := range []string{"eval", "base64", "child process"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("packed payload missing marker %q (got %v)", want, m)
+		}
+	}
+
+	longLine := []byte("var a=" + strings.Repeat("0123456789", 250) + ";")
+	if m := looksObfuscated(longLine); len(m) == 0 {
+		t.Errorf("very long single line not flagged")
+	}
+}
+
+func TestIsTextContent(t *testing.T) {
+	if !isTextContent([]byte("plain ascii config\n")) {
+		t.Error("ascii not recognised as text")
+	}
+	if !isTextContent(nil) {
+		t.Error("empty content should count as text")
+	}
+	if isTextContent([]byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe}) {
+		t.Error("binary content recognised as text")
+	}
+}
+
+// --- engine: verdict matrix ---------------------------------------------
+
+func provBranch(name string, isDefault bool) BranchProvenance {
+	return BranchProvenance{
+		Name:           name,
+		IsDefault:      isDefault,
+		TipOID:         "deadbeefcafebabe",
+		Signed:         true,
+		SignedByGitHub: false,
+	}
+}
+
+func TestEvaluateScanClean(t *testing.T) {
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 1,
+		Branches: []scanBranch{
+			{
+				Prov: provBranch("main", true),
+				Matches: []ignitionMatch{
+					{Path: "package.json", Size: 1200, BlobSHA: "p", Rule: ignitionRule{Glob: "package.json", Class: classPackage, Weight: 0}},
+					{Path: ".vscode/tasks.json", Size: 800, BlobSHA: "v", Rule: ignitionRule{Glob: ".vscode/tasks.json", Class: classEditorTask, Weight: 0}},
+				},
+			},
+		},
+		Blobs: map[string]blobAnalysis{
+			"p": {Size: 1200, Fetched: true, IsText: true},
+			"v": {Size: 800, Fetched: true, IsText: true},
+		},
+	}
+	got := evaluateScan(in)
+	if got.Verdict != VerdictClean {
+		t.Fatalf("verdict = %v, want clean (score %d, findings %+v)", got.Verdict, got.Score, got.Findings)
+	}
+	if got.Score != 0 {
+		t.Errorf("score = %d, want 0", got.Score)
+	}
+	if len(got.IgnitionInventory()) != 2 {
+		t.Errorf("inventory = %d, want 2", len(got.IgnitionInventory()))
+	}
+	if len(got.ScoredFindings()) != 0 {
+		t.Errorf("scored findings = %d, want 0", len(got.ScoredFindings()))
+	}
+}
+
+func TestEvaluateScanWatch(t *testing.T) {
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 1,
+		Branches: []scanBranch{
+			{
+				Prov: provBranch("main", true),
+				Matches: []ignitionMatch{
+					{Path: ".claude/settings.json", Size: 400, BlobSHA: "c", Rule: ignitionRule{Class: classAgentHook, Weight: wIgnitionAgentHook}},
+					{Path: ".gemini/settings.json", Size: 300, BlobSHA: "g", Rule: ignitionRule{Class: classAgentHook, Weight: wIgnitionAgentHook}},
+				},
+			},
+		},
+		Blobs: map[string]blobAnalysis{
+			"c": {Size: 400, Fetched: true, IsText: true},
+			"g": {Size: 300, Fetched: true, IsText: true},
+		},
+	}
+	got := evaluateScan(in)
+	if got.Verdict != VerdictWatch {
+		t.Fatalf("verdict = %v, want watch (score %d)", got.Verdict, got.Score)
+	}
+}
+
+func TestEvaluateScanCompromised(t *testing.T) {
+	prov := provBranch("main", true)
+	prov.Signed = false
+	prov.SignedByGitHub = false
+	prov.Bot = true
+	prov.AuthorName = "github-actions"
+
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 1,
+		Branches: []scanBranch{
+			{
+				Prov: prov,
+				Matches: []ignitionMatch{
+					{Path: ".github/setup.js", Size: 4500000, BlobSHA: "d", Rule: ignitionRule{Class: classDropper, Weight: wIgnitionNamedIOC}},
+				},
+			},
+		},
+		Blobs: map[string]blobAnalysis{
+			"d": {Size: 4500000, Fetched: false, Markers: []string{"eval() call", "base64 decode at runtime"}},
+		},
+	}
+	got := evaluateScan(in)
+	if got.Verdict != VerdictCompromised {
+		t.Fatalf("verdict = %v, want compromised (score %d, findings %+v)", got.Verdict, got.Score, got.Findings)
+	}
+	// Expect: ignition(4) + oversized(4) + obfuscated(5) + spoof(5) + combined(4) = 22.
+	if got.Score < tCompromised {
+		t.Errorf("score = %d, want >= %d", got.Score, tCompromised)
+	}
+	var sawSpoof, sawCombined bool
+	for _, f := range got.Findings {
+		if f.Axis == AxisProvenance && strings.Contains(f.Reason, "forged") {
+			sawSpoof = true
+		}
+		if strings.Contains(f.Reason, "coincide") {
+			sawCombined = true
+		}
+	}
+	if !sawSpoof {
+		t.Error("expected a spoofed-identity finding")
+	}
+	if !sawCombined {
+		t.Error("expected a combined smoking-gun finding")
+	}
+}
+
+func TestEvaluateScanUnsignedDelta(t *testing.T) {
+	// Default branch signed; a side branch carrying an agent hook is
+	// unsigned → unsigned-delta + divergence fire.
+	main := provBranch("main", true)
+	main.Signed = true
+	side := provBranch("next", false)
+	side.Signed = false
+
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 2,
+		Branches: []scanBranch{
+			{Prov: main},
+			{
+				Prov: side,
+				Matches: []ignitionMatch{
+					{Path: ".claude/settings.json", Size: 500, BlobSHA: "c", Rule: ignitionRule{Class: classAgentHook, Weight: wIgnitionAgentHook}},
+				},
+			},
+		},
+		Blobs: map[string]blobAnalysis{"c": {Size: 500, Fetched: true, IsText: true}},
+	}
+	got := evaluateScan(in)
+	var sawUnsigned, sawDivergence bool
+	for _, f := range got.Findings {
+		if strings.Contains(f.Reason, "unsigned while the repo otherwise signs") {
+			sawUnsigned = true
+		}
+		if strings.Contains(f.Reason, "divergence") {
+			sawDivergence = true
+		}
+	}
+	if !sawUnsigned {
+		t.Error("expected an unsigned-delta finding")
+	}
+	if !sawDivergence {
+		t.Error("expected a side-branch divergence finding")
+	}
+}

--- a/internal/ui/hyperlink_test.go
+++ b/internal/ui/hyperlink_test.go
@@ -45,6 +45,12 @@ func TestSponsorURLsAreHyperlinked(t *testing.T) {
 	if !strings.Contains(ansi.Strip(spOut), sponsorURL) {
 		t.Error("sponsor splash should still show the bare URL after strip")
 	}
+	if !strings.Contains(spOut, ansi.SetHyperlink(coffeeURL)) {
+		t.Error("sponsor splash should hyperlink the buy-me-a-coffee URL")
+	}
+	if !strings.Contains(ansi.Strip(spOut), coffeeURL) {
+		t.Error("sponsor splash should still show the bare coffee URL after strip")
+	}
 
 	wn := renderWhatsNewTab("0.16.0", 80)
 	if !strings.Contains(wn, ansi.SetHyperlink(sponsorURL)) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -182,6 +182,13 @@ type Model struct {
 	// pattern note.
 	issueDetail IssueDetailModel
 
+	// scan is the supply-chain integrity-scan drill-in opened from
+	// the Repos action menu ("Security scan", `s`). Same drill-in
+	// idiom and mutual-exclusion contract as repoDetail / prDetail /
+	// issueDetail — only one of the four is ever open at a time. See
+	// internal/ui/scan.go and the ROADMAP integrity-scan design.
+	scan ScanModel
+
 	// help is the keyboard-shortcut overlay opened with `?`. Like the
 	// other modals it absorbs keys while open (any key dismisses) and
 	// renders at the top of the modal priority chain.
@@ -628,6 +635,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 
+		// Integrity-scan drill-in — same dispatch shape as the detail
+		// views. Routed before the per-tab dispatch so its keys
+		// (esc / r / o / y / scroll) win while open.
+		if msg.String() != "ctrl+c" && m.scan.IsOpen() {
+			width := computeAvailable(m.width)
+			height := computeTabHeight(m)
+			newScan, cmd := m.scan.Update(msg, m.client, width, height)
+			m.scan = newScan
+			return m, cmd
+		}
+
 		// When a sub-model is capturing text input (e.g. a search
 		// box), give it the keystroke first so "q", "1"–"5", "tab"
 		// etc. become literal characters instead of triggering the
@@ -699,6 +717,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					actions = []Action{
 						{Label: "Open in GitHub", Shortcut: 'o', Cmd: openURLCmd(r.URL)},
 						{Label: "View details", Shortcut: 'd', Cmd: viewRepoDetailCmd(r)},
+						{Label: "Security scan", Shortcut: 's', Cmd: viewRepoScanCmd(r)},
 						{Label: pinLabel, Shortcut: 'P', Cmd: togglePinCmd(r.URL, pinNext)},
 						{Label: "Copy URL", Shortcut: 'c', Cmd: copyURLCmd(r.URL)},
 					}
@@ -1017,6 +1036,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// invariant the View priority assumes.
 		m.prDetail = m.prDetail.Close()
 		m.issueDetail = m.issueDetail.Close()
+		m.scan = m.scan.Close()
 		m.repoDetail = m.repoDetail.Open(msg.repo)
 		return m, fetchRepoDetailCmd(m.client, owner, name, msg.repo.URL)
 
@@ -1057,6 +1077,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// viewRepoDetailMsg.
 		m.repoDetail = m.repoDetail.Close()
 		m.issueDetail = m.issueDetail.Close()
+		m.scan = m.scan.Close()
 		m.prDetail = m.prDetail.Open(msg.pr)
 		return m, fetchPRDetailCmd(m.client, owner, name, num, msg.pr.URL)
 
@@ -1081,6 +1102,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Mutual exclusion — see viewRepoDetailMsg note.
 		m.repoDetail = m.repoDetail.Close()
 		m.prDetail = m.prDetail.Close()
+		m.scan = m.scan.Close()
 		m.issueDetail = m.issueDetail.Open(msg.issue)
 		return m, fetchIssueDetailCmd(m.client, owner, name, num, msg.issue.URL)
 
@@ -1089,6 +1111,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.issueDetail = m.issueDetail.applyFetched(msg.detail, msg.err)
+		return m, nil
+
+	case viewRepoScanMsg:
+		// Integrity-scan drill-in (mirror of viewRepoDetailMsg). Parse
+		// owner/name from the row URL, enforce one-drill-in-at-a-time,
+		// open in loading state and fire the targeted scan.
+		owner, name := github.SplitOwnerName(msg.repo.URL)
+		if owner == "" || name == "" {
+			m.toastMsg = "Could not parse repo URL"
+			m.toastUntil = time.Now().Add(toastDuration)
+			return m, tea.Tick(toastDuration, func(time.Time) tea.Msg {
+				return clockTickMsg(time.Now())
+			})
+		}
+		m.repoDetail = m.repoDetail.Close()
+		m.prDetail = m.prDetail.Close()
+		m.issueDetail = m.issueDetail.Close()
+		m.scan = m.scan.Open(msg.repo)
+		return m, fetchRepoScanCmd(m.client, owner, name, msg.repo.URL)
+
+	case repoScanFetchedMsg:
+		// Stale-fetch protection by URL — same idiom as
+		// repoDetailFetchedMsg.
+		if !m.scan.IsOpen() || m.scan.repo.URL != msg.url {
+			return m, nil
+		}
+		m.scan = m.scan.applyFetched(msg.scan, msg.err)
 		return m, nil
 
 	case pinToggledMsg:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -543,8 +543,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		// Sponsor splash has the highest priority: while open it absorbs
-		// every key except ctrl+c. `o` opens the Sponsors page, `c`
-		// copies the URL, and ANY other key dismisses. Dismissal is
+		// every key except ctrl+c. `o` opens the GitHub Sponsors page,
+		// `b` opens the one-off "buy me a coffee" link, `c` copies the
+		// Sponsors URL, and ANY other key dismisses. Dismissal is
 		// session-only (no persisted flag) — by design the splash
 		// reappears on the next launch unless the user opted out.
 		if msg.String() != "ctrl+c" && m.sponsor.IsOpen() {
@@ -552,6 +553,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "o":
 				cmd = openURLCmd(m.sponsor.url)
+			case "b":
+				cmd = openURLCmd(coffeeURL)
 			case "c":
 				cmd = copyURLCmd(m.sponsor.url)
 			}

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -231,7 +231,7 @@ func scanVerdictStyle(v github.ScanVerdict) (string, lipgloss.Style) {
 	case github.VerdictClean:
 		return "✓", okStyle.Bold(true)
 	case github.VerdictWatch:
-		return "•", lipgloss.NewStyle().Foreground(colValue).Bold(true)
+		return "•", watchStyle
 	case github.VerdictSuspicious:
 		return "⚠", warnStyle.Bold(true)
 	case github.VerdictCompromised:
@@ -379,12 +379,7 @@ func renderRemediation(s *github.RepoScan, width int) string {
 	lines = append(lines, boldStyle.Foreground(colAccent).Render("Press y")+mutedStyle.Render(" to copy a ready-to-run remediation script to your clipboard."))
 
 	boxW := max(width-4, 30)
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(border).
-		Padding(0, 2).
-		Width(boxW).
-		Render(strings.Join(lines, "\n"))
+	return remediationBoxStyle(border, boxW).Render(strings.Join(lines, "\n"))
 }
 
 // remediationScript builds the plain-text shell script copied to the
@@ -420,10 +415,22 @@ func remediationScript(s *github.RepoScan) string {
 
 	fmt.Fprintf(&b, "# 2. Confirm the implant across every branch (by content, not by author).\n")
 	if len(paths) > 0 {
-		fmt.Fprintf(&b, "for b in $(git branch -r | sed 's/origin\\///'); do\n")
-		for _, p := range paths {
-			fmt.Fprintf(&b, "  git cat-file -e \"$b:%s\" 2>/dev/null && echo \"  ^ %s on $b\"\n", p, p)
+		// Paths go into a single-quote-escaped bash array so a hostile
+		// path can't break out of the generated script; branches are
+		// iterated via for-each-ref (no word-splitting, and the
+		// symbolic origin/HEAD is filtered out).
+		fmt.Fprintf(&b, "paths=(")
+		for i, p := range paths {
+			if i > 0 {
+				fmt.Fprint(&b, " ")
+			}
+			fmt.Fprint(&b, bashSingleQuote(p))
 		}
+		fmt.Fprintf(&b, ")\n")
+		fmt.Fprintf(&b, "for b in $(git for-each-ref --format='%%(refname:short)' refs/remotes/origin | grep -v '^origin/HEAD$'); do\n")
+		fmt.Fprintf(&b, "  for p in \"${paths[@]}\"; do\n")
+		fmt.Fprintf(&b, "    git cat-file -e \"$b:$p\" 2>/dev/null && echo \"  ^ $p on $b\"\n")
+		fmt.Fprintf(&b, "  done\n")
 		fmt.Fprintf(&b, "done\n\n")
 	} else {
 		fmt.Fprintf(&b, "# (no specific payload path flagged — inspect the findings in octoscope)\n\n")
@@ -446,6 +453,14 @@ func remediationScript(s *github.RepoScan) string {
 	fmt.Fprintf(&b, "#    https://github.com/settings/tokens\n")
 
 	return b.String()
+}
+
+// bashSingleQuote wraps s in single quotes for safe interpolation into
+// the generated remediation script, escaping any embedded single quote
+// via the standard '\” trick. The script is copy-paste text the user
+// runs, so a hostile path must not be able to break out of it.
+func bashSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // sortedKeys returns the keys of a set in stable, sorted order.

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -1,0 +1,510 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// ScanModel is the supply-chain integrity-scan drill-in for a single
+// repository. It follows the canonical drill-in shape (see
+// repo_detail.go): a sticky title row + a viewport-wrapped body, with
+// loading / error / loaded states, reached via the Repos action menu
+// ("Security scan", shortcut `s`).
+//
+// Read-only by construction: the loaded report explains findings and
+// hands the user a copy-paste remediation script + the right revoke
+// links, but octoscope never mutates the repository (design principle
+// 3 / CLAUDE.md "Out of scope").
+type ScanModel struct {
+	open    bool
+	repo    github.Repo
+	scan    *github.RepoScan
+	err     error
+	loading bool
+
+	viewport viewport.Model
+}
+
+// IsOpen reports whether the scan view is active — used by the root
+// model to route keystrokes here and to replace the Repos tab body.
+func (sm ScanModel) IsOpen() bool { return sm.open }
+
+// Open returns a fresh scan model in the loading state, seeded with
+// the row the user picked. The caller dispatches fetchRepoScanCmd
+// alongside this so the loading state transitions.
+func (sm ScanModel) Open(repo github.Repo) ScanModel {
+	return ScanModel{
+		open:     true,
+		repo:     repo,
+		loading:  true,
+		viewport: viewport.New(0, 0),
+	}
+}
+
+// Close returns a closed scan model (zero value).
+func (sm ScanModel) Close() ScanModel { return ScanModel{} }
+
+// Update handles one key event while the scan view is open. Action
+// keys (q / esc / r / o / y) take precedence; everything else scrolls
+// the viewport. `y` copies the remediation script — offered only once
+// a loaded scan has actually flagged something, so the key is never
+// advertised when there's nothing to remediate.
+func (sm ScanModel) Update(msg tea.KeyMsg, client *github.Client, width, height int) (ScanModel, tea.Cmd) {
+	if !sm.open {
+		return sm, nil
+	}
+	switch msg.String() {
+	case "q":
+		return sm.Close(), tea.Quit
+	case "esc":
+		return sm.Close(), nil
+	case "o":
+		return sm, openURLCmd(sm.repo.URL)
+	case "r":
+		owner, name := github.SplitOwnerName(sm.repo.URL)
+		if owner == "" {
+			return sm, nil
+		}
+		sm.loading = true
+		sm.err = nil
+		sm.scan = nil
+		return sm, fetchRepoScanCmd(client, owner, name, sm.repo.URL)
+	case "y":
+		if sm.scan != nil && sm.scan.Verdict >= github.VerdictSuspicious {
+			return sm, copyTextCmd(remediationScript(sm.scan), "Script")
+		}
+	}
+
+	sm = sm.syncViewport(width, height)
+	var cmd tea.Cmd
+	sm.viewport, cmd = sm.viewport.Update(msg)
+	return sm, cmd
+}
+
+// syncViewport refreshes the viewport content + dimensions. No-op in
+// the transient states (their bodies are short and always fit).
+func (sm ScanModel) syncViewport(width, height int) ScanModel {
+	if sm.loading || sm.err != nil || sm.scan == nil {
+		return sm
+	}
+	sm.viewport.Width = width
+	sm.viewport.Height = bodyViewportHeight(height)
+	sm.viewport.SetContent(sm.computeBody(width))
+	return sm
+}
+
+// applyFetched commits a fetched scan (or error). The root checks the
+// URL correlation before calling this so a stale response can't
+// clobber a re-opened scan.
+func (sm ScanModel) applyFetched(scan *github.RepoScan, err error) ScanModel {
+	sm.loading = false
+	sm.scan = scan
+	sm.err = err
+	return sm
+}
+
+// View renders the scan inside the tab content area: sticky title +
+// viewport-wrapped body. Mirrors RepoDetailModel.View.
+func (sm ScanModel) View(width, height int) string {
+	if !sm.open {
+		return ""
+	}
+	title := sm.renderTitle()
+
+	if sm.loading {
+		_, name := github.SplitOwnerName(sm.repo.URL)
+		return title + "\n\n" +
+			mutedStyle.Render("Scanning "+name+" for supply-chain integrity issues…")
+	}
+	if sm.err != nil {
+		return title + "\n\n" +
+			errorStyle.Render("Could not complete the scan") + "\n" +
+			mutedStyle.Render(sm.err.Error()) + "\n\n" +
+			keyHints("r", "retry", "esc", "back")
+	}
+	if sm.scan == nil {
+		return title + "\n\n" + mutedStyle.Render("(no data)")
+	}
+
+	body := sm.computeBody(width)
+	if height <= 0 {
+		return title + "\n\n" + body
+	}
+	vp := sm.viewport
+	vp.Width = width
+	vp.Height = bodyViewportHeight(height)
+	vp.SetContent(body)
+	return title + "\n\n" + vp.View()
+}
+
+// renderTitle is the sticky breadcrumb + key hints. The `y` hint
+// appears only when there's something to remediate.
+func (sm ScanModel) renderTitle() string {
+	owner, name := github.SplitOwnerName(sm.repo.URL)
+	titleText := fmt.Sprintf("▸ Repos / %s / %s / security scan", owner, name)
+	hints := []string{
+		"esc", "back",
+		"o", "open in github",
+		"r", "rescan",
+	}
+	if sm.scan != nil && sm.scan.Verdict >= github.VerdictSuspicious {
+		hints = append(hints, "y", "copy fix script")
+	}
+	return activeTabStyle.Render(titleText) + "  " + keyHints(hints...)
+}
+
+// computeBody renders the loaded report: verdict headline, scan
+// summary, scored findings, ignition-surface inventory, per-branch
+// provenance, and (when warranted) the remediation panel.
+func (sm ScanModel) computeBody(width int) string {
+	s := sm.scan
+	var b strings.Builder
+
+	// ---- Verdict headline
+	glyph, style := scanVerdictStyle(s.Verdict)
+	headline := style.Render(fmt.Sprintf("%s  %s", glyph, strings.ToUpper(s.Verdict.String())))
+	b.WriteString(headline)
+	if s.Score > 0 {
+		b.WriteString("   " + mutedStyle.Render(fmt.Sprintf("risk score %d", s.Score)))
+	}
+	b.WriteString("\n")
+
+	// ---- Scan summary
+	summary := fmt.Sprintf("Scanned %d of %d branches", s.BranchesScanned, s.BranchesTotal)
+	if s.Truncated {
+		summary += " (bounded — some branches / deep trees not fully walked)"
+	}
+	b.WriteString(mutedStyle.Render(summary))
+	b.WriteString("\n\n")
+
+	// ---- Scored findings (the evidence behind the verdict)
+	if scored := s.ScoredFindings(); len(scored) > 0 {
+		b.WriteString(subSectionTitleStyle.Render("Findings"))
+		b.WriteString("\n")
+		b.WriteString(renderFindings(scored, width))
+		b.WriteString("\n\n")
+	} else {
+		b.WriteString(okStyle.Render("No anomalies scored.") +
+			mutedStyle.Render(" The auto-execution surface below is informational."))
+		b.WriteString("\n\n")
+	}
+
+	// ---- Ignition-surface inventory (always shown — know your surface)
+	if inv := s.IgnitionInventory(); len(inv) > 0 {
+		b.WriteString(subSectionTitleStyle.Render("Auto-execution surface present"))
+		b.WriteString("\n")
+		b.WriteString(renderIgnitionInventory(inv, width))
+		b.WriteString("\n\n")
+	}
+
+	// ---- Per-branch provenance
+	if len(s.Branches) > 0 {
+		b.WriteString(subSectionTitleStyle.Render("Branch tips"))
+		b.WriteString("\n")
+		b.WriteString(renderBranchProvenance(s.Branches, width))
+		b.WriteString("\n\n")
+	}
+
+	// ---- Remediation (only when there's something to act on)
+	if s.Verdict >= github.VerdictSuspicious {
+		b.WriteString(renderRemediation(s, width))
+		b.WriteString("\n")
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// scanVerdictStyle pairs each verdict with a distinct glyph and a
+// theme style. The glyph carries the meaning even in monochromatic
+// themes where the colours sit close together — same discipline as
+// the CI rollup dot (CLAUDE.md monochrome contract).
+func scanVerdictStyle(v github.ScanVerdict) (string, lipgloss.Style) {
+	switch v {
+	case github.VerdictClean:
+		return "✓", okStyle.Bold(true)
+	case github.VerdictWatch:
+		return "•", lipgloss.NewStyle().Foreground(colValue).Bold(true)
+	case github.VerdictSuspicious:
+		return "⚠", warnStyle.Bold(true)
+	case github.VerdictCompromised:
+		return "✕", errorStyle
+	default:
+		return "?", mutedStyle
+	}
+}
+
+// renderFindings lays out the scored evidence: an axis tag, the
+// reason, the branch (when branch-specific) and the weight it added.
+func renderFindings(findings []github.Finding, width int) string {
+	var lines []string
+	for _, f := range findings {
+		tag := mutedStyle.Render("[" + string(f.Axis) + "]")
+		weight := warnStyle.Render(fmt.Sprintf("+%d", f.Weight))
+		reason := f.Reason
+		if f.Branch != "" {
+			reason = fmt.Sprintf("%s  %s", reason, mutedStyle.Render("· "+f.Branch))
+		}
+		line := fmt.Sprintf("  %s %s  %s", weight, tag, reason)
+		lines = append(lines, lipgloss.NewStyle().Width(max(width-2, 20)).Render(line))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderIgnitionInventory lists every auto-execution surface found,
+// regardless of score, so the user can audit their attack surface.
+func renderIgnitionInventory(findings []github.Finding, width int) string {
+	// Dedupe by path so the same file on multiple branches lists once.
+	seen := map[string]bool{}
+	var lines []string
+	for _, f := range findings {
+		if f.Path == "" || seen[f.Path] {
+			continue
+		}
+		seen[f.Path] = true
+		path := valueStyle.Render(f.Path)
+		line := fmt.Sprintf("  %s  %s", path, mutedStyle.Render(f.Reason))
+		lines = append(lines, lipgloss.NewStyle().Width(max(width-2, 20)).Render(line))
+	}
+	if len(lines) == 0 {
+		return mutedStyle.Render("  (none)")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderBranchProvenance renders the per-branch tip table: name (with
+// a default-branch marker), short OID, signature state, and identity.
+func renderBranchProvenance(branches []github.BranchProvenance, width int) string {
+	// Stable order: default branch first, then alphabetical.
+	rows := make([]github.BranchProvenance, len(branches))
+	copy(rows, branches)
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].IsDefault != rows[j].IsDefault {
+			return rows[i].IsDefault
+		}
+		return rows[i].Name < rows[j].Name
+	})
+
+	const (
+		nameW = 22
+		oidW  = 9
+		sigW  = 12
+	)
+	var lines []string
+	for _, p := range rows {
+		name := p.Name
+		if p.IsDefault {
+			name += " *"
+		}
+		nameCol := padRight(truncate(name, nameW), nameW)
+		oidCol := mutedStyle.Render(padRight(shortBranchOID(p.TipOID), oidW))
+
+		sig := signatureLabel(p)
+		sigStyle := mutedStyle
+		switch {
+		case p.Bot && !p.SignedByGitHub:
+			sigStyle = errorStyle
+		case p.Signed:
+			sigStyle = okStyle
+		case !p.Signed:
+			sigStyle = warnStyle
+		}
+		sigCol := sigStyle.Render(padRight(sig, sigW))
+
+		identity := p.AuthorLogin
+		if identity == "" {
+			identity = p.AuthorName
+		}
+		idCol := mutedStyle.Render(truncate(identity, max(width-nameW-oidW-sigW-8, 8)))
+
+		lines = append(lines, "  "+nameCol+"  "+oidCol+"  "+sigCol+"  "+idCol)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// signatureLabel summarises a tip's signature state for the table.
+func signatureLabel(p github.BranchProvenance) string {
+	switch {
+	case p.Bot && !p.SignedByGitHub:
+		return "forged"
+	case p.SignedByGitHub:
+		return "gh-signed"
+	case p.Signed:
+		return "signed"
+	default:
+		return "unsigned"
+	}
+}
+
+// shortBranchOID renders a 7-char short OID, or a placeholder when the
+// tip OID is missing.
+func shortBranchOID(oid string) string {
+	if len(oid) >= 7 {
+		return oid[:7]
+	}
+	if oid == "" {
+		return "—"
+	}
+	return oid
+}
+
+// renderRemediation renders the read-only remediation panel: the safe
+// next steps, the revoke links, and a pointer to the `y` copy-script
+// key. Bordered in the verdict colour so it reads as the call to
+// action.
+func renderRemediation(s *github.RepoScan, width int) string {
+	_, style := scanVerdictStyle(s.Verdict)
+	border := colWarn
+	if s.Verdict >= github.VerdictCompromised {
+		border = colError
+	}
+
+	var lines []string
+	lines = append(lines, style.Render("Remediation — octoscope is read-only, these are steps for you to run"))
+	lines = append(lines, "")
+	lines = append(lines, mutedStyle.Render("1. Inspect without executing:  git clone --no-checkout "+s.URL))
+	lines = append(lines, mutedStyle.Render("2. Reset (not revert) affected branches to a clean parent, then force-push"))
+	lines = append(lines, mutedStyle.Render("3. Ask GitHub Support to GC the malicious commit SHAs from the fork network"))
+	lines = append(lines, mutedStyle.Render("4. Revoke the OAuth authorization grant, not just the token:"))
+	lines = append(lines, "     "+valueStyle.Render("https://github.com/settings/applications"))
+	lines = append(lines, "     "+valueStyle.Render("https://github.com/settings/tokens"))
+	lines = append(lines, "")
+	lines = append(lines, boldStyle.Foreground(colAccent).Render("Press y")+mutedStyle.Render(" to copy a ready-to-run remediation script to your clipboard."))
+
+	boxW := max(width-4, 30)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(border).
+		Padding(0, 2).
+		Width(boxW).
+		Render(strings.Join(lines, "\n"))
+}
+
+// remediationScript builds the plain-text shell script copied to the
+// clipboard by `y`. It is filled with the repo's URL and the actual
+// affected branches / ignition paths the scan found, but is otherwise
+// inert text — octoscope hands it over, it never runs it.
+func remediationScript(s *github.RepoScan) string {
+	owner, name := s.Owner, s.Name
+
+	// Collect affected branches + the ignition paths flagged on them.
+	branchSet := map[string]bool{}
+	pathSet := map[string]bool{}
+	for _, f := range s.ScoredFindings() {
+		if f.Branch != "" {
+			branchSet[f.Branch] = true
+		}
+		if f.Path != "" {
+			pathSet[f.Path] = true
+		}
+	}
+	branches := sortedKeys(branchSet)
+	paths := sortedKeys(pathSet)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "#!/usr/bin/env bash\n")
+	fmt.Fprintf(&b, "# octoscope supply-chain remediation for %s/%s\n", owner, name)
+	fmt.Fprintf(&b, "# Verdict: %s (risk score %d). Review every step before running.\n", s.Verdict, s.Score)
+	fmt.Fprintf(&b, "set -euo pipefail\n\n")
+
+	fmt.Fprintf(&b, "# 1. Mirror the repo WITHOUT checking it out (never execute the payload).\n")
+	fmt.Fprintf(&b, "git clone --no-checkout %s inspect-%s\n", s.URL, name)
+	fmt.Fprintf(&b, "cd inspect-%s\n\n", name)
+
+	fmt.Fprintf(&b, "# 2. Confirm the implant across every branch (by content, not by author).\n")
+	if len(paths) > 0 {
+		fmt.Fprintf(&b, "for b in $(git branch -r | sed 's/origin\\///'); do\n")
+		for _, p := range paths {
+			fmt.Fprintf(&b, "  git cat-file -e \"$b:%s\" 2>/dev/null && echo \"  ^ %s on $b\"\n", p, p)
+		}
+		fmt.Fprintf(&b, "done\n\n")
+	} else {
+		fmt.Fprintf(&b, "# (no specific payload path flagged — inspect the findings in octoscope)\n\n")
+	}
+
+	fmt.Fprintf(&b, "# 3. RESET (not revert) the affected branches to a clean parent, then force-push.\n")
+	fmt.Fprintf(&b, "#    A revert leaves the payload retrievable at the old commit.\n")
+	if len(branches) > 0 {
+		for _, br := range branches {
+			fmt.Fprintf(&b, "#    git push --force origin <clean-sha>:%s\n", br)
+		}
+	} else {
+		fmt.Fprintf(&b, "#    git push --force origin <clean-sha>:<branch>\n")
+	}
+	fmt.Fprintf(&b, "\n")
+
+	fmt.Fprintf(&b, "# 4. Ask GitHub Support to garbage-collect the malicious commit SHAs.\n")
+	fmt.Fprintf(&b, "# 5. REVOKE THE OAUTH GRANT (not just the token):\n")
+	fmt.Fprintf(&b, "#    https://github.com/settings/applications\n")
+	fmt.Fprintf(&b, "#    https://github.com/settings/tokens\n")
+
+	return b.String()
+}
+
+// sortedKeys returns the keys of a set in stable, sorted order.
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// max is the int sibling of the min helper in repo_detail.go — Go's
+// builtin max exists since 1.21 but lipgloss width math reads clearer
+// with a guarded local here.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// ---- root-model plumbing -------------------------------------------------
+
+// viewRepoScanMsg is fired by the "Security scan" menu entry on a
+// Repos row. The root model intercepts it to open the scan drill-in
+// and fire the targeted fetch (mirror of viewRepoDetailMsg).
+type viewRepoScanMsg struct {
+	repo github.Repo
+}
+
+// repoScanFetchedMsg carries the FetchRepoScan result back to Update.
+// The URL field is the stale-fetch correlation key.
+type repoScanFetchedMsg struct {
+	url  string
+	scan *github.RepoScan
+	err  error
+}
+
+// viewRepoScanCmd captures a Repos row for the action menu.
+func viewRepoScanCmd(r github.Repo) tea.Cmd {
+	return func() tea.Msg {
+		return viewRepoScanMsg{repo: r}
+	}
+}
+
+// scanFetchTimeout is generous: a scan is a bounded REST fan-out (one
+// tree per branch + a few blobs) on top of one GraphQL round-trip, so
+// it can run longer than a single detail query on a many-branched
+// repo. Matches the dashboard fetch ceiling.
+const scanFetchTimeout = 30 * time.Second
+
+// fetchRepoScanCmd builds the BubbleTea command that runs the scan off
+// the network and returns a repoScanFetchedMsg.
+func fetchRepoScanCmd(client *github.Client, owner, name, url string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), scanFetchTimeout)
+		defer cancel()
+		scan, err := client.FetchRepoScan(ctx, owner, name)
+		return repoScanFetchedMsg{url: url, scan: scan, err: err}
+	}
+}

--- a/internal/ui/scan_test.go
+++ b/internal/ui/scan_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// compromisedScan builds a realistic "likely compromised" RepoScan for
+// the render / remediation tests — the 2026-06 reference shape: an
+// oversized dropper on the default branch with a forged bot tip.
+func compromisedScan() *github.RepoScan {
+	return &github.RepoScan{
+		Owner: "octocat", Name: "infected",
+		URL:           "https://github.com/octocat/infected",
+		DefaultBranch: "main", BranchesScanned: 2, BranchesTotal: 2,
+		Score: 22, Verdict: github.VerdictCompromised,
+		Findings: []github.Finding{
+			{Axis: github.AxisIgnition, Branch: "main", Path: ".github/setup.js", Weight: 4, Reason: "known dropper filename"},
+			{Axis: github.AxisBlob, Branch: "main", Path: ".github/setup.js", Weight: 4, Reason: "oversized for its type: 4.3 MiB"},
+			{Axis: github.AxisProvenance, Branch: "main", Weight: 5, Reason: `tip deadbee forged as "github-actions" but not signed by GitHub`},
+		},
+		Branches: []github.BranchProvenance{
+			{Name: "main", IsDefault: true, TipOID: "deadbeefcafe", Bot: true, SignedByGitHub: false},
+			{Name: "next", TipOID: "feedface1234", Signed: true},
+		},
+	}
+}
+
+func TestRemediationScript(t *testing.T) {
+	script := remediationScript(compromisedScan())
+	for _, want := range []string{
+		"octocat/infected",
+		"git clone --no-checkout",
+		".github/setup.js",
+		"settings/applications",
+		"main", // the affected branch
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("remediation script missing %q\n---\n%s", want, script)
+		}
+	}
+	// The article's load-bearing rule: reset, never revert (a revert
+	// leaves the payload retrievable at the old commit).
+	if strings.Contains(script, "git revert") {
+		t.Error("remediation script must reset, not revert")
+	}
+}
+
+func TestScanVerdictStyleDistinctGlyphs(t *testing.T) {
+	seen := map[string]github.ScanVerdict{}
+	for _, v := range []github.ScanVerdict{
+		github.VerdictClean, github.VerdictWatch,
+		github.VerdictSuspicious, github.VerdictCompromised,
+	} {
+		g, _ := scanVerdictStyle(v)
+		if g == "" {
+			t.Errorf("empty glyph for verdict %v", v)
+		}
+		if prev, dup := seen[g]; dup {
+			t.Errorf("glyph %q reused for %v and %v", g, prev, v)
+		}
+		seen[g] = v
+	}
+}
+
+func TestScanModelViewLoading(t *testing.T) {
+	sm := ScanModel{}.Open(github.Repo{URL: "https://github.com/octocat/infected"})
+	out := sm.View(80, 24)
+	if !strings.Contains(out, "Scanning") {
+		t.Errorf("loading view missing 'Scanning': %q", out)
+	}
+}
+
+func TestScanModelViewLoaded(t *testing.T) {
+	sm := ScanModel{}.
+		Open(github.Repo{URL: "https://github.com/octocat/infected"}).
+		applyFetched(compromisedScan(), nil)
+
+	// Large height so the whole body sits inside the viewport window.
+	out := sm.View(120, 200)
+	for _, want := range []string{"LIKELY COMPROMISED", "Findings", "setup.js", "Remediation"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("loaded view missing %q", want)
+		}
+	}
+
+	// The copy-fix-script key is advertised only when there's
+	// something to remediate.
+	if !strings.Contains(sm.renderTitle(), "copy fix script") {
+		t.Error("compromised verdict should advertise the fix-script key")
+	}
+	clean := ScanModel{}.
+		Open(github.Repo{URL: "https://github.com/octocat/clean"}).
+		applyFetched(&github.RepoScan{DefaultBranch: "main", Verdict: github.VerdictClean}, nil)
+	if strings.Contains(clean.renderTitle(), "copy fix script") {
+		t.Error("clean verdict must not advertise the fix-script key")
+	}
+}

--- a/internal/ui/sponsor.go
+++ b/internal/ui/sponsor.go
@@ -12,6 +12,14 @@ import (
 // of which account the dashboard is currently showing.
 const sponsorURL = "https://github.com/sponsors/gfazioli"
 
+// coffeeURL is the maintainer's one-off Stripe donation ("buy me a
+// coffee") link, offered alongside the recurring GitHub Sponsors
+// option in the splash. Hardcoded like sponsorURL for the same reason
+// — it funds octoscope's maintainer, not the viewed profile. A
+// one-time tip lowers the barrier for users who don't want a recurring
+// commitment.
+const coffeeURL = "https://donate.stripe.com/fZu4gy4Tn3b1dgudGx0co00"
+
 // SponsorModel is the launch splash inviting the user to sponsor
 // octoscope. It opens on every launch (dismissal is session-only — see
 // the interaction note below) and follows the modal idiom of
@@ -20,9 +28,10 @@ const sponsorURL = "https://github.com/sponsors/gfazioli"
 // banner, tab bar and footer staying pinned (or over the loading /
 // error screen before the first fetch lands).
 //
-// Interaction is deliberately tiny: `o` opens the Sponsors page in the
-// browser, `c` copies the URL, and ANY other key dismisses. Dismissal
-// is session-only — the splash reappears on the next launch by design,
+// Interaction is deliberately tiny: `o` opens the GitHub Sponsors page
+// in the browser, `b` opens the one-off "buy me a coffee" link, `c`
+// copies the Sponsors URL, and ANY other key dismisses. Dismissal is
+// session-only — the splash reappears on the next launch by design,
 // unless the user opted out (show_sponsor=false / --no-sponsor) or is
 // in --public-only mode.
 type SponsorModel struct {
@@ -51,20 +60,30 @@ func (s SponsorModel) View(width int) string {
 		return ""
 	}
 
+	// link renders one option as a key-marked label + its (clickable)
+	// URL on the next line, indented under the label.
+	link := func(key, label, url string) []string {
+		head := boldStyle.Foreground(colAccent).Render(key) + "  " + mutedStyle.Render(label)
+		return []string{head, "   " + hyperlink(url, valueStyle.Render(url))}
+	}
+
 	lines := []string{
 		boldStyle.Foreground(colAccent).Render("♥  Enjoying octoscope?"),
 		"",
 		mutedStyle.Render("If you find it useful, please consider"),
-		mutedStyle.Render("sponsoring its development:"),
+		mutedStyle.Render("supporting its development:"),
 		"",
-		hyperlink(s.url, valueStyle.Render(s.url)),
-		"",
-		keyHints(
-			"o", "open",
-			"c", "copy",
-			"any key", "dismiss",
-		),
 	}
+	lines = append(lines, link("o", "Sponsor on GitHub  (recurring)", s.url)...)
+	lines = append(lines, "")
+	lines = append(lines, link("b", "Buy me a coffee  (one-off)", coffeeURL)...)
+	lines = append(lines, "")
+	lines = append(lines, keyHints(
+		"o", "sponsor",
+		"b", "coffee",
+		"c", "copy",
+		"any key", "dismiss",
+	))
 
 	panel := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/internal/ui/sponsor_routing_test.go
+++ b/internal/ui/sponsor_routing_test.go
@@ -47,7 +47,8 @@ func TestSponsorKeyRouting(t *testing.T) {
 		wantStillOpen bool
 		wantCmd       bool
 	}{
-		{"o", false, true},      // open browser + dismiss
+		{"o", false, true},      // open sponsors + dismiss
+		{"b", false, true},      // open buy-me-a-coffee + dismiss
 		{"c", false, true},      // copy URL + dismiss
 		{"x", false, false},     // arbitrary key dismisses, no cmd
 		{"enter", false, false}, // same

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -32,6 +32,7 @@ var (
 	errorStyle           lipgloss.Style
 	okStyle              lipgloss.Style
 	warnStyle            lipgloss.Style
+	watchStyle           lipgloss.Style
 	valueStyle           lipgloss.Style
 	boxStyle             lipgloss.Style
 	sectionTitleStyle    lipgloss.Style
@@ -66,6 +67,13 @@ func rebuildStyles() {
 
 	okStyle = lipgloss.NewStyle().Foreground(colOK)
 	warnStyle = lipgloss.NewStyle().Foreground(colWarn)
+
+	// watchStyle is the "watch" verdict accent in the integrity-scan
+	// report — value-coloured + bold, the same tonal weight as a
+	// numeric value. Distinct from warn/error so the scan's four
+	// verdict tiers each read differently (paired with a glyph for
+	// monochromatic themes).
+	watchStyle = lipgloss.NewStyle().Foreground(colValue).Bold(true)
 
 	valueStyle = lipgloss.NewStyle().
 		Bold(true).
@@ -159,4 +167,18 @@ func rebuildStyles() {
 	// ("less ░▒▓█ more"). Kept distinct so we can swap legend format
 	// without touching the grid rendering.
 	heatmapLegendStyle = lipgloss.NewStyle().Foreground(colMuted)
+}
+
+// remediationBoxStyle is the bordered panel that frames the
+// integrity-scan remediation steps. A factory rather than a package
+// var because the border colour tracks the verdict severity (warn vs
+// error) and the width tracks the terminal — but it stays here so the
+// border styling lives in this file like every other box. Picks up the
+// live palette on each call.
+func remediationBoxStyle(borderCol lipgloss.Color, width int) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderCol).
+		Padding(0, 2).
+		Width(width)
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -135,12 +135,12 @@ func (m Model) View() string {
 	//
 	// Priority order MUST match the Update dispatcher in model.go
 	// (sponsor splash ▸ help overlay ▸ rate-limit panel ▸ settings ▸
-	// action menu ▸ repo detail ▸ PR detail ▸ issue detail): if
-	// Update routes a key to one modal but View renders a different
-	// one, the user types into ghost UI. The "open one closes the
-	// others" mutation in the *DetailMsg handlers makes co-occurrence
-	// rare in practice, but the priority is the load-bearing
-	// invariant — keep aligned.
+	// action menu ▸ repo detail ▸ PR detail ▸ issue detail ▸ scan):
+	// if Update routes a key to one modal but View renders a
+	// different one, the user types into ghost UI. The "open one
+	// closes the others" mutation in the *DetailMsg / *ScanMsg
+	// handlers makes co-occurrence rare in practice, but the priority
+	// is the load-bearing invariant — keep aligned.
 	switch {
 	case m.sponsor.IsOpen():
 		b.WriteString(m.sponsor.View(available))
@@ -158,6 +158,8 @@ func (m Model) View() string {
 		b.WriteString(m.prDetail.View(available, tabHeight))
 	case m.issueDetail.IsOpen():
 		b.WriteString(m.issueDetail.View(available, tabHeight))
+	case m.scan.IsOpen():
+		b.WriteString(m.scan.View(available, tabHeight))
 	default:
 		switch m.activeTab {
 		case TabOverview:

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,19 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.20.0": {
+		headline: "Integrity — scan your repos for the supply-chain worm.",
+		items: []whatsNewItem{
+			{
+				title: "Supply-chain integrity scan",
+				desc:  "Open a repo's action menu (space) and pick Security scan to check it for the Shai-Hulud / Miasma class of attack — an implant pushed to your repos that auto-runs when you open them in an AI editor or install them. It scores by what matters (auto-execution surface, oversized/obfuscated payloads, forged or unsigned commit tips), not by a single filename, so renamed variants still trip it. Read-only: it explains the findings and hands you a fix script plus the right revoke links — it never touches the repo.",
+			},
+			{
+				title: "Buy me a coffee",
+				desc:  "The launch splash now offers a one-off donation (press b) alongside recurring GitHub Sponsors (press o).",
+			},
+		},
+	},
 	"0.19.0": {
 		headline: "Freshness & correctness — stay current, count everything.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.19.0"
+const version = "0.20.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## What

Two independent additions, one commit each.

### 1. Supply-chain integrity scan — generic Shai-Hulud / Miasma detector

A **read-only** detector for the Shai-Hulud / Miasma class of supply-chain
attack: a self-replicating implant pushed to repos you own that
auto-executes when the repo is opened in an AI editor or installed, then
harvests credentials. The attack lives in the GitHub source (not the npm
registry), so a source-level reader like octoscope is the right place to
see it.

It matches the **invariant** of the attack, not a single payload filename
(which rots the moment the worm renames its dropper), across
filename-agnostic axes:

- **Axis 1** — a data-driven catalog of auto-execution "ignition"
  surfaces (agent/editor session hooks, devcontainer/package lifecycle,
  CI workflows). Adding a future location is a one-line table edit.
- **Axis 2** — blob anomaly (oversize / entropy / obfuscation markers)
  on a matched ignition file, regardless of its name. This is what
  catches future variants.
- **Axis 3** — provenance anomaly (tips forged under a bot identity but
  not GitHub-signed; unsigned tips against a genuinely-signed history).

Scoring is **weighted and explainable**: every finding carries the reason
it fired, and no single axis reaches the high verdict tiers alone.

Reached on demand from the Repos action menu → "Security scan" (key
`s`): one GraphQL `refs` query for per-branch tip provenance + a bounded
REST get-a-tree / get-a-blob fan-out (semaphore + branch cap) for the
ignition and blob axes. Renders a drill-in report (verdict, scored
findings, auto-execution inventory, per-branch provenance) plus a
read-only remediation panel — `y` copies a *reset-not-revert* fix script
and the OAuth-grant revoke links. **octoscope never mutates the
repository.**

### 2. Sponsor splash: one-off "buy me a coffee" link

Adds a one-time Stripe donation (`b`) next to the recurring GitHub
Sponsors option (`o`) in the launch splash; `c` still copies the Sponsors
URL, any other key dismisses.

## Scoping notes

- **Read-only** throughout (design principle 3 / Out of scope).
- **Complexity ceiling**: the scan is one GraphQL query + a bounded REST
  fan-out, on-demand only — never on the always-on refresh.
- **Generic by design**: the literal `.github/setup.js` is a single
  high-weight seed row; everything else is name-agnostic.

## Design note — push-burst banner dropped

An always-on dashboard banner flagging "N repos pushed in a tight window"
(the worm's fan-out shape) was prototyped and **pulled before merge**:
timing alone can't separate a worm from an ordinary batch push (a
maintainer scripting an update across many repos, Dependabot, a CI
sweep), and it had no recency gate, so a months-old batch would re-alarm
on every launch. The pure `DetectPushBurst` helper is kept (with tests)
as a building block to fold into the scan later — gated on recency and
combined with the stronger Axis 1-3 signals — rather than standing alone
as a noisy banner.

## Testing

- Unit tests: push-burst detection, glob match, entropy/obfuscation, the
  scoring matrix / verdict tiers, the remediation script
  (reset-not-revert), scan rendering, and the sponsor routing + hyperlink.
- Verified against the **real GitHub API** with a throwaway smoke test
  (not committed): the actual now-cleaned victim repos
  `icflorescu/mantine-datatable` and `icflorescu/mantine-contextmenu`,
  plus `charmbracelet/bubbletea` and `gfazioli/octoscope`, all score
  **clean** with no false positives; the compromised pattern scores
  *likely compromised*.
- `gofmt -l`, `go vet ./...`, `go test ./...` all green.

## Deferred (backlog)

Axis 4 (self-hosted runners / deploy keys / `contents:write` workflow
parsing), Tier C (bounded account-wide sweep), the persisted
baseline/delta scan, and folding the recency-gated push-burst signal into
the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository supply-chain integrity scan with scored verdicts (clean/watch/suspicious/likely compromised), findings view, ignition inventory, and remediation guidance including a copyable fix script.
* **UI/UX**
  * New Security scan drill-in for repos (shortcut s), verdict/headline display, per-branch provenance table, and “Buy me a coffee” one‑off sponsor link (shortcut b).
* **Tests**
  * Unit and UI tests covering scan logic, rendering, verdicts, and remediation script generation.
* **Documentation**
  * README, docs, and “What’s new” updated; app version bumped to 0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->