### PR TITLE
feat(whatsnew): surface buy-me-a-coffee in the support section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1023,7 +1023,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.20.0</span>
+                <span class="version-tag" id="version-pill">0.20.1</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -853,10 +853,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			case TabWhatsNew:
 				// Static tab. The only actions are on the embedded
-				// sponsor link: o opens it in the browser, c copies it.
+				// support links: o opens GitHub Sponsors, b opens the
+				// one-off "buy me a coffee" link, c copies the Sponsors
+				// URL.
 				switch msg.String() {
 				case "o":
 					return m, openURLCmd(sponsorURL)
+				case "b":
+					return m, openURLCmd(coffeeURL)
 				case "c":
 					return m, copyURLCmd(sponsorURL)
 				}

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,15 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.20.1": {
+		headline: "A small polish on the support links.",
+		items: []whatsNewItem{
+			{
+				title: "Buy me a coffee on this tab",
+				desc:  "The Support octoscope section here now offers the one-off \"buy me a coffee\" tip (press b) alongside recurring GitHub Sponsors (press o), mirroring the launch splash.",
+			},
+		},
+	},
 	"0.20.0": {
 		headline: "Integrity — scan your repos for the supply-chain worm.",
 		items: []whatsNewItem{

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -175,10 +175,21 @@ func renderWhatsNewTab(version string, available int) string {
 	b.WriteString("\n")
 	b.WriteString(mutedStyle.Width(wrapW).Render("If octoscope is useful to you, please consider sponsoring:"))
 	b.WriteString("\n")
-	// URL left unwrapped so it stays copy-pasteable.
-	b.WriteString(hyperlink(sponsorURL, valueStyle.Render(sponsorURL)))
+	// URLs left unwrapped so they stay copy-pasteable. Recurring
+	// GitHub Sponsors first, then the one-off "buy me a coffee" tip —
+	// same pairing the launch splash offers.
+	key := func(k, label string) string {
+		return boldStyle.Foreground(colAccent).Render(k) + "  " + mutedStyle.Render(label)
+	}
+	b.WriteString(key("o", "Sponsor on GitHub  (recurring)"))
+	b.WriteString("\n")
+	b.WriteString("   " + hyperlink(sponsorURL, valueStyle.Render(sponsorURL)))
 	b.WriteString("\n\n")
-	b.WriteString(keyHints("o", "open", "c", "copy"))
+	b.WriteString(key("b", "Buy me a coffee  (one-off)"))
+	b.WriteString("\n")
+	b.WriteString("   " + hyperlink(coffeeURL, valueStyle.Render(coffeeURL)))
+	b.WriteString("\n\n")
+	b.WriteString(keyHints("o", "sponsor", "b", "coffee", "c", "copy"))
 
 	return b.String()
 }

--- a/internal/ui/whatsnew_test.go
+++ b/internal/ui/whatsnew_test.go
@@ -20,7 +20,10 @@ func TestRenderWhatsNewTab(t *testing.T) {
 			"Full release notes",
 			"https://github.com/gfazioli/octoscope/releases",
 			"https://github.com/sponsors/gfazioli",
-			"o open",
+			"https://donate.stripe.com/fZu4gy4Tn3b1dgudGx0co00",
+			"Buy me a coffee",
+			"o sponsor",
+			"b coffee",
 		} {
 			if !strings.Contains(out, want) {
 				t.Errorf("render missing %q:\n%s", want, out)
@@ -68,9 +71,12 @@ func TestWhatsNewTabWiring(t *testing.T) {
 		t.Fatalf("after '6', activeTab = %d, want TabWhatsNew (%d)", m.activeTab, TabWhatsNew)
 	}
 
-	// On the What's new tab, o / c act on the sponsor link; other keys no-op.
+	// On the What's new tab, o / b / c act on the support links; other keys no-op.
 	if _, cmd := m.Update(key("o")); cmd == nil {
 		t.Error("'o' on What's new should return an open-URL cmd")
+	}
+	if _, cmd := m.Update(key("b")); cmd == nil {
+		t.Error("'b' on What's new should return an open-URL cmd")
 	}
 	if _, cmd := m.Update(key("c")); cmd == nil {
 		t.Error("'c' on What's new should return a copy-URL cmd")

--- a/internal/ui/whatsnew_test.go
+++ b/internal/ui/whatsnew_test.go
@@ -24,6 +24,7 @@ func TestRenderWhatsNewTab(t *testing.T) {
 			"Buy me a coffee",
 			"o sponsor",
 			"b coffee",
+			"c copy",
 		} {
 			if !strings.Contains(out, want) {
 				t.Errorf("render missing %q:\n%s", want, out)

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.20.0"
+const version = "0.20.1"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## What

The launch splash offers two ways to support octoscope — recurring **GitHub Sponsors** (`o`) and the one-off **"buy me a coffee"** Stripe tip (`b`) — but the persistent *Support octoscope* footer on the **What's new** tab only surfaced Sponsors. This adds the coffee link there too, so the tab mirrors the splash.

## Changes

- **`internal/ui/whatsnew.go`** — render both options under *Support octoscope*, using the same accent-bold key markers as the splash. Hints now read `o sponsor · b coffee · c copy`.
- **`internal/ui/model.go`** — the What's new key handler routes `b` to the coffee URL. `o` still opens Sponsors, `c` still copies the Sponsors URL.
- **`internal/ui/whatsnew_test.go`** — assert the coffee URL/label/hint and the `b` key wiring.

## Before / after

Before, the footer ended at the Sponsors URL. Now:

```
♥  Support octoscope
If octoscope is useful to you, please consider sponsoring:

o  Sponsor on GitHub  (recurring)
   https://github.com/sponsors/gfazioli

b  Buy me a coffee  (one-off)
   https://donate.stripe.com/fZu4gy4Tn3b1dgudGx0co00

o sponsor · b coffee · c copy
```

## Tests

`go test ./internal/ui/ -run WhatsNew` green; dual-target `make build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)