### PR TITLE
feat(ui): honour NO_COLOR and add --no-color flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ octoscope --compact             # dense card layout for narrow terminals
 octoscope --public-only         # hide private repos/PRs/issues (safe for demos)
 octoscope --no-sponsor          # skip the sponsor splash for this run
 octoscope --theme phosphor      # 80s green CRT theme — see Themes section
+octoscope --no-color            # force the monochrome theme (or set NO_COLOR)
 ```
 
 Examples:
@@ -363,6 +364,17 @@ You can override just the accent colour while keeping the rest of a
 theme via the `accent_color` config key (or `--theme` plus an
 `accent_color` in the file). Any value lipgloss accepts works: hex
 like `"#FF0080"` or ANSI 256 numbers like `"201"`.
+
+### No colour
+
+octoscope honours the [`NO_COLOR`](https://no-color.org) convention:
+when the `NO_COLOR` environment variable is present and non-empty (its
+value doesn't matter), or you pass `--no-color`, octoscope forces the
+zero-chroma `monochrome` theme, overriding any `--theme` / `theme`
+config value and dropping the accent override. It's an environment
+directive for that run only — the `theme` / `accent_color` keys saved
+in your config file are left untouched, so your real theme comes back
+the moment `NO_COLOR` is unset.
 
 ## Configuration
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -101,6 +101,14 @@ type Model struct {
 	// theme so launch-time and runtime sources stay in sync.
 	accentColor string
 
+	// noColor records that this run was forced to the monochrome
+	// palette by the NO_COLOR env convention or the --no-color flag
+	// (resolved in main.go). It's an environment directive for the
+	// current session, NOT a stored preference: persistConfig leaves
+	// the file's theme / accent_color keys untouched while it's set,
+	// so the user's real theme survives unsetting NO_COLOR.
+	noColor bool
+
 	// pinned is the live list of "owner/name" pinned repositories
 	// for the Repos tab (v0.13.0). Mutable via P on a row or via
 	// the action menu; on every change we write back to config so
@@ -434,6 +442,14 @@ type Options struct {
 	// only. Empty = no override.
 	AccentColor string
 
+	// NoColor records that main.go forced the monochrome palette for
+	// this run via the NO_COLOR env convention or the --no-color flag.
+	// main.go has already set Theme to "monochrome" and cleared
+	// AccentColor; this flag only tells the Model to keep the file's
+	// theme / accent_color keys untouched on persist (the directive is
+	// environmental, not a stored preference).
+	NoColor bool
+
 	// PinnedRepos is the persisted list of "owner/name" identifiers
 	// that the Repos tab renders in a sticky section at the top.
 	// Already sanitised (see config.SanitizeRepoList) by the
@@ -501,6 +517,7 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 		configPath:      opts.ConfigPath,
 		theme:           themeName,
 		accentColor:     opts.AccentColor,
+		noColor:         opts.NoColor,
 		pinned:          append([]string(nil), opts.PinnedRepos...),
 		pinnedIssues:    append([]string(nil), opts.PinnedIssues...),
 		version:         version,
@@ -1316,8 +1333,15 @@ func (m *Model) persistConfig() error {
 	cfgOnDisk.RefreshInterval = m.interval
 	cfgOnDisk.PublicOnly = m.client.PublicOnly()
 	cfgOnDisk.Compact = m.compact
-	cfgOnDisk.Theme = m.theme
-	cfgOnDisk.AccentColor = m.accentColor
+	// NO_COLOR / --no-color force the monochrome palette for this run,
+	// so m.theme is "monochrome" — but that's an environment directive,
+	// not the user's stored choice. Leave the file's theme / accent_color
+	// keys exactly as Load read them so they survive unsetting NO_COLOR.
+	// (Same hands-off treatment as ShowSponsor / WatchRepos below.)
+	if !m.noColor {
+		cfgOnDisk.Theme = m.theme
+		cfgOnDisk.AccentColor = m.accentColor
+	}
 	cfgOnDisk.PinnedRepos = m.pinned
 	cfgOnDisk.PinnedIssues = m.pinnedIssues
 	// NOTE: ShowSponsor is a user-facing knob the in-app UI never

--- a/internal/ui/persist_test.go
+++ b/internal/ui/persist_test.go
@@ -91,6 +91,80 @@ func TestPersistConfigPreservesHandEditedLists(t *testing.T) {
 	}
 }
 
+// TestPersistConfigNoColorLeavesThemeUntouched pins the NO_COLOR /
+// --no-color contract: when that environment directive forced the
+// monochrome palette for the run (m.noColor = true, m.theme =
+// "monochrome"), persisting must NOT rewrite the file's theme /
+// accent_color keys — they're the user's stored preference and have to
+// survive unsetting NO_COLOR. The rest of the save (interval, etc.)
+// still lands. The !noColor branch is the inverse: a genuine theme
+// choice does persist.
+func TestPersistConfigNoColorLeavesThemeUntouched(t *testing.T) {
+	t.Run("no-color run does not overwrite the stored theme", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.toml")
+
+		seed := config.Defaults()
+		seed.Theme = "amber"
+		seed.AccentColor = "#FF0080"
+		if err := config.Save(path, seed); err != nil {
+			t.Fatalf("seed Save: %v", err)
+		}
+
+		// A run forced to monochrome by NO_COLOR: the live theme is
+		// "monochrome" but noColor marks it as environmental.
+		m := newTestModel(t, path, false, nil)
+		m.noColor = true
+		m.theme = "monochrome"
+		m.accentColor = ""
+		m.interval = 30 * time.Second
+		if err := m.persistConfig(); err != nil {
+			t.Fatalf("persistConfig: %v", err)
+		}
+
+		got, err := config.Load(path)
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if got.Theme != "amber" {
+			t.Errorf("theme overwritten by NO_COLOR run: got %q, want amber", got.Theme)
+		}
+		if got.AccentColor != "#FF0080" {
+			t.Errorf("accent_color overwritten by NO_COLOR run: got %q, want #FF0080", got.AccentColor)
+		}
+		// The non-theme part of the save still applied.
+		if got.RefreshInterval != 30*time.Second {
+			t.Errorf("refresh_interval = %v, want 30s", got.RefreshInterval)
+		}
+	})
+
+	t.Run("normal run persists the chosen theme", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.toml")
+
+		seed := config.Defaults()
+		seed.Theme = "amber"
+		if err := config.Save(path, seed); err != nil {
+			t.Fatalf("seed Save: %v", err)
+		}
+
+		m := newTestModel(t, path, false, nil)
+		m.noColor = false
+		m.theme = "phosphor"
+		if err := m.persistConfig(); err != nil {
+			t.Fatalf("persistConfig: %v", err)
+		}
+
+		got, err := config.Load(path)
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if got.Theme != "phosphor" {
+			t.Errorf("theme not persisted on a normal run: got %q, want phosphor", got.Theme)
+		}
+	})
+}
+
 // TestPersistConfigLeavesFileUntouchedOnReadError pins the safety
 // invariant: if the on-disk file can't be re-read, persistConfig must
 // NOT overwrite it (which would nuke hand-edits with Defaults()), and

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ type cliOverrides struct {
 	publicOnly *bool
 	theme      *string
 	noSponsor  *bool
+	noColor    *bool
 }
 
 func main() {
@@ -63,12 +64,27 @@ func main() {
 	}
 
 	// Validate theme name before booting the model so a typo surfaces
-	// as a clear startup error instead of a silent fallback.
+	// as a clear startup error instead of a silent fallback. Done before
+	// the NO_COLOR override so a "--theme bogus" still errors even when
+	// NO_COLOR would otherwise mask it with the monochrome fallback.
 	if !ui.IsValidTheme(cfg.Theme) {
 		fmt.Fprintf(os.Stderr,
 			"octoscope: unknown theme %q (valid: %s)\n",
 			cfg.Theme, strings.Join(ui.ThemeNames(), ", "))
 		os.Exit(2)
+	}
+
+	// NO_COLOR (the de-facto env convention, https://no-color.org) and
+	// the --no-color flag force the zero-chroma monochrome palette,
+	// overriding any configured / --theme value and dropping the accent
+	// override (a hex accent would re-introduce colour). It's an
+	// environment directive for this run only — ui.Model keeps the
+	// file's theme / accent_color keys untouched on persist (see
+	// Options.NoColor), so the user's real theme survives unsetting it.
+	noColor := noColorActive(cli.noColor != nil, os.Getenv("NO_COLOR"))
+	if noColor {
+		cfg.Theme = "monochrome"
+		cfg.AccentColor = ""
 	}
 
 	client, err := github.New(userLogin, github.Options{
@@ -90,6 +106,7 @@ func main() {
 		PinnedIssues:    cfg.PinnedIssues,
 		ShowSponsor:     cfg.ShowSponsor,
 		CheckForUpdates: cfg.CheckForUpdates,
+		NoColor:         noColor,
 	})
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
@@ -141,6 +158,9 @@ func parseArgs(args []string) (string, string, cliOverrides, bool) {
 		case arg == "--no-sponsor":
 			t := true
 			cli.noSponsor = &t
+		case arg == "--no-color":
+			t := true
+			cli.noColor = &t
 		case arg == "--refresh":
 			raw := nextValue(&i, "--refresh")
 			d, err := time.ParseDuration(raw)
@@ -176,6 +196,16 @@ func parseArgs(args []string) (string, string, cliOverrides, bool) {
 	return userLogin, configPath, cli, true
 }
 
+// noColorActive resolves whether colour output should be suppressed for
+// this run. flagSet is true when --no-color was passed; env is the raw
+// value of the NO_COLOR environment variable. Following the no-color.org
+// convention, NO_COLOR counts only when present and non-empty (its value
+// is irrelevant — "0" still disables colour), so an explicit NO_COLOR=""
+// does NOT trigger it. The --no-color flag triggers it regardless.
+func noColorActive(flagSet bool, env string) bool {
+	return flagSet || env != ""
+}
+
 func printHelp() {
 	fmt.Println(`octoscope — a terminal dashboard for your GitHub account
 
@@ -199,6 +229,11 @@ Flags:
     --theme NAME             Visual theme. Built-in: octoscope (default),
                              high-contrast, terminal, monochrome,
                              stranger-things, phosphor, amber
+    --no-color               Force the zero-chroma monochrome theme,
+                             overriding --theme / config. Also honoured
+                             via the NO_COLOR environment variable
+                             (https://no-color.org). Does not alter the
+                             theme saved in your config file.
     -v, --version            Print version
     -h, --help               Print this help
 
@@ -220,6 +255,7 @@ Examples:
     octoscope --refresh 30s         # auto-refresh every 30 seconds
     octoscope --compact             # dense layout for narrow terminals
     octoscope --public-only         # screenshot-safe (hides private items)
+    octoscope --no-color            # force monochrome (or set NO_COLOR=1)
 
 Key bindings (while running):
     r         refresh now

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,74 @@ package main
 
 import "testing"
 
+// TestParseArgsNoColor pins the --no-color flag plumbing: present →
+// cli.noColor non-nil (main() forces the monochrome theme), absent →
+// nil (config/--theme/default wins). Also confirms it composes with a
+// username arg, mirroring the --no-sponsor coverage.
+func TestParseArgsNoColor(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		_, _, cli, ok := parseArgs([]string{"--no-color"})
+		if !ok {
+			t.Fatal("parseArgs returned !ok for a valid flag")
+		}
+		if cli.noColor == nil {
+			t.Error("--no-color should set cli.noColor (got nil)")
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		_, _, cli, ok := parseArgs([]string{})
+		if !ok {
+			t.Fatal("parseArgs returned !ok for empty args")
+		}
+		if cli.noColor != nil {
+			t.Errorf("absent --no-color should leave cli.noColor nil, got %v", *cli.noColor)
+		}
+	})
+
+	t.Run("composes with username", func(t *testing.T) {
+		login, _, cli, ok := parseArgs([]string{"--no-color", "torvalds"})
+		if !ok {
+			t.Fatal("parseArgs returned !ok")
+		}
+		if cli.noColor == nil {
+			t.Error("--no-color should be set alongside a username")
+		}
+		if login != "torvalds" {
+			t.Errorf("username = %q, want torvalds", login)
+		}
+	})
+}
+
+// TestNoColorActive pins the NO_COLOR resolution rules: the flag always
+// triggers; the env var triggers only when present and non-empty (per
+// the no-color.org convention, its value — "0", "false", etc. — is
+// irrelevant), so an explicit empty string must NOT trigger.
+func TestNoColorActive(t *testing.T) {
+	cases := []struct {
+		name    string
+		flagSet bool
+		env     string
+		want    bool
+	}{
+		{"nothing set", false, "", false},
+		{"flag only", true, "", true},
+		{"env empty string is ignored", false, "", false},
+		{"env zero still disables colour", false, "0", true},
+		{"env one", false, "1", true},
+		{"env arbitrary value", false, "false", true},
+		{"flag and env both", true, "1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := noColorActive(tc.flagSet, tc.env); got != tc.want {
+				t.Errorf("noColorActive(%v, %q) = %v, want %v",
+					tc.flagSet, tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestParseArgsNoSponsor pins the --no-sponsor flag plumbing: present →
 // cli.noSponsor non-nil (main() forces ShowSponsor off), absent → nil
 // (config/default wins). Also confirms it composes with a username arg.


### PR DESCRIPTION
## What

octoscope now honours the [`NO_COLOR`](https://no-color.org) convention and adds a matching `--no-color` flag. When `NO_COLOR` is present and non-empty (its value is irrelevant — `0` still disables colour) **or** `--no-color` is passed, octoscope forces the zero-chroma `monochrome` theme, overriding `--theme` / the `theme` config key and dropping the accent override (a hex accent would re-introduce chroma).

Closes #32.

## Why this isn't just "set the theme"

It's an **environment directive for the run, not a stored preference**. The in-app settings panel persists the theme to the config file, so naively forcing `m.theme = "monochrome"` would let a later save overwrite the user's real theme (e.g. `amber`). To prevent that, `persistConfig` leaves the file's `theme` / `accent_color` keys untouched while `NoColor` is active — the same hands-off treatment `show_sponsor` / `watch_repos` already get. The user's real theme comes back the moment `NO_COLOR` is unset.

Theme-name validation still runs **before** the override, so a `--theme bogus` typo errors out instead of being silently masked by the monochrome fallback.

## Behaviour (verified live with vhs)

| | Chroma | Render |
|---|---|---|
| default theme | yes | pink + cyan, GitHub-coloured language bar |
| `--no-color` | **no** | greys — hierarchy preserved (gradient language bar) |
| `NO_COLOR=1` | **no** | flat — termenv degrades natively (uniform language bar) |

Both no-colour paths drop all chroma. The plain-vs-grey difference is expected: `--no-color` renders the monochrome palette (greys), while `NO_COLOR=1` additionally trips termenv's native colour-profile downgrade — which is exactly what a `NO_COLOR` user wants.

## Tests

- `noColorActive` resolver (table: flag, empty/`0`/`1`/arbitrary env)
- `--no-color` flag plumbing in `parseArgs`
- `persistConfig` NO_COLOR gate — the stored theme survives a no-colour run, and a genuine theme choice still persists

`gofmt` clean · full suite green · dual-target `make build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-color` option and support for the `NO_COLOR` environment variable to run the app in monochrome mode.
  * Updated usage and theme docs to explain how no-color mode works and how it affects saved appearance settings.

* **Bug Fixes**
  * Preserved the user’s saved theme and accent settings when no-color mode is active, so normal colors return once it’s disabled.
  * Kept invalid theme values from being accepted at startup, even when no-color mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->