### PR TITLE
chore(release): prep v0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,9 @@ like `"#FF0080"` or ANSI 256 numbers like `"201"`.
 
 ### No colour
 
-octoscope honours the [`NO_COLOR`](https://no-color.org) convention:
-when the `NO_COLOR` environment variable is present and non-empty (its
+octoscope honours the [`NO_COLOR`](https://no-color.org) convention
+(since v0.22.0): when the `NO_COLOR` environment variable is present and
+non-empty (its
 value doesn't matter), or you pass `--no-color`, octoscope forces the
 zero-chroma `monochrome` theme, overriding any `--theme` / `theme`
 config value and dropping the accent override. It's an environment

--- a/docs/index.html
+++ b/docs/index.html
@@ -1023,7 +1023,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.21.0</span>
+                <span class="version-tag" id="version-pill">0.22.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1206,6 +1206,11 @@
                     <div class="feature-label">Pinned issues</div>
                     <h3>Float what matters to the top</h3>
                     <p>Since v0.21.0. Press <code class="inline">P</code> on an Issues row to <strong style="color: var(--text);">pin</strong> it &mdash; pinned issues stick to the top of the tab in the order you pin them, compose with the sort cycle and <code class="inline">/</code> search, and are persisted to <code class="inline">pinned_issues</code> in your config. The same sticky-section treatment the Repos tab already had.</p>
+                </div>
+                <div class="feature">
+                    <div class="feature-label">Accessibility</div>
+                    <h3>Respects NO_COLOR</h3>
+                    <p>Since v0.22.0. Set <code class="inline">NO_COLOR</code> in your environment or pass <code class="inline">--no-color</code> and octoscope drops to its <strong style="color: var(--text);">zero-chroma monochrome theme</strong>, overriding <code class="inline">--theme</code> and the config. It's per-run only &mdash; your saved theme and accent come back the moment <code class="inline">NO_COLOR</code> is unset.</p>
                 </div>
                 <div class="feature">
                     <div class="feature-label">Configurable</div>

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,15 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.22.0": {
+		headline: "Respect NO_COLOR — a calmer, monochrome octoscope.",
+		items: []whatsNewItem{
+			{
+				title: "NO_COLOR / --no-color",
+				desc:  "octoscope now honours the NO_COLOR convention: set NO_COLOR in your environment, or pass --no-color, and it switches to the zero-chroma monochrome theme, overriding --theme and the config. It's per-run only — your saved theme and accent stay untouched and come back the moment NO_COLOR is unset.",
+			},
+		},
+	},
 	"0.21.0": {
 		headline: "Pin the issues you keep coming back to.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.21.0"
+const version = "0.22.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Release-prep for **v0.22.0**, shipping the NO_COLOR feature (#32, merged via #39) on its own.

We decided to cut #32 as a standalone minor rather than wait for the rest of the *polish & reliability* cycle (#35 / #36 / #37), which move to the next cut. `--no-color` adds a new CLI flag + `NO_COLOR` support, so it's a minor (v0.22.0), not a patch.

## Changes
- **`main.go`** — `const version` `0.21.0` → `0.22.0`
- **`internal/ui/whatsnew.go`** — `whatsNew["0.22.0"]` entry so the *What's new* tab (`6`) shows the NO_COLOR highlight after upgrade
- **`docs/index.html`** — hero version pill fallback → `0.22.0` + a new *At a glance* card ("Respects NO_COLOR")
- **`README.md`** — version marker on the *No colour* section (the flag itself was already documented in #39)

## Notes
- `gofmt` clean · full suite green · dual-target `make build` OK · `octoscope --version` → `0.22.0`
- The landing hero screenshot (`docs/screenshots/screenshot.png`) still shows `0.21.0` in the banner — cosmetic; can be regenerated via vhs as a follow-up if we want it pixel-current.
- Merging this leaves `main` immediately taggable for `v0.22.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessibility note for `NO_COLOR` / `--no-color`, which now forces a monochrome, zero-chroma theme for that run and overrides theme/accent settings.
* **Updates**
  * Updated the displayed app version to `0.22.0`.
  * Refreshed the “What’s New” and README content to reflect the latest release and no-color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->