### PR TITLE
feat(issues): pin/unpin issues with a sticky section (v0.21.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,17 @@ check_for_updates = true
 #   "gfazioli/Mantine-Hint",
 # ]
 
+# Issues pinned to the top of the Issues tab (v0.21.0+). Each entry
+# is "owner/name#N"; order is preserved exactly as listed here. Press
+# P on any issue row to add / remove it — the file is rewritten
+# atomically. Malformed entries are dropped silently at load, and a
+# pinned issue that gets closed simply stops showing (the entry is
+# harmless).
+# pinned_issues = [
+#   "gfazioli/octoscope#42",
+#   "charmbracelet/bubbletea#1234",
+# ]
+
 # External repositories to monitor in a Watched section under
 # the Repos tab (v0.14.0+). Hand-edit only — there is no
 # in-app toggle. Each entry resolves to its own GraphQL query
@@ -477,8 +488,8 @@ Key bindings while running:
 | `o` | Open the selected repo / PR / issue in your browser (or, inside the PR diff viewer, the PR's Files-changed tab on github.com) |
 | `c` | Copy the selected row's URL (or, inside the PR diff viewer / files list, the current file's path) to your system clipboard |
 | `f` | Inside the PR drill-in: inspect the changed files (full-screen list → Enter opens each file's diff with syntax highlighting) |
-| `P` | On a Repos row: toggle pin/unpin (pinned repos stick to the top of the Repos tab, ordering preserved across refreshes; writes back to config) |
-| `o` / `d` / `c` / `P` | Inside the action menu on Repos: Open in GitHub · View details · Copy URL · Pin/Unpin |
+| `P` | On a Repos or Issues row: toggle pin/unpin (pinned rows stick to the top of that tab, ordering preserved across refreshes; writes back to config) |
+| `o` / `d` / `c` / `P` | Inside the action menu on Repos or Issues: Open in GitHub · View details · Copy URL · Pin/Unpin |
 | `esc` | Close the action menu / detail view, or clear the current filter |
 | `r` | Refresh now (or refetch the current detail view when open) |
 | `p` | Toggle public-only mode (saves to config) |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1023,7 +1023,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.20.2</span>
+                <span class="version-tag" id="version-pill">0.21.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1201,6 +1201,11 @@
                     <div class="feature-label">Integrity scan</div>
                     <h3>Catch the supply-chain worm</h3>
                     <p>Since v0.20.0. On a repo's action menu, <code class="inline">s</code> runs a read-only <strong style="color: var(--text);">supply-chain integrity scan</strong> for the Shai-Hulud / Miasma class of attack &mdash; scoring auto-execution surfaces, oversized / obfuscated payloads and forged or unsigned commit tips, not a single filename, so renamed variants still trip it. It explains every finding and hands you a fix script plus the right revoke links; it never touches the repo.</p>
+                </div>
+                <div class="feature">
+                    <div class="feature-label">Pinned issues</div>
+                    <h3>Float what matters to the top</h3>
+                    <p>Since v0.21.0. Press <code class="inline">P</code> on an Issues row to <strong style="color: var(--text);">pin</strong> it &mdash; pinned issues stick to the top of the tab in the order you pin them, compose with the sort cycle and <code class="inline">/</code> search, and are persisted to <code class="inline">pinned_issues</code> in your config. The same sticky-section treatment the Repos tab already had.</p>
                 </div>
                 <div class="feature">
                     <div class="feature-label">Configurable</div>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,16 @@ type Config struct {
 	// occurrence so the file's intent is preserved.
 	PinnedRepos []string `toml:"pinned_repos"`
 
+	// PinnedIssues is the list of "owner/name#N" identifiers that the
+	// Issues tab will surface in a dedicated section above the rest
+	// of the list, in the order written here. v0.21.0+ feature.
+	// Each entry must look exactly like "owner/name#N" (a positive
+	// issue number) — anything else is silently dropped at load time
+	// (see SanitizeIssueList), so a typo in the file can't crash the
+	// app on boot. Duplicates are de-duplicated keeping the first
+	// occurrence so the file's intent is preserved.
+	PinnedIssues []string `toml:"pinned_issues"`
+
 	// WatchRepos is the v0.14.0 counterpart of PinnedRepos for
 	// repositories the user doesn't own. Same "owner/name"
 	// schema, same sanitiser (SanitizeRepoList). Surfaces a
@@ -129,6 +139,7 @@ func Defaults() Config {
 		Theme:           "octoscope",
 		AccentColor:     "",
 		PinnedRepos:     nil,
+		PinnedIssues:    nil,
 		WatchRepos:      nil,
 		ShowSponsor:     true,
 		CheckForUpdates: true,
@@ -172,6 +183,75 @@ func SanitizeRepoList(in []string) []string {
 		return nil
 	}
 	return out
+}
+
+// SanitizeIssueList is the PinnedIssues counterpart of
+// SanitizeRepoList: it returns a fresh slice with empty entries
+// dropped, "owner/name#N" shape enforced, and duplicates removed
+// (first occurrence wins so the file's ordering survives). Used at
+// Load time and as a defensive pre-Save scrub so a bad in-memory
+// list never reaches disk.
+//
+// The shape check splits on the last "#" into an "owner/name" part
+// (exactly one "/" with both sides non-empty) and a number part
+// (non-empty, all ASCII digits, no sign — a positive issue number).
+// Anything else is silently dropped — callers can compare len(in)
+// vs len(out) to detect a file worth warning the user about.
+func SanitizeIssueList(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			continue
+		}
+		// Split on the LAST "#": an owner or name can't contain "#",
+		// but splitting on the last one is robust regardless.
+		hash := strings.LastIndex(s, "#")
+		if hash <= 0 || hash == len(s)-1 {
+			continue
+		}
+		repoPart := s[:hash]
+		numPart := s[hash+1:]
+		// owner/name shape: exactly one "/" with both sides non-empty.
+		parts := strings.Split(repoPart, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		// numPart must be all ASCII digits (a positive issue number);
+		// this also rejects a leading "+" / "-".
+		if !isAllDigits(numPart) {
+			continue
+		}
+		key := strings.ToLower(s)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// isAllDigits reports whether s is non-empty and every byte is an
+// ASCII digit 0-9. Used by SanitizeIssueList to validate the "#N"
+// suffix of a pinned issue identifier.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // DefaultPath returns the file octoscope looks for absent
@@ -224,6 +304,7 @@ func Load(path string) (Config, error) {
 		Theme           string   `toml:"theme"`
 		AccentColor     string   `toml:"accent_color"`
 		PinnedRepos     []string `toml:"pinned_repos"`
+		PinnedIssues    []string `toml:"pinned_issues"`
 		WatchRepos      []string `toml:"watch_repos"`
 		ShowSponsor     *bool    `toml:"show_sponsor"`
 		CheckForUpdates *bool    `toml:"check_for_updates"`
@@ -253,6 +334,7 @@ func Load(path string) (Config, error) {
 		cfg.AccentColor = raw.AccentColor
 	}
 	cfg.PinnedRepos = SanitizeRepoList(raw.PinnedRepos)
+	cfg.PinnedIssues = SanitizeIssueList(raw.PinnedIssues)
 	cfg.WatchRepos = SanitizeRepoList(raw.WatchRepos)
 	if raw.ShowSponsor != nil {
 		cfg.ShowSponsor = *raw.ShowSponsor
@@ -307,6 +389,23 @@ func Save(path string, cfg Config) error {
 		pinnedLine = b.String()
 	}
 
+	// pinned_issues block: same shape as pinned_repos but the
+	// identifier is "owner/name#N". Toggled at runtime with P on an
+	// Issues row; defensively re-sanitised here so garbage can't reach
+	// disk.
+	pinnedIssuesLine := ""
+	if pins := SanitizeIssueList(cfg.PinnedIssues); len(pins) > 0 {
+		var b strings.Builder
+		b.WriteString("\n# Issues pinned to the top of the Issues tab.\n")
+		b.WriteString("# Order preserved; press P on a row to toggle.\n")
+		b.WriteString("pinned_issues = [\n")
+		for _, p := range pins {
+			fmt.Fprintf(&b, "  %q,\n", p)
+		}
+		b.WriteString("]\n")
+		pinnedIssuesLine = b.String()
+	}
+
 	// watch_repos block: same shape as pinned_repos, hand-edit
 	// only (no runtime toggle), surfaces a separate section under
 	// the Repos tab for repositories the user doesn't own.
@@ -349,7 +448,7 @@ show_sponsor = %t
 # small notice when one exists. Never auto-updates the binary — it only
 # suggests the upgrade command. Set to false to disable.
 check_for_updates = %t
-%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, cfg.CheckForUpdates, accentLine, pinnedLine, watchLine)
+%s%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, cfg.CheckForUpdates, accentLine, pinnedLine, pinnedIssuesLine, watchLine)
 
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,3 +95,146 @@ pinned_repos = [
 		t.Errorf("pinned = %#v, want %#v", cfg.PinnedRepos, want)
 	}
 }
+
+// TestSanitizeIssueList pins the "owner/name#N" contract: accept a
+// well-formed identifier, reject the malformed shapes (no "#", empty
+// or non-numeric number, signed number, bad owner/name), trim
+// surrounding whitespace, and de-duplicate case-insensitively keeping
+// the first occurrence.
+func TestSanitizeIssueList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "nil in, nil out",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "valid passes through",
+			in:   []string{"gfazioli/octoscope#42", "charmbracelet/glamour#7"},
+			want: []string{"gfazioli/octoscope#42", "charmbracelet/glamour#7"},
+		},
+		{
+			name: "leading/trailing whitespace trimmed",
+			in:   []string{"  gfazioli/octoscope#42  "},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "missing # dropped",
+			in:   []string{"gfazioli/octoscope", "gfazioli/octoscope#42"},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "empty number dropped",
+			in:   []string{"gfazioli/octoscope#", "gfazioli/octoscope#42"},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "non-numeric number dropped",
+			in:   []string{"gfazioli/octoscope#abc", "gfazioli/octoscope#42"},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "signed number dropped",
+			in:   []string{"gfazioli/octoscope#-1", "gfazioli/octoscope#+3", "gfazioli/octoscope#42"},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "bad owner/name dropped — missing owner",
+			in:   []string{"/octoscope#42", "gfazioli/octoscope#42"},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "bad owner/name dropped — missing name",
+			in:   []string{"gfazioli/#42", "gfazioli/octoscope#42"},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "bad owner/name dropped — too many segments",
+			in:   []string{"a/b/c#42", "gfazioli/octoscope#42"},
+			want: []string{"gfazioli/octoscope#42"},
+		},
+		{
+			name: "bare owner/name (no #N) rejected",
+			in:   []string{"gfazioli/octoscope"},
+			want: nil,
+		},
+		{
+			name: "duplicates dropped, case-insensitive, first wins",
+			in:   []string{"gfazioli/Octoscope#42", "GFAZIOLI/OCTOSCOPE#42"},
+			want: []string{"gfazioli/Octoscope#42"},
+		},
+		{
+			name: "same repo different numbers kept",
+			in:   []string{"gfazioli/octoscope#42", "gfazioli/octoscope#7"},
+			want: []string{"gfazioli/octoscope#42", "gfazioli/octoscope#7"},
+		},
+		{
+			name: "all entries invalid → nil",
+			in:   []string{"", "no-hash", "a/b#", "a/b#x", "/x#1"},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeIssueList(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadPinnedIssues covers the end-to-end TOML parse + sanitize
+// path for pinned_issues: a file with mixed valid / malformed entries
+// produces a clean slice on the Config.
+func TestLoadPinnedIssues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	body := []byte(`
+refresh_interval = "30s"
+pinned_issues = [
+  "gfazioli/octoscope#42",
+  "",
+  "no-hash",
+  "gfazioli/octoscope#abc",
+  "GFAZIOLI/OCTOSCOPE#42",
+  "charmbracelet/glamour#7",
+]
+`)
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"gfazioli/octoscope#42", "charmbracelet/glamour#7"}
+	if !reflect.DeepEqual(cfg.PinnedIssues, want) {
+		t.Errorf("pinnedIssues = %#v, want %#v", cfg.PinnedIssues, want)
+	}
+}
+
+// TestSaveLoadPinnedIssuesRoundTrip asserts a pinned_issues list
+// written by Save survives a subsequent Load unchanged — the property
+// the runtime P toggle relies on.
+func TestSaveLoadPinnedIssuesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := Defaults()
+	cfg.PinnedIssues = []string{"gfazioli/octoscope#42", "charmbracelet/glamour#7"}
+	if err := Save(path, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !reflect.DeepEqual(got.PinnedIssues, cfg.PinnedIssues) {
+		t.Errorf("round-trip pinnedIssues = %#v, want %#v", got.PinnedIssues, cfg.PinnedIssues)
+	}
+}

--- a/internal/ui/issues.go
+++ b/internal/ui/issues.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -48,14 +49,18 @@ func (im IssuesModel) IsInputMode() bool {
 }
 
 // selectedIssue returns the issue at the current cursor inside the
-// sorted-and-filtered view. Same idiom as ReposModel.selectedRepo /
-// PRsModel.selectedPR — used by the action menu so the dispatcher
-// doesn't reimplement the list pipeline.
-func (im IssuesModel) selectedIssue(stats *github.Stats) (github.Issue, bool) {
+// sorted-filtered-partitioned view. Same idiom as
+// ReposModel.selectedRepo / PRsModel.selectedPR — used by the action
+// menu so the dispatcher doesn't reimplement the list pipeline.
+//
+// `pinned` is the ordered list of "owner/name#N" entries that render
+// in the sticky top section. An empty slice degenerates the partition
+// into a single section — same behaviour as before v0.21.0.
+func (im IssuesModel) selectedIssue(stats *github.Stats, pinned []string) (github.Issue, bool) {
 	if stats == nil {
 		return github.Issue{}, false
 	}
-	rows := sortIssues(filterIssues(stats.OpenIssuesList, im.query), im.sort)
+	rows, _, _ := visibleIssuesPartitioned(stats.OpenIssuesList, im.query, im.sort, pinned)
 	if len(rows) == 0 {
 		return github.Issue{}, false
 	}
@@ -69,7 +74,13 @@ func (im IssuesModel) selectedIssue(stats *github.Stats) (github.Issue, bool) {
 	return rows[idx], true
 }
 
-func (im IssuesModel) Update(msg tea.Msg, stats *github.Stats) (IssuesModel, tea.Cmd) {
+// Update handles key events routed from the root model when the
+// Issues tab is active. `pinned` is the live list of pinned
+// "owner/name#N" identifiers so the cursor walks the same partitioned
+// ordering the view paints — without it, the cursor at row N would
+// resolve to a different issue than the highlighted one once any issue
+// got pinned.
+func (im IssuesModel) Update(msg tea.Msg, stats *github.Stats, pinned []string) (IssuesModel, tea.Cmd) {
 	km, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return im, nil
@@ -78,10 +89,15 @@ func (im IssuesModel) Update(msg tea.Msg, stats *github.Stats) (IssuesModel, tea
 		return im.updateSearch(km), nil
 	}
 
-	n := 0
+	// Row count + ordering drive cursor bounds and the row-key
+	// handlers. Built from the same pipeline the renderer uses
+	// (visibleIssuesPartitioned) so Update + View can never disagree
+	// on which issue lives at index N.
+	var rows []github.Issue
 	if stats != nil {
-		n = len(filterIssues(stats.OpenIssuesList, im.query))
+		rows, _, _ = visibleIssuesPartitioned(stats.OpenIssuesList, im.query, im.sort, pinned)
 	}
+	n := len(rows)
 
 	switch km.String() {
 	case "up", "k":
@@ -106,23 +122,29 @@ func (im IssuesModel) Update(msg tea.Msg, stats *github.Stats) (IssuesModel, tea
 	case "enter", "d":
 		// v0.11.0: Enter / d → drill-in detail. Was openURLCmd
 		// through v0.10.1. See repos.go for the rationale.
-		if stats == nil || n == 0 || im.cursor >= n {
+		if n == 0 || im.cursor >= n {
 			return im, nil
 		}
-		rows := sortIssues(filterIssues(stats.OpenIssuesList, im.query), im.sort)
 		return im, viewIssueDetailCmd(rows[im.cursor])
 	case "o":
-		if stats == nil || n == 0 || im.cursor >= n {
+		if n == 0 || im.cursor >= n {
 			return im, nil
 		}
-		rows := sortIssues(filterIssues(stats.OpenIssuesList, im.query), im.sort)
 		return im, openURLCmd(rows[im.cursor].URL)
 	case "c":
-		if stats == nil || n == 0 || im.cursor >= n {
+		if n == 0 || im.cursor >= n {
 			return im, nil
 		}
-		rows := sortIssues(filterIssues(stats.OpenIssuesList, im.query), im.sort)
 		return im, copyURLCmd(rows[im.cursor].URL)
+	case "P":
+		// Toggle pin/unpin (v0.21.0). Capital P, mirror of the Repos
+		// tab. The list mutation + config writeback happen in the root
+		// model's pinIssueToggledMsg handler; this sub-model only emits
+		// the request.
+		if n == 0 || im.cursor >= n {
+			return im, nil
+		}
+		return im, togglePinIssueCmd(issueID(rows[im.cursor]), !isPinnedIssue(rows[im.cursor], pinned))
 	case "esc":
 		if im.query != "" {
 			im.query = ""
@@ -194,7 +216,103 @@ func sortIssues(issues []github.Issue, mode IssuesSort) []github.Issue {
 	return out
 }
 
-func (im IssuesModel) renderIssuesTab(stats *github.Stats, available, availableHeight int) string {
+// issueID is the pin identity for an issue: "owner/name#N". Unlike
+// repos (which parse owner/name out of a URL) the Issue struct
+// already carries Repo ("owner/name") and Number, so the identity is
+// a direct concatenation.
+func issueID(it github.Issue) string {
+	return it.Repo + "#" + strconv.Itoa(it.Number)
+}
+
+// isPinnedIssue reports whether an issue's "owner/name#N" identity is
+// in pins (case-insensitive). Mirrors repos.isPinned but needs no URL
+// parse. Used by the action-menu label ("Pin" vs "Unpin").
+func isPinnedIssue(it github.Issue, pins []string) bool {
+	if len(pins) == 0 {
+		return false
+	}
+	key := strings.ToLower(issueID(it))
+	for _, p := range pins {
+		if strings.ToLower(p) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// partitionIssuesByPinned splits issues into (pinned, rest); pinned
+// are ordered by their position in pins (config order preserved),
+// rest keeps input order. Comparison is case-insensitive on the
+// "owner/name#N" identity. A pinned id that matches no issue in the
+// input is silently absent — a closed/stale pinned entry simply
+// doesn't appear. Mirror of repos.partitionByPinned.
+func partitionIssuesByPinned(issues []github.Issue, pins []string) (pinned, rest []github.Issue) {
+	if len(pins) == 0 {
+		return nil, issues
+	}
+	rank := make(map[string]int, len(pins))
+	for i, p := range pins {
+		rank[strings.ToLower(p)] = i
+	}
+	type ranked struct {
+		it   github.Issue
+		rank int
+	}
+	var ordered []ranked
+	rest = make([]github.Issue, 0, len(issues))
+	for _, it := range issues {
+		if pos, ok := rank[strings.ToLower(issueID(it))]; ok {
+			ordered = append(ordered, ranked{it, pos})
+			continue
+		}
+		rest = append(rest, it)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].rank < ordered[j].rank })
+	pinned = make([]github.Issue, len(ordered))
+	for i, e := range ordered {
+		pinned[i] = e.it
+	}
+	return pinned, rest
+}
+
+// visibleIssuesPartitioned is the single source of truth for the
+// Issues row pipeline: the pinned section on top (config order),
+// then the filtered-and-sorted rest. The `/` filter applies to both
+// segments; the sort cycle re-orders only the rest, like the Repos
+// tab. selectedIssue, the Update cursor bounds and renderIssuesTab
+// all consume it so the cursor can never disagree with the paint.
+// Mirror of repos.visibleReposPartitioned (2-way, no watched
+// section).
+func visibleIssuesPartitioned(open []github.Issue, query string, mode IssuesSort, pinned []string) (rows []github.Issue, pinCount, restCount int) {
+	filtered := filterIssues(open, query)
+	pinnedRows, rest := partitionIssuesByPinned(filtered, pinned)
+	rest = sortIssues(rest, mode)
+	rows = make([]github.Issue, 0, len(pinnedRows)+len(rest))
+	rows = append(rows, pinnedRows...)
+	rows = append(rows, rest...)
+	return rows, len(pinnedRows), len(rest)
+}
+
+// togglePinIssueCmd asks the root model to flip an issue's pinned
+// state. `pin == true` means "add to the pinned list"; false means
+// "remove". The root holds the canonical pinnedIssues slice and runs
+// the config writeback + toast in one place. Mirror of togglePinCmd.
+func togglePinIssueCmd(id string, pin bool) tea.Cmd {
+	return func() tea.Msg {
+		return pinIssueToggledMsg{id: id, pin: pin}
+	}
+}
+
+// pinIssueToggledMsg is fired from the Issues tab (and the action
+// menu) asking the root model to update the pinned-issues list.
+// Carries the "owner/name#N" identity — already complete, no URL
+// parse needed (unlike pinToggledMsg).
+type pinIssueToggledMsg struct {
+	id  string
+	pin bool
+}
+
+func (im IssuesModel) renderIssuesTab(stats *github.Stats, available, availableHeight int, pinned []string) string {
 	if stats == nil {
 		return mutedStyle.Render("(no issue data yet — waiting for first refresh)")
 	}
@@ -202,7 +320,9 @@ func (im IssuesModel) renderIssuesTab(stats *github.Stats, available, availableH
 		return mutedStyle.Render("(no open issues you authored)")
 	}
 
-	rows := sortIssues(filterIssues(stats.OpenIssuesList, im.query), im.sort)
+	// Single source of truth for the row pipeline (pinned section on
+	// top, then filtered+sorted rest). pinCount positions the divider.
+	rows, pinCount, _ := visibleIssuesPartitioned(stats.OpenIssuesList, im.query, im.sort, pinned)
 
 	cursor := im.cursor
 	if cursor >= len(rows) {
@@ -255,7 +375,7 @@ func (im IssuesModel) renderIssuesTab(stats *github.Stats, available, availableH
 			mutedStyle.Render("   (esc to clear)")
 	}
 
-	table := renderIssuesTable(rows[offset:end], cursor-offset, im.sort)
+	table := renderIssuesTable(rows[offset:end], cursor-offset, im.sort, pinCount-offset)
 
 	hint := keyHints(
 		"↑↓", "move",
@@ -265,6 +385,7 @@ func (im IssuesModel) renderIssuesTab(stats *github.Stats, available, availableH
 		"enter", "details",
 		"o", "github",
 		"c", "copy",
+		"P", "pin",
 	)
 
 	parts := []string{headerLine}
@@ -297,7 +418,13 @@ func (im IssuesModel) renderHeaderLine(visible, total, offset, end int) string {
 	return strings.Join(parts, mutedStyle.Render(" · "))
 }
 
-func renderIssuesTable(issues []github.Issue, cursorRow int, sortMode IssuesSort) string {
+// renderIssuesTable lays out the column header and one line per issue
+// for the visible slice. `cursorRow` is zero-based within the slice
+// (caller already computed the offset). `pinDivider` is the index (in
+// the visible window, post-offset) AFTER which a muted rule marks the
+// pinned/rest boundary; ≤0 or ≥len(issues) suppresses it — an empty
+// pinned section simply collapses. Mirror of renderReposTable.
+func renderIssuesTable(issues []github.Issue, cursorRow int, sortMode IssuesSort, pinDivider int) string {
 	const (
 		cursorW  = 2
 		numberW  = 6
@@ -357,6 +484,13 @@ func renderIssuesTable(issues []github.Issue, cursorRow int, sortMode IssuesSort
 		}
 
 		out = append(out, marker+num+"  "+title+"  "+repo+"  "+updated)
+
+		// Insert the pinned/rest divider exactly once, after the last
+		// pinned row, and only when a rest row follows. Re-uses the
+		// header-width rule so the divider spans the same band.
+		if pinDivider > 0 && i == pinDivider-1 && i+1 < len(issues) {
+			out = append(out, rule)
+		}
 	}
 	return strings.Join(out, "\n")
 }

--- a/internal/ui/issues_test.go
+++ b/internal/ui/issues_test.go
@@ -1,0 +1,219 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// mkIssue builds an Issue with a deterministic UpdatedAt derived from
+// the number so the "updated" sort is stable in tests.
+func mkIssue(repo string, number int) github.Issue {
+	return github.Issue{
+		Number:    number,
+		Title:     repo + " issue",
+		URL:       "https://github.com/" + repo + "/issues/" + itoa(number),
+		Repo:      repo,
+		UpdatedAt: time.Unix(int64(number), 0),
+	}
+}
+
+func itoa(n int) string {
+	// tiny local helper so the test file doesn't need strconv just for
+	// building fixture URLs.
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// TestIssueID pins the "owner/name#N" identity construction.
+func TestIssueID(t *testing.T) {
+	got := issueID(mkIssue("alice/alpha", 42))
+	if got != "alice/alpha#42" {
+		t.Errorf("issueID = %q, want %q", got, "alice/alpha#42")
+	}
+}
+
+// TestIsPinnedIssue covers the case-insensitive membership check used
+// for the action-menu Pin/Unpin label.
+func TestIsPinnedIssue(t *testing.T) {
+	it := mkIssue("alice/alpha", 42)
+	if isPinnedIssue(it, nil) {
+		t.Errorf("empty pins should report not pinned")
+	}
+	if !isPinnedIssue(it, []string{"alice/alpha#42"}) {
+		t.Errorf("exact match should report pinned")
+	}
+	if !isPinnedIssue(it, []string{"ALICE/ALPHA#42"}) {
+		t.Errorf("case-insensitive match should report pinned")
+	}
+	if isPinnedIssue(it, []string{"alice/alpha#7"}) {
+		t.Errorf("different number should report not pinned")
+	}
+	if isPinnedIssue(it, []string{"alice/beta#42"}) {
+		t.Errorf("different repo should report not pinned")
+	}
+}
+
+// TestPartitionIssuesByPinned pins the partition contract:
+//   - pinned slice ordered by position in the pins list, not by
+//     position in the issues input
+//   - case-insensitive "owner/name#N" match
+//   - rest preserves input order
+//   - a pin that matches no issue is silently absent (a stale/closed
+//     pinned entry doesn't appear)
+func TestPartitionIssuesByPinned(t *testing.T) {
+	issues := []github.Issue{
+		mkIssue("alice/alpha", 1),
+		mkIssue("bob/beta", 2),
+		mkIssue("carol/gamma", 3),
+	}
+	tests := []struct {
+		name       string
+		pins       []string
+		wantPinned []string // expected "owner/name#N" in the pinned slice (in order)
+		wantRest   []string
+	}{
+		{
+			name:       "empty pins → everything in rest",
+			pins:       nil,
+			wantPinned: nil,
+			wantRest:   []string{"alice/alpha#1", "bob/beta#2", "carol/gamma#3"},
+		},
+		{
+			name:       "single pin pulled to top",
+			pins:       []string{"bob/beta#2"},
+			wantPinned: []string{"bob/beta#2"},
+			wantRest:   []string{"alice/alpha#1", "carol/gamma#3"},
+		},
+		{
+			name:       "pinned order matches pins order, not issue order",
+			pins:       []string{"carol/gamma#3", "alice/alpha#1"},
+			wantPinned: []string{"carol/gamma#3", "alice/alpha#1"},
+			wantRest:   []string{"bob/beta#2"},
+		},
+		{
+			name:       "case-insensitive match",
+			pins:       []string{"ALICE/ALPHA#1"},
+			wantPinned: []string{"alice/alpha#1"},
+			wantRest:   []string{"bob/beta#2", "carol/gamma#3"},
+		},
+		{
+			name:       "pin that matches no issue is silently absent",
+			pins:       []string{"nobody/nothing#9", "alice/alpha#1"},
+			wantPinned: []string{"alice/alpha#1"},
+			wantRest:   []string{"bob/beta#2", "carol/gamma#3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pinned, rest := partitionIssuesByPinned(issues, tt.pins)
+			if got := issueIDs(pinned); !reflect.DeepEqual(got, tt.wantPinned) {
+				t.Errorf("pinned = %v, want %v", got, tt.wantPinned)
+			}
+			if got := issueIDs(rest); !reflect.DeepEqual(got, tt.wantRest) {
+				t.Errorf("rest = %v, want %v", got, tt.wantRest)
+			}
+		})
+	}
+}
+
+// TestVisibleIssuesPartitioned checks the single-source-of-truth row
+// pipeline: pinned float to the top in config order, the rest is
+// filtered + sorted, and the section counts are correct. The filter
+// and sort apply to the rest only — a pinned row stays pinned and in
+// config order regardless of the active sort.
+func TestVisibleIssuesPartitioned(t *testing.T) {
+	open := []github.Issue{
+		mkIssue("alice/alpha", 1),
+		mkIssue("bob/beta", 2),
+		mkIssue("carol/gamma", 3),
+		mkIssue("alice/delta", 4),
+	}
+
+	t.Run("no pins, sort by number", func(t *testing.T) {
+		rows, pinCount, restCount := visibleIssuesPartitioned(open, "", IssuesSortNumber, nil)
+		if pinCount != 0 {
+			t.Errorf("pinCount = %d, want 0", pinCount)
+		}
+		if restCount != 4 {
+			t.Errorf("restCount = %d, want 4", restCount)
+		}
+		want := []string{"alice/alpha#1", "bob/beta#2", "carol/gamma#3", "alice/delta#4"}
+		if got := issueIDs(rows); !reflect.DeepEqual(got, want) {
+			t.Errorf("rows = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("pinned float to top in config order; rest sorted", func(t *testing.T) {
+		// Pin gamma then alpha (config order). Rest (beta, delta) is
+		// sorted by number ascending.
+		pins := []string{"carol/gamma#3", "alice/alpha#1"}
+		rows, pinCount, restCount := visibleIssuesPartitioned(open, "", IssuesSortNumber, pins)
+		if pinCount != 2 {
+			t.Errorf("pinCount = %d, want 2", pinCount)
+		}
+		if restCount != 2 {
+			t.Errorf("restCount = %d, want 2", restCount)
+		}
+		want := []string{"carol/gamma#3", "alice/alpha#1", "bob/beta#2", "alice/delta#4"}
+		if got := issueIDs(rows); !reflect.DeepEqual(got, want) {
+			t.Errorf("rows = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("filter applies to both segments; counts reflect matches", func(t *testing.T) {
+		// Filter "alice" matches alpha (#1) and delta (#4). Pin alpha:
+		// it stays pinned, delta is the only rest row.
+		pins := []string{"alice/alpha#1"}
+		rows, pinCount, restCount := visibleIssuesPartitioned(open, "alice", IssuesSortNumber, pins)
+		if pinCount != 1 {
+			t.Errorf("pinCount = %d, want 1", pinCount)
+		}
+		if restCount != 1 {
+			t.Errorf("restCount = %d, want 1", restCount)
+		}
+		want := []string{"alice/alpha#1", "alice/delta#4"}
+		if got := issueIDs(rows); !reflect.DeepEqual(got, want) {
+			t.Errorf("rows = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("filter that drops a pinned issue removes it from pinned", func(t *testing.T) {
+		// gamma is pinned but the "alice" filter excludes it, so the
+		// pinned section collapses to nothing.
+		pins := []string{"carol/gamma#3"}
+		rows, pinCount, restCount := visibleIssuesPartitioned(open, "alice", IssuesSortNumber, pins)
+		if pinCount != 0 {
+			t.Errorf("pinCount = %d, want 0", pinCount)
+		}
+		if restCount != 2 {
+			t.Errorf("restCount = %d, want 2", restCount)
+		}
+		want := []string{"alice/alpha#1", "alice/delta#4"}
+		if got := issueIDs(rows); !reflect.DeepEqual(got, want) {
+			t.Errorf("rows = %v, want %v", got, want)
+		}
+	})
+}
+
+// issueIDs maps issues to their "owner/name#N" identity for compact
+// assertions.
+func issueIDs(issues []github.Issue) []string {
+	if len(issues) == 0 {
+		return nil
+	}
+	out := make([]string, len(issues))
+	for i, it := range issues {
+		out[i] = issueID(it)
+	}
+	return out
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -109,6 +109,13 @@ type Model struct {
 	// section — to preserve the user's intent.
 	pinned []string
 
+	// pinnedIssues is the live list of "owner/name#N" pinned issues
+	// for the Issues tab (v0.21.0). Same lifecycle as pinned: mutable
+	// via P on a row or via the action menu, written back to config on
+	// every change, and treated as ordered so config order is the
+	// section order.
+	pinnedIssues []string
+
 	// settings holds the in-app settings form's transient state
 	// (focused row, edit buffer, staged toggles). The panel is open
 	// iff settings.IsOpen().
@@ -433,6 +440,12 @@ type Options struct {
 	// caller — NewModel trusts the slice as-is.
 	PinnedRepos []string
 
+	// PinnedIssues is the persisted list of "owner/name#N" identifiers
+	// that the Issues tab renders in a sticky section at the top.
+	// Already sanitised (see config.SanitizeIssueList) by the
+	// caller — NewModel trusts the slice as-is.
+	PinnedIssues []string
+
 	// ShowSponsor gates the sponsor splash (v0.16.0). When true (and
 	// not in public-only mode) the splash opens on every launch. False
 	// opts out — set via config show_sponsor or the --no-sponsor flag,
@@ -489,6 +502,7 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 		theme:           themeName,
 		accentColor:     opts.AccentColor,
 		pinned:          append([]string(nil), opts.PinnedRepos...),
+		pinnedIssues:    append([]string(nil), opts.PinnedIssues...),
 		version:         version,
 		spinner:         sp,
 		pulseMap:        make(map[string]time.Time),
@@ -675,7 +689,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			case m.activeTab == TabIssues && m.issues.IsInputMode():
 				var cmd tea.Cmd
-				m.issues, cmd = m.issues.Update(msg, eff)
+				m.issues, cmd = m.issues.Update(msg, eff, m.pinnedIssues)
 				return m, cmd
 			}
 		}
@@ -735,11 +749,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 			case TabIssues:
-				if it, ok := m.issues.selectedIssue(s); ok {
+				if it, ok := m.issues.selectedIssue(s, m.pinnedIssues); ok {
 					title = fmt.Sprintf("Actions for issue #%d", it.Number)
+					pinLabel := "Pin"
+					pinNext := true
+					if isPinnedIssue(it, m.pinnedIssues) {
+						pinLabel = "Unpin"
+						pinNext = false
+					}
 					actions = []Action{
 						{Label: "Open in GitHub", Shortcut: 'o', Cmd: openURLCmd(it.URL)},
 						{Label: "View details", Shortcut: 'd', Cmd: viewIssueDetailCmd(it)},
+						{Label: pinLabel, Shortcut: 'P', Cmd: togglePinIssueCmd(issueID(it), pinNext)},
 						{Label: "Copy URL", Shortcut: 'c', Cmd: copyURLCmd(it.URL)},
 					}
 				}
@@ -835,7 +856,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			case TabIssues:
 				var cmd tea.Cmd
-				m.issues, cmd = m.issues.Update(msg, eff)
+				m.issues, cmd = m.issues.Update(msg, eff, m.pinnedIssues)
 				return m, cmd
 			case TabOverview:
 				// Static tab content — let the viewport handle scroll
@@ -1198,6 +1219,36 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return clockTickMsg(time.Now())
 		})
 
+	case pinIssueToggledMsg:
+		// Issues counterpart of pinToggledMsg. The id is already the
+		// canonical "owner/name#N" identity (built by issueID), so
+		// there's no URL parse here — the only difference from the repo
+		// handler. Everything else mirrors it: mutate the canonical
+		// list, no-op when unchanged, best-effort writeback, toast.
+		next := togglePinList(m.pinnedIssues, msg.id, msg.pin)
+		if pinnedEqual(m.pinnedIssues, next) {
+			return m, nil
+		}
+		m.pinnedIssues = next
+
+		saveErr := ""
+		if err := m.persistConfig(); err != nil {
+			saveErr = "config not saved (" + err.Error() + "), pin kept in memory only"
+		}
+
+		switch {
+		case saveErr != "":
+			m.toastMsg = saveErr
+		case msg.pin:
+			m.toastMsg = msg.id + " pinned"
+		default:
+			m.toastMsg = msg.id + " unpinned"
+		}
+		m.toastUntil = time.Now().Add(toastDuration)
+		return m, tea.Tick(toastDuration, func(time.Time) tea.Msg {
+			return clockTickMsg(time.Now())
+		})
+
 	case urlCopiedMsg:
 		// Set the toast based on the outcome. The clipboard helper
 		// failure path is rare in practice (macOS / Windows always
@@ -1268,6 +1319,7 @@ func (m *Model) persistConfig() error {
 	cfgOnDisk.Theme = m.theme
 	cfgOnDisk.AccentColor = m.accentColor
 	cfgOnDisk.PinnedRepos = m.pinned
+	cfgOnDisk.PinnedIssues = m.pinnedIssues
 	// NOTE: ShowSponsor is a user-facing knob the in-app UI never
 	// toggles, so it's left as Load read it (same treatment as
 	// WatchRepos below).

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -169,7 +169,7 @@ func (m Model) View() string {
 		case TabPRs:
 			b.WriteString(m.prs.renderPRsTab(s, available, tabHeight))
 		case TabIssues:
-			b.WriteString(m.issues.renderIssuesTab(s, available, tabHeight))
+			b.WriteString(m.issues.renderIssuesTab(s, available, tabHeight, m.pinnedIssues))
 		case TabActivity:
 			b.WriteString(m.renderActivityScrolled(s, available, tabHeight))
 		case TabWhatsNew:

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,15 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.21.0": {
+		headline: "Pin the issues you keep coming back to.",
+		items: []whatsNewItem{
+			{
+				title: "Pinned issues",
+				desc:  "Press P on an issue row (or pick Pin from the action menu) to pin or unpin it. Pinned issues stick to the top of the Issues tab in the order you pin them, and they compose with the sort cycle (s) and the / search just like pinned repos. The set is saved to pinned_issues in your config, so the next launch brings them right back.",
+			},
+		},
+	},
 	"0.20.2": {
 		headline: "Hardening & housekeeping — a stronger, fresher build.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func main() {
 		Theme:           cfg.Theme,
 		AccentColor:     cfg.AccentColor,
 		PinnedRepos:     cfg.PinnedRepos,
+		PinnedIssues:    cfg.PinnedIssues,
 		ShowSponsor:     cfg.ShowSponsor,
 		CheckForUpdates: cfg.CheckForUpdates,
 	})

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.20.2"
+const version = "0.21.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## What

Adds **pinned issues** to the Issues tab — press `P` on an issue row (or the action menu) to pin/unpin it; pinned issues stick to the top in a sticky section, in the order you pin them, persisted to `pinned_issues` in your config. A direct mirror of the existing pinned-repos feature, with `owner/name#N` as the identity.

This is the **v0.21.0** feature; the release-prep (version bump, What's-new entry, README, landing card) is the **last commit** so merging leaves `main` immediately taggable.

## Change

- **`internal/config`**: `PinnedIssues` (`pinned_issues`) field + `SanitizeIssueList` (validates `owner/name#N` — one `/`, positive integer; trims, dedups case-insensitively) + Load/Save block.
- **`internal/ui/issues.go`**: `issueID` / `isPinnedIssue` / `partitionIssuesByPinned` / `visibleIssuesPartitioned` (the new single source of truth) + the `P` keybind + the sticky-section divider (mirror of `renderReposTable`, collapses when nothing is pinned). Routing `selectedIssue`/`Update` through the partition helper also **fixes a long-standing list-tab inconsistency**: Issues used to re-run `sortIssues(filterIssues(...))` inline at every keypress with no shared "visible rows" helper — it now matches Repos/PRs, so the cursor can't disagree with the paint.
- **`internal/ui/model.go`**: `Model.pinnedIssues`, the `pinIssueToggledMsg` handler (mirror of the repo one, no URL parse), `persistConfig`, and the Issues action-menu Pin/Unpin entry.
- Reuses the generic `togglePinList` / `pinnedEqual` from `repos.go`; `repos.go` / `prs.go` / `internal/github/` are **unchanged**.

## Tests

- config: `SanitizeIssueList` (valid + every malformed shape + dedup), Load, and a Save→Load round-trip.
- ui: `partitionIssuesByPinned` / `isPinnedIssue` / `visibleIssuesPartitioned` — config-order, a stale/closed pinned id silently absent, the filter dropping a pinned row, and the section counts.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`, `go test -race ./...` — all green; `go run . --version` → `octoscope 0.21.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pin issues to the top of the Issues tab for quick access
  * Toggle pin status with the `P` keyboard shortcut
  * Pinned issues are saved in your configuration and persist across sessions
  * Visual divider separates pinned issues from the rest

* **Documentation**
  * Updated README with pinned issues configuration format and keyboard shortcuts
  * Added pinned issues feature to the website overview

<!-- end of auto-generated comment: release notes by coderabbit.ai -->