### PR TITLE
fix(ui): strip UTF-8-encoded C1 controls in sanitizeBody

### DIFF
--- a/internal/ui/markdown.go
+++ b/internal/ui/markdown.go
@@ -39,8 +39,11 @@ func renderDetailDescription(body string, width int) string {
 // Two-stage strip:
 //  1. ansi.Strip removes well-formed CSI / OSC / SGR sequences.
 //  2. The byte-level filter removes any remaining C0 control
-//     characters (0x00–0x1F) except tab and newline, plus DEL
-//     (0x7F). C1 controls are already covered by the ansi pass.
+//     characters (0x00–0x1F) plus DEL (0x7F), keeping only
+//     newline and tab. UTF-8-encoded C1 controls (U+0080–U+009F,
+//     the 8-bit CSI/OSC/DCS introducers) are dropped by the
+//     byte-pair case below — ansi.Strip only handles the 7-bit
+//     ESC-prefixed forms.
 //
 // Result is safe to feed to glamour or to lipgloss directly.
 // Idempotent — sanitizing an already-sanitized string returns
@@ -55,7 +58,13 @@ func sanitizeBody(s string) string {
 		case c == '\n' || c == '\t':
 			b.WriteByte(c)
 		case c < 0x20 || c == 0x7F:
-			// drop
+			// C0 controls + DEL — drop
+		case c == 0xC2 && i+1 < len(s) && s[i+1] >= 0x80 && s[i+1] <= 0x9F:
+			// UTF-8-encoded C1 control (U+0080–U+009F: 0xC2 0x80–0xC2 0x9F),
+			// which includes the 8-bit CSI/OSC/DCS introducers. ansi.Strip
+			// only recognizes the 7-bit ESC-prefixed forms, so these arrive
+			// here intact; drop both bytes.
+			i++
 		default:
 			b.WriteByte(c)
 		}

--- a/internal/ui/markdown_test.go
+++ b/internal/ui/markdown_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"testing"
+)
+
+// TestSanitizeBody pins the core behaviors of sanitizeBody: ANSI stripping,
+// C0 control removal, and C1 UTF-8 byte-pair removal.
+func TestSanitizeBody(t *testing.T) {
+	const esc = "\x1b"
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain ascii unchanged", "hello world", "hello world"},
+		{"newline preserved", "a\nb", "a\nb"},
+		{"tab preserved", "a\tb", "a\tb"},
+		{"carriage return dropped", "a\rb", "ab"},
+		{"null byte dropped", "a\x00b", "ab"},
+		{"bell dropped", "a\x07b", "ab"},
+		{"DEL dropped", "a\x7fb", "ab"},
+		{"CSI SGR color stripped", esc + "[31mred" + esc + "[0m", "red"},
+		{"OSC 8 hyperlink stripped", esc + "]8;;https://x" + esc + "\\" + "label" + esc + "]8;;" + esc + "\\", "label"},
+		{"utf8 accents preserved", "caf\u00e9 r\u00e9sum\u00e9", "caf\u00e9 r\u00e9sum\u00e9"},
+		{"utf8 cjk preserved", "\u65e5\u672c\u8a9e", "\u65e5\u672c\u8a9e"},
+		{"utf8 emoji preserved", "ship \U0001f680 it", "ship \U0001f680 it"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := sanitizeBody(c.in)
+			if got != c.want {
+				t.Errorf("sanitizeBody(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeBodyC1Controls verifies that sanitizeBody strips UTF-8-encoded
+// C1 controls (U+0080-U+009F). These encode as the two-byte sequences
+// 0xC2 0x80 through 0xC2 0x9F and include the 8-bit CSI/OSC/DCS
+// introducers. ansi.Strip only handles the 7-bit ESC-prefixed forms; the
+// byte-pair case in sanitizeBody covers the rest.
+func TestSanitizeBodyC1Controls(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// U+0080-U+009F (UTF-8 0xC2 0x80 through 0xC2 0x9F) are the C1 controls.
+		{"C1 CSI introducer U+009B dropped", "a\u009bb", "ab"},
+		{"C1 low boundary U+0080 dropped", "a\u0080b", "ab"},
+		{"C1 high boundary U+009F dropped", "a\u009fb", "ab"},
+		// The introducer is removed, so an 8-bit SGR degrades to inert text.
+		{"8-bit CSI sequence neutered to literal text", "x\u009b31my", "x31my"},
+		// U+00A0 (just past C1) is a normal printable rune -- must survive.
+		{"U+00A0 (just past C1) preserved", "a\u00a0b", "a\u00a0b"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := sanitizeBody(c.in)
+			if got != c.want {
+				t.Errorf("sanitizeBody(%q) = %q, want %q", c.in, got, c.want)
+			}
+			for i := 0; i < len(got); i++ {
+				if b := got[i]; (b < 0x20 && b != '\n' && b != '\t') || b == 0x7F {
+					t.Errorf("sanitizeBody(%q) left raw control byte 0x%02X", c.in, b)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Brings `internal/ui/markdown.go`'s `sanitizeBody` — the render-layer
defense-in-depth sanitizer — in line with `github.Sanitize` after #25: it now
strips UTF-8-encoded C1 controls (U+0080–U+009F), and its docstring (which
still claimed "C1 controls are already covered by the ansi pass") is corrected.
Flagged by CodeRabbit on #25.

## Change

- `internal/ui/markdown.go`: the same surgical byte-pair case as `Sanitize`
  (drop `0xC2` followed by `0x80`–`0x9F`); docstring fixed. Not rune-based.
- `internal/ui/markdown_test.go` (new — the file had no tests):
  `TestSanitizeBody` (C0 / ANSI / UTF-8 basics) and `TestSanitizeBodyC1Controls`
  (C1 stripped, boundaries, 8-bit-CSI neutered, and a `U+00A0 preserved`
  regression guard with a control-byte safety check). Mirrors
  `internal/github/sanitize_test.go`.

## Severity

Low — all content already passes through `github.Sanitize` (which strips C1)
before reaching `sanitizeBody`, so this is consistency + completeness of the
second layer, not a live exposure.

## Verification

- `go test -race ./...`, `go vet ./...`, `gofmt -l .` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization of control characters in content to ensure safer terminal display and prevent potential terminal manipulation issues.

* **Tests**
  * Added comprehensive tests to verify proper handling of control characters and escape sequences in content sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->