### PR TITLE
fix(github): strip UTF-8-encoded C1 control sequences in Sanitize

### DIFF
--- a/internal/github/sanitize.go
+++ b/internal/github/sanitize.go
@@ -27,8 +27,10 @@ import (
 //     sequences (covers the common attack shapes).
 //  2. The byte-level filter removes any remaining C0 control
 //     characters (0x00–0x1F) plus DEL (0x7F), keeping only
-//     newline and tab. C1 controls inside multi-byte UTF-8
-//     sequences are already covered by the ansi pass.
+//     newline and tab. UTF-8-encoded C1 controls (U+0080–U+009F,
+//     the 8-bit CSI/OSC/DCS introducers) are dropped by the
+//     byte-pair case below — ansi.Strip only handles the 7-bit
+//     ESC-prefixed forms.
 //
 // Idempotent — sanitising an already-sanitised string returns
 // the same string. Safe to call defensively at the render
@@ -53,7 +55,13 @@ func Sanitize(s string) string {
 		case c == '\n' || c == '\t':
 			b.WriteByte(c)
 		case c < 0x20 || c == 0x7F:
-			// drop
+			// C0 controls + DEL — drop
+		case c == 0xC2 && i+1 < len(s) && s[i+1] >= 0x80 && s[i+1] <= 0x9F:
+			// UTF-8-encoded C1 control (U+0080–U+009F: 0xC2 0x80–0xC2 0x9F),
+			// which includes the 8-bit CSI/OSC/DCS introducers. ansi.Strip
+			// only recognizes the 7-bit ESC-prefixed forms, so these arrive
+			// here intact; drop both bytes.
+			i++
 		default:
 			b.WriteByte(c)
 		}

--- a/internal/github/sanitize_test.go
+++ b/internal/github/sanitize_test.go
@@ -65,45 +65,37 @@ func TestSanitizeIdempotent(t *testing.T) {
 	}
 }
 
-// TestSanitizeC1ControlUTF8 characterizes the behavior of Sanitize when given
-// a string containing U+009B (the 8-bit CSI introducer), which encodes in
-// UTF-8 as the two bytes 0xC2 0x9B.
-//
-// The docstring claims: "C1 controls inside multi-byte UTF-8 sequences are
-// already covered by the ansi pass." This test pins what the code actually
-// does today, so that any future change in behavior is caught as a regression.
-//
-// Observed result: U+009B survives sanitization. ansi.Strip does not remove
-// it (it treats 0xC2 0x9B as an ordinary two-byte UTF-8 sequence, not a
-// CSI introducer), and the byte-level filter passes both bytes because they
-// are >= 0x80. The docstring claim is therefore INACCURATE for this code
-// path: a UTF-8-encoded C1 control is NOT stripped by the current
-// implementation. This is a characterization finding only — sanitize.go is
-// not modified here; the decision whether to fix the implementation is left
-// to the maintainer.
+// TestSanitizeC1ControlUTF8 verifies that Sanitize strips UTF-8-encoded C1
+// controls (U+0080–U+009F). These encode as the two-byte sequences 0xC2 0x80
+// through 0xC2 0x9F and include the 8-bit CSI/OSC/DCS introducers.
+// ansi.Strip only handles the 7-bit ESC-prefixed forms; the byte-pair case
+// in Sanitize covers the rest.
 func TestSanitizeC1ControlUTF8(t *testing.T) {
-	// U+009B (8-bit CSI introducer) encoded as UTF-8: 0xC2 0x9B
-	in := "ab"
-
-	got := Sanitize(in)
-
-	// Log the observed output so the result is always visible in verbose mode.
-	t.Logf("Sanitize(%q) = %q", in, got)
-
-	// Characterization: U+009B survives (observed behavior, not the
-	// docstring's claim). Pin it so a future change is detected.
-	want := "ab"
-	if got != want {
-		t.Errorf("Sanitize(%q) = %q, want %q", in, got, want)
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// U+0080–U+009F (UTF-8 0xC2 0x80–0xC2 0x9F) are the C1 controls.
+		{"C1 CSI introducer U+009B dropped", "a\u009bb", "ab"},
+		{"C1 low boundary U+0080 dropped", "a\u0080b", "ab"},
+		{"C1 high boundary U+009F dropped", "a\u009fb", "ab"},
+		// The introducer is removed, so an 8-bit SGR degrades to inert text.
+		{"8-bit CSI sequence neutered to literal text", "x\u009b31my", "x31my"},
+		// U+00A0 (just past C1) is a normal printable rune — must survive.
+		{"U+00A0 (just past C1) preserved", "a\u00a0b", "a\u00a0b"},
 	}
-
-	// Safety check: ensure no raw C0 control byte (< 0x20) or DEL (0x7F)
-	// slipped through, which would indicate a genuine security issue rather
-	// than a characterization variance.
-	for i := 0; i < len(got); i++ {
-		b := got[i]
-		if (b < 0x20 && b != '\n' && b != '\t') || b == 0x7F {
-			t.Errorf("Sanitize(%q) left raw control byte 0x%02X at position %d in output %q", in, b, i, got)
-		}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Sanitize(c.in)
+			if got != c.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", c.in, got, c.want)
+			}
+			for i := 0; i < len(got); i++ {
+				if b := got[i]; (b < 0x20 && b != '\n' && b != '\t') || b == 0x7F {
+					t.Errorf("Sanitize(%q) left raw control byte 0x%02X", c.in, b)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Hardens `Sanitize` (octoscope's terminal-injection boundary) to also strip
UTF-8-encoded **C1 control characters** (U+0080–U+009F) — the 8-bit
CSI/OSC/DCS introducers that `ansi.Strip` (which only handles the 7-bit
ESC-prefixed forms) leaves intact.

This closes a doc-vs-code gap surfaced while adding the `Sanitize` tests
(#23): the docstring claimed C1 controls in multi-byte UTF-8 were "already
covered by the ansi pass" — they were not. A UTF-8-encoded U+009B
(bytes `0xC2 0x9B`) passed straight through both `ansi.Strip` and the byte
filter (both bytes are ≥ 0x80).

## Change

- `internal/github/sanitize.go`: a **surgical byte-pair case** drops `0xC2`
  followed by `0x80`–`0x9F` (the exact UTF-8 encoding of U+0080–U+009F),
  consuming both bytes. Deliberately *not* a rune-based rewrite, to preserve
  the current byte-for-byte handling of all other input (including invalid
  UTF-8). Docstring corrected to match.
- `internal/github/sanitize_test.go`: `TestSanitizeC1ControlUTF8` now asserts
  C1 is **stripped**, with boundary cases (U+0080 / U+009F), an
  8-bit-CSI-neutered-to-literal-text case, and a `U+00A0 (just past C1)
  preserved` regression guard that proves the fix doesn't over-reach into the
  adjacent printable range (U+00A0 shares the `0xC2` lead byte).

## Severity

Low in practice — modern UTF-8 terminals don't interpret `0xC2 0x9B` as the
8-bit CSI introducer — but a security boundary should keep the contract it
documents. The test's safety check confirms no raw C0/DEL byte ever leaks
through.

## Verification

- `go test -race ./...` — green (including the new C1 cases)
- `go vet ./...`, `gofmt -l .` — clean
- `govulncheck ./...` — clean (the CI gate, now on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text sanitization to properly strip UTF-8-encoded control characters, improving security and preventing potential display issues from malformed input sequences.

* **Tests**
  * Updated and expanded test coverage to verify correct handling of edge-case control character encodings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->