### PR TITLE
test(auth): cover token resolution order with an injectable gh seam

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+// ghTokenOutput runs `gh auth token` and returns its raw stdout. It is a
+// package var so tests can stub the gh CLI fallback without invoking the
+// real binary (which would make the test depend on the host's gh login).
+var ghTokenOutput = func() ([]byte, error) {
+	return exec.Command("gh", "auth", "token").Output()
+}
+
 // Token returns a GitHub personal access token by, in order:
 //
 //  1. $GITHUB_TOKEN env var
@@ -19,7 +26,7 @@ func Token() string {
 	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
 		return t
 	}
-	out, err := exec.Command("gh", "auth", "token").Output()
+	out, err := ghTokenOutput()
 	if err != nil {
 		return ""
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestTokenResolutionOrder covers the three-way fallback in Token():
+// env var wins, gh CLI is the fallback, errors and whitespace yield "".
+func TestTokenResolutionOrder(t *testing.T) {
+	cases := []struct {
+		name   string
+		envVal string
+		cliOut []byte
+		cliErr error
+		want   string
+	}{
+		{
+			name:   "env var wins over the CLI",
+			envVal: "env-token",
+			cliOut: []byte("cli-token"),
+			cliErr: nil,
+			want:   "env-token",
+		},
+		{
+			name:   "env var is trimmed",
+			envVal: "  env-token\n",
+			cliOut: nil,
+			cliErr: nil,
+			want:   "env-token",
+		},
+		{
+			name:   "empty env falls through to the CLI",
+			envVal: "",
+			cliOut: []byte("cli-token\n"),
+			cliErr: nil,
+			want:   "cli-token",
+		},
+		{
+			name:   "CLI error yields empty string",
+			envVal: "",
+			cliOut: nil,
+			cliErr: errors.New("gh not logged in"),
+			want:   "",
+		},
+		{
+			name:   "CLI whitespace-only yields empty string",
+			envVal: "",
+			cliOut: []byte("   \n"),
+			cliErr: nil,
+			want:   "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", c.envVal)
+
+			orig := ghTokenOutput
+			defer func() { ghTokenOutput = orig }()
+			cliOut, cliErr := c.cliOut, c.cliErr
+			ghTokenOutput = func() ([]byte, error) { return cliOut, cliErr }
+
+			if got := Token(); got != c.want {
+				t.Errorf("got = %q, want %q", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds unit tests for `auth.Token()`'s resolution order — the
env var → `gh auth token` → unauthenticated fallback that runs on every
launch. A regression here silently downgrades an authenticated session
(5000 req/h) to unauthenticated (60 req/h), so the order and trimming deserve
coverage. The `auth` package had none.

## Change

- `internal/auth/auth.go`: a minimal, idiomatic **test seam** — `ghTokenOutput`
  is now a package var wrapping `exec.Command("gh", "auth", "token").Output()`,
  so tests can stub the CLI fallback without invoking the real `gh` binary.
  `Token()`'s observable behavior is unchanged.
- `internal/auth/auth_test.go` (new): table-driven `TestTokenResolutionOrder`
  — env wins over CLI, env is trimmed, empty env falls through to the CLI,
  CLI error → `""`, CLI whitespace-only → `""`. Uses `t.Setenv` and stubs the
  seam (restored via `defer`). Fake token strings only.

## Verification

- `go test -race ./...`, `go vet ./...`, `gofmt -l .` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
