### PR TITLE
ci: bump actions to Node 24 majors and pin goreleaser to ~> v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -43,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -54,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -72,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -42,8 +42,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -53,8 +53,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -71,8 +71,8 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,22 +37,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # goreleaser needs full history to compute the changelog
           # from commit messages since the previous tag.
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
           cache: true
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Clears the two warnings surfaced by the v0.20.2 release run.

1. **Node.js 20 deprecation.** GitHub is removing the Node 20 runtime; `actions/checkout@v4`, `actions/setup-go@v5` and `goreleaser/goreleaser-action@v6` still target Node 20 and were being force-run on Node 24 with a warning. Bumped to the current Node-24 majors: **checkout v4 → v7**, **setup-go v5 → v6**, **goreleaser-action v6 → v7**.
2. **goreleaser `latest`.** The action warned it was defaulting to `latest` and would lock to `~> v2`. Pinned `version: "~> v2"` explicitly for reproducible releases.

## Scope

- `.github/workflows/ci.yml` — checkout/setup-go bumps across all four jobs.
- `.github/workflows/release.yml` — checkout/setup-go/goreleaser-action bumps + the goreleaser version pin.

## Validation

- The `ci.yml` bumps are exercised by **this PR's own CI run** (build / test / lint / govulncheck on `checkout@v7` + `setup-go@v6`).
- `release.yml` only runs on a `v*` tag, so its changes are validated at the **next** release — but they're standard configs (the `~> v2` pin is exactly what the action recommended; `go-version: stable` is supported on setup-go v6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow automation actions to newer versions to improve build stability and compatibility.
  * Updated the release workflow’s automation actions and constrained the GoReleaser major version used during releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->