### PR TITLE
ci: pin actions to commit SHAs and add Dependabot to keep them current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Keep the SHA-pinned GitHub Actions current. The workflow `uses:` refs are
+# pinned to commit SHAs (with a trailing version comment) for supply-chain
+# safety; Dependabot opens a PR to bump the SHA + comment when a new release
+# of an action ships, so pinning doesn't freeze us on a stale, unpatched
+# action. Scoped to github-actions only — Go module updates stay manual.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -44,10 +44,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -57,10 +57,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -77,10 +77,10 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,20 +37,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # goreleaser needs full history to compute the changelog
           # from commit messages since the previous tag.
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
           cache: true
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
## What

Pins every GitHub Action to an immutable commit SHA (with a version comment) and adds Dependabot to keep the pins current — closing out the SHA-pinning suggestion deferred from #29.

## Why

Floating major tags (`@v7`) can be retargeted upstream, which is the supply-chain surface CodeRabbit flagged. Pinning to a SHA removes it. The catch is that a SHA pin *freezes* the action until someone bumps it — so this also adds `.github/dependabot.yml` (github-actions ecosystem, weekly, grouped into one PR), which opens a PR to bump the SHA **and** its version comment whenever a new release ships. Pinned, but not stale.

## Change

- `ci.yml` + `release.yml` — pinned refs (with `# vX.Y.Z` comments Dependabot reads):
  - `actions/checkout` → `9c091bb` (v7.0.0)
  - `actions/setup-go` → `4a36011` (v6.4.0)
  - `goreleaser/goreleaser-action` → `5daf1e9` (v7.2.2)
- `.github/dependabot.yml` (new) — weekly github-actions updates, grouped, `ci:` commit prefix. Scoped to actions only; Go module bumps stay manual.

## Validation

- The `ci.yml` pins are exercised by **this PR's own CI** (identical action code, just referenced by SHA).
- `release.yml` is validated at the **next** tag (standard).
- The Dependabot config is read by GitHub (no CI impact); it'll show under Insights → Dependency graph → Dependabot on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
