### PR TITLE
feat(errors): classify expired and under-scoped tokens with actionable hints

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -8,11 +8,42 @@ import (
 	"strings"
 )
 
+// Source identifies where a resolved token came from, so auth-error
+// surfaces can name the right fix (regenerate the PAT vs re-run
+// `gh auth login`) without ever echoing the token itself.
+type Source int
+
+const (
+	// SourceNone means no token was found — the session is unauthenticated.
+	SourceNone Source = iota
+	// SourceEnv means the token came from the $GITHUB_TOKEN env var.
+	SourceEnv
+	// SourceGHCLI means the token came from `gh auth token`.
+	SourceGHCLI
+)
+
 // ghTokenOutput runs `gh auth token` and returns its raw stdout. It is a
 // package var so tests can stub the gh CLI fallback without invoking the
 // real binary (which would make the test depend on the host's gh login).
 var ghTokenOutput = func() ([]byte, error) {
 	return exec.Command("gh", "auth", "token").Output()
+}
+
+// TokenSource resolves a token like Token and also reports where it
+// came from, so callers can tailor "your token was rejected" guidance
+// to the source actually in use.
+func TokenSource() (string, Source) {
+	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
+		return t, SourceEnv
+	}
+	out, err := ghTokenOutput()
+	if err != nil {
+		return "", SourceNone
+	}
+	if t := strings.TrimSpace(string(out)); t != "" {
+		return t, SourceGHCLI
+	}
+	return "", SourceNone
 }
 
 // Token returns a GitHub personal access token by, in order:
@@ -23,12 +54,6 @@ var ghTokenOutput = func() ([]byte, error) {
 //     (GitHub gives 60 req/h in that case, which is enough for an occasional
 //     demo but not for a 60-second polling loop)
 func Token() string {
-	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
-		return t
-	}
-	out, err := ghTokenOutput()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	t, _ := TokenSource()
+	return t
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -3,9 +3,11 @@
 package auth
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Source identifies where a resolved token came from, so auth-error
@@ -22,11 +24,18 @@ const (
 	SourceGHCLI
 )
 
+// ghTokenTimeout caps the `gh auth token` subprocess: a wedged gh
+// (stuck keyring read, unexpected interactive prompt) must not hang
+// octoscope's startup indefinitely.
+const ghTokenTimeout = 3 * time.Second
+
 // ghTokenOutput runs `gh auth token` and returns its raw stdout. It is a
 // package var so tests can stub the gh CLI fallback without invoking the
 // real binary (which would make the test depend on the host's gh login).
 var ghTokenOutput = func() ([]byte, error) {
-	return exec.Command("gh", "auth", "token").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), ghTokenTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "gh", "auth", "token").Output()
 }
 
 // TokenSource resolves a token like Token and also reports where it

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -5,50 +5,58 @@ import (
 	"testing"
 )
 
-// TestTokenResolutionOrder covers the three-way fallback in Token():
-// env var wins, gh CLI is the fallback, errors and whitespace yield "".
+// TestTokenResolutionOrder covers the three-way fallback in
+// TokenSource(): env var wins, gh CLI is the fallback, errors and
+// whitespace yield "" — and each path reports the matching Source so
+// auth-error hints can name the right fix.
 func TestTokenResolutionOrder(t *testing.T) {
 	cases := []struct {
-		name   string
-		envVal string
-		cliOut []byte
-		cliErr error
-		want   string
+		name    string
+		envVal  string
+		cliOut  []byte
+		cliErr  error
+		want    string
+		wantSrc Source
 	}{
 		{
-			name:   "env var wins over the CLI",
-			envVal: "env-token",
-			cliOut: []byte("cli-token"),
-			cliErr: nil,
-			want:   "env-token",
+			name:    "env var wins over the CLI",
+			envVal:  "env-token",
+			cliOut:  []byte("cli-token"),
+			cliErr:  nil,
+			want:    "env-token",
+			wantSrc: SourceEnv,
 		},
 		{
-			name:   "env var is trimmed",
-			envVal: "  env-token\n",
-			cliOut: nil,
-			cliErr: nil,
-			want:   "env-token",
+			name:    "env var is trimmed",
+			envVal:  "  env-token\n",
+			cliOut:  nil,
+			cliErr:  nil,
+			want:    "env-token",
+			wantSrc: SourceEnv,
 		},
 		{
-			name:   "empty env falls through to the CLI",
-			envVal: "",
-			cliOut: []byte("cli-token\n"),
-			cliErr: nil,
-			want:   "cli-token",
+			name:    "empty env falls through to the CLI",
+			envVal:  "",
+			cliOut:  []byte("cli-token\n"),
+			cliErr:  nil,
+			want:    "cli-token",
+			wantSrc: SourceGHCLI,
 		},
 		{
-			name:   "CLI error yields empty string",
-			envVal: "",
-			cliOut: nil,
-			cliErr: errors.New("gh not logged in"),
-			want:   "",
+			name:    "CLI error yields empty string",
+			envVal:  "",
+			cliOut:  nil,
+			cliErr:  errors.New("gh not logged in"),
+			want:    "",
+			wantSrc: SourceNone,
 		},
 		{
-			name:   "CLI whitespace-only yields empty string",
-			envVal: "",
-			cliOut: []byte("   \n"),
-			cliErr: nil,
-			want:   "",
+			name:    "CLI whitespace-only yields empty string",
+			envVal:  "",
+			cliOut:  []byte("   \n"),
+			cliErr:  nil,
+			want:    "",
+			wantSrc: SourceNone,
 		},
 	}
 	for _, c := range cases {
@@ -60,8 +68,13 @@ func TestTokenResolutionOrder(t *testing.T) {
 			cliOut, cliErr := c.cliOut, c.cliErr
 			ghTokenOutput = func() ([]byte, error) { return cliOut, cliErr }
 
+			got, gotSrc := TokenSource()
+			if got != c.want || gotSrc != c.wantSrc {
+				t.Errorf("TokenSource() = (%q, %d), want (%q, %d)", got, gotSrc, c.want, c.wantSrc)
+			}
+			// Token() must stay a plain delegation to the same resolution.
 			if got := Token(); got != c.want {
-				t.Errorf("got = %q, want %q", got, c.want)
+				t.Errorf("Token() = %q, want %q", got, c.want)
 			}
 		})
 	}

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -23,6 +24,10 @@ func TestClassifyErr(t *testing.T) {
 		{"primary rate limit", errors.New("API rate limit exceeded"), ReasonRateLimitPrimary},
 		{"secondary rate limit", errors.New("you have exceeded a secondary rate limit"), ReasonRateLimitSecondary},
 		{"bad credentials", errors.New("401 Bad credentials"), ReasonAuth},
+		{"expired or revoked token (401 body)", errors.New(`non-200 OK status code: 401 Unauthorized body: "{\"message\":\"Bad credentials\"}"`), ReasonAuth},
+		{"classic PAT missing a scope", errors.New("Your token has not been granted the required scopes to execute this query. The 'starredRepositories' field requires one of the following scopes: ['read:user'], but your token has only been granted the: ['repo'] scopes."), ReasonAuthScope},
+		{"fine-grained PAT missing a permission", errors.New("Resource not accessible by personal access token"), ReasonAuthScope},
+		{"REST admin-rights 403", errors.New("Must have admin rights to Repository."), ReasonAuthScope},
 		{"network unreachable", errors.New("dial tcp: network is unreachable"), ReasonNetwork},
 		{"tls handshake", errors.New("tls: handshake failure"), ReasonNetwork},
 		{"unknown", errors.New("something weird happened"), ReasonUnknown},
@@ -32,6 +37,33 @@ func TestClassifyErr(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := classifyErr(ctx, c.err); got != c.want {
 				t.Errorf("classifyErr(%q) = %d, want %d", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// TestMissingScopes pins the scope-name extraction from GitHub's
+// insufficient-scopes wording: required scopes are captured, the
+// "granted the:" list is not, and names are sanitized, deduped and
+// capped since they ride inside a GitHub-controlled error body.
+func TestMissingScopes(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{"single scope", errors.New("The 'starredRepositories' field requires one of the following scopes: ['read:user'], but your token has only been granted the: ['repo'] scopes."), []string{"read:user"}},
+		{"multiple scopes, deduped", errors.New("requires one of the following scopes: ['read:user', 'user:email', 'read:user']"), []string{"read:user", "user:email"}},
+		{"granted list is not mistaken for required", errors.New("requires one of the following scopes: ['read:org'], but your token has only been granted the: ['repo', 'gist'] scopes."), []string{"read:org"}},
+		{"no scope list in the message", errors.New("401 Bad credentials"), nil},
+		{"nil error", nil, nil},
+		{"hostile scope name is sanitized", errors.New("following scopes: ['read:user\x1b[2J\x1b[31m']"), []string{"read:user"}},
+		{"capped at six", errors.New("following scopes: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']"), []string{"a", "b", "c", "d", "e", "f"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := MissingScopes(c.err); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("MissingScopes(%v) = %v, want %v", c.err, got, c.want)
 			}
 		})
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -36,6 +37,7 @@ type Client struct {
 	gql           *githubv4.Client
 	rest          *http.Client // shares the oauth2 transport with gql; never nil — falls back to http.DefaultClient for unauthenticated sessions
 	authenticated bool
+	tokenSource   auth.Source // where the token came from — drives auth-error hints, never holds the token
 	login         string
 	publicOnly    bool
 
@@ -242,7 +244,8 @@ const (
 	ReasonUnknown            FetchErrorReason = iota
 	ReasonRateLimitPrimary                    // 5000/h GraphQL budget exhausted
 	ReasonRateLimitSecondary                  // short-term abuse throttle
-	ReasonAuth                                // 401/403 from token rejection
+	ReasonAuth                                // 401: token rejected — expired, revoked, or invalid
+	ReasonAuthScope                           // token authenticated but lacks a scope / permission for the data
 	ReasonNetwork                             // DNS, TCP, TLS, context timeout
 	ReasonServer                              // 5xx, HTTP/2 stream error (RST_STREAM/GOAWAY), or GraphQL-level error
 )
@@ -491,7 +494,7 @@ func (s *Stats) Public() *Stats {
 // profile (works with or without a token, though without one the
 // dashboard will burn through the 60/h limit quickly).
 func New(login string, opts Options) (*Client, error) {
-	token := auth.Token()
+	token, tokenSrc := auth.TokenSource()
 	var httpClient *http.Client
 	authed := false
 	if token != "" {
@@ -514,6 +517,7 @@ func New(login string, opts Options) (*Client, error) {
 		gql:           githubv4.NewClient(httpClient),
 		rest:          rest,
 		authenticated: authed,
+		tokenSource:   tokenSrc,
 		login:         login,
 		publicOnly:    opts.PublicOnly,
 	}, nil
@@ -532,6 +536,17 @@ func (c *Client) SetPublicOnly(v bool) {
 // reflect the live state, not the launch-time value.
 func (c *Client) PublicOnly() bool {
 	return c.publicOnly
+}
+
+// TokenSource reports where the client's token came from (env var,
+// gh CLI, or none) so auth-error surfaces can point at the matching
+// fix. Nil-safe because footer render paths consult it on Models that
+// unit tests build without a client.
+func (c *Client) TokenSource() auth.Source {
+	if c == nil {
+		return auth.SourceNone
+	}
+	return c.tokenSource
 }
 
 // SetWatchRepos replaces the list of external "owner/name"
@@ -1129,11 +1144,16 @@ func classifyErr(ctx context.Context, err error) FetchErrorReason {
 	case strings.Contains(msg, "rate limit exceeded"),
 		strings.Contains(msg, "api rate limit"):
 		return ReasonRateLimitPrimary
+	// Scope / permission failures sit apart from plain rejection: the
+	// token authenticated fine but can't see the field or resource, so
+	// the fix is "grant a scope", not "regenerate a dead token".
+	case strings.Contains(msg, "not been granted the required scopes"),
+		strings.Contains(msg, "resource not accessible"),
+		strings.Contains(msg, "must have admin"):
+		return ReasonAuthScope
 	case strings.Contains(msg, "bad credentials"),
 		strings.Contains(msg, "401"),
-		strings.Contains(msg, "requires authentication"),
-		strings.Contains(msg, "must have admin"),
-		strings.Contains(msg, "resource not accessible"):
+		strings.Contains(msg, "requires authentication"):
 		return ReasonAuth
 	case strings.Contains(msg, "no such host"),
 		strings.Contains(msg, "connection refused"),
@@ -1161,6 +1181,45 @@ func classifyErr(ctx context.Context, err error) FetchErrorReason {
 		return ReasonServer
 	}
 	return ReasonUnknown
+}
+
+// scopeListPattern matches the bracketed list in GitHub's GraphQL
+// insufficient-scopes error: "… requires one of the following scopes:
+// ['read:user', 'read:org'], but your token has only been granted
+// the: […] scopes." Anchoring on "following scopes:" captures only
+// the required list — the granted list is introduced by "granted
+// the:" and never matches.
+var scopeListPattern = regexp.MustCompile(`following scopes: \[([^\]]*)\]`)
+
+// MissingScopes extracts the OAuth scope names an insufficient-scopes
+// error says the query needs, so the error UI can tell the user which
+// scope to add instead of a generic "check your token". Returns nil
+// when the error carries no scope list (the fine-grained-PAT wording
+// "Resource not accessible…" names no scopes). Extracted names pass
+// through Sanitize and are deduped + capped: they arrive inside a
+// GitHub-controlled error body, and the boundary rule applies to
+// error strings the same as to field data.
+func MissingScopes(err error) []string {
+	if err == nil {
+		return nil
+	}
+	const maxScopes = 6
+	seen := make(map[string]bool)
+	var scopes []string
+	for _, m := range scopeListPattern.FindAllStringSubmatch(err.Error(), -1) {
+		for _, raw := range strings.Split(m[1], ",") {
+			s := Sanitize(strings.Trim(strings.TrimSpace(raw), `'"`))
+			if s == "" || seen[s] {
+				continue
+			}
+			seen[s] = true
+			scopes = append(scopes, s)
+			if len(scopes) >= maxScopes {
+				return scopes
+			}
+		}
+	}
+	return scopes
 }
 
 // extractStats flattens the two GraphQL response halves

--- a/internal/ui/fetcherror_test.go
+++ b/internal/ui/fetcherror_test.go
@@ -178,6 +178,20 @@ func TestFetchErrorMessageAuth(t *testing.T) {
 		}
 	})
 
+	t.Run("permission failure without a scope list gets permission wording", func(t *testing.T) {
+		permErr := errors.New("Resource not accessible by personal access token")
+		title, detail := fetchErrorMessage(github.ReasonAuthScope, permErr, nil, auth.SourceEnv)
+		if strings.Contains(detail, "missing a scope this data needs") {
+			t.Errorf("no-scope failure must not claim a missing scope: %q", detail)
+		}
+		if !strings.Contains(strings.ToLower(title), "permission") {
+			t.Errorf("title should mention the permission problem: %q", title)
+		}
+		if !strings.Contains(detail, tokensSettingsURL) {
+			t.Errorf("detail should still offer the token settings URL: %q", detail)
+		}
+	})
+
 	t.Run("auth messages never echo the raw error", func(t *testing.T) {
 		for _, src := range []auth.Source{auth.SourceNone, auth.SourceEnv, auth.SourceGHCLI} {
 			title, detail := fetchErrorMessage(github.ReasonAuth, rejected, nil, src)

--- a/internal/ui/fetcherror_test.go
+++ b/internal/ui/fetcherror_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gfazioli/octoscope/internal/auth"
 	"github.com/gfazioli/octoscope/internal/github"
 )
 
@@ -78,7 +79,7 @@ func TestFetchErrorMessage(t *testing.T) {
 	rawHTML := errors.New(`non-200 OK status code: 502 Bad Gateway body: "<html>\r\n<head><title>502 Bad Gateway</title></head>"`)
 
 	t.Run("5xx shows a friendly message, no HTML", func(t *testing.T) {
-		title, detail := fetchErrorMessage(github.ReasonServer, rawHTML, nil)
+		title, detail := fetchErrorMessage(github.ReasonServer, rawHTML, nil, auth.SourceNone)
 		if title == "" {
 			t.Error("expected a title")
 		}
@@ -128,6 +129,61 @@ func TestFetchErrorMessage(t *testing.T) {
 		}
 		if got := cleanErr(errors.New("just a plain error")); got != "just a plain error" {
 			t.Errorf("plain error mangled: %q", got)
+		}
+	})
+}
+
+// TestFetchErrorMessageAuth pins the #36 error UX: a rejected token
+// names its source and the matching fix, an under-scoped token names
+// the missing scope, and neither path ever echoes the raw error body
+// (which could ride alongside a token-shaped string).
+func TestFetchErrorMessageAuth(t *testing.T) {
+	rejected := errors.New(`non-200 OK status code: 401 Unauthorized body: "{\"message\":\"Bad credentials\"}" ghp_deadbeef`)
+
+	t.Run("env token points at $GITHUB_TOKEN and the tokens page", func(t *testing.T) {
+		title, detail := fetchErrorMessage(github.ReasonAuth, rejected, nil, auth.SourceEnv)
+		if !strings.Contains(strings.ToLower(title), "expired or revoked") {
+			t.Errorf("title should say expired/revoked: %q", title)
+		}
+		if !strings.Contains(detail, "$GITHUB_TOKEN") || !strings.Contains(detail, tokensSettingsURL) {
+			t.Errorf("detail should name the env var and the regen URL: %q", detail)
+		}
+	})
+
+	t.Run("gh CLI token points at gh auth, not the tokens page", func(t *testing.T) {
+		_, detail := fetchErrorMessage(github.ReasonAuth, rejected, nil, auth.SourceGHCLI)
+		if !strings.Contains(detail, "gh auth") {
+			t.Errorf("detail should point at gh auth refresh/login: %q", detail)
+		}
+		if strings.Contains(detail, "settings/tokens") {
+			t.Errorf("regenerating a PAT does not fix a gh login — drop the URL: %q", detail)
+		}
+	})
+
+	t.Run("no token falls back to the generic guidance", func(t *testing.T) {
+		_, detail := fetchErrorMessage(github.ReasonAuth, rejected, nil, auth.SourceNone)
+		if !strings.Contains(detail, "$GITHUB_TOKEN") || !strings.Contains(detail, "gh auth login") {
+			t.Errorf("fallback should offer both auth paths: %q", detail)
+		}
+	})
+
+	t.Run("under-scoped token names the missing scope", func(t *testing.T) {
+		scopeErr := errors.New("Your token has not been granted the required scopes to execute this query. The 'starredRepositories' field requires one of the following scopes: ['read:user'], but your token has only been granted the: ['repo'] scopes.")
+		title, detail := fetchErrorMessage(github.ReasonAuthScope, scopeErr, nil, auth.SourceEnv)
+		if !strings.Contains(strings.ToLower(title), "scope") {
+			t.Errorf("title should mention the scope problem: %q", title)
+		}
+		if !strings.Contains(detail, "read:user") || !strings.Contains(detail, tokensSettingsURL) {
+			t.Errorf("detail should name the scope and the regen URL: %q", detail)
+		}
+	})
+
+	t.Run("auth messages never echo the raw error", func(t *testing.T) {
+		for _, src := range []auth.Source{auth.SourceNone, auth.SourceEnv, auth.SourceGHCLI} {
+			title, detail := fetchErrorMessage(github.ReasonAuth, rejected, nil, src)
+			if strings.Contains(title+detail, "ghp_deadbeef") {
+				t.Errorf("source %d echoed the raw error (token-shaped string leaked)", src)
+			}
 		}
 	})
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/gfazioli/octoscope/internal/auth"
 	"github.com/gfazioli/octoscope/internal/github"
 	"github.com/gfazioli/octoscope/internal/update"
 )
@@ -65,7 +66,7 @@ func (m Model) View() string {
 		)
 	}
 	if m.err != nil && m.stats == nil {
-		title, detail := fetchErrorMessage(m.errReason, m.err, m.lastRateLimit)
+		title, detail := fetchErrorMessage(m.errReason, m.err, m.lastRateLimit, m.client.TokenSource())
 		return outerStyle.Render(
 			renderBanner(m.version) + "\n\n" +
 				errorStyle.Render(title) + "\n" +
@@ -270,11 +271,19 @@ func renderTabBar(active Tab, available int) string {
 	return bar + "\n" + rule
 }
 
+// tokensSettingsURL is where a PAT is inspected / regenerated. Shown
+// verbatim (not OSC 8-wrapped): the detail line word-wraps through
+// lipgloss and a hyperlink escape split across wrapped lines would
+// break — terminals auto-link the plain text anyway.
+const tokensSettingsURL = "https://github.com/settings/tokens"
+
 // fetchErrorMessage maps a classified fetch failure to a clean, human
 // title + one-line detail for the full-screen error view. It never
 // surfaces the raw transport error: for a 5xx that's a multi-line HTML
 // body ("502 Bad Gateway <html>…") that reads like the app crashed.
-func fetchErrorMessage(reason github.FetchErrorReason, err error, rl *github.RateLimit) (title, detail string) {
+// The auth cases tailor the fix to where the token came from (src)
+// and never echo the token or the raw error body.
+func fetchErrorMessage(reason github.FetchErrorReason, err error, rl *github.RateLimit, src auth.Source) (title, detail string) {
 	switch reason {
 	case github.ReasonServer:
 		return "GitHub had a hiccup",
@@ -287,7 +296,24 @@ func fetchErrorMessage(reason github.FetchErrorReason, err error, rl *github.Rat
 	case github.ReasonRateLimitSecondary:
 		return "Rate limited", "GitHub's secondary rate limit kicked in — wait a few seconds, then press r."
 	case github.ReasonAuth:
-		return "Authentication failed", "GitHub rejected the token. Check $GITHUB_TOKEN or run `gh auth login`, then press r."
+		switch src {
+		case auth.SourceEnv:
+			return "Token expired or revoked",
+				"GitHub rejected the token in $GITHUB_TOKEN — it has likely expired or been revoked. Generate a new one at " + tokensSettingsURL + ", update the variable, then press r."
+		case auth.SourceGHCLI:
+			return "GitHub CLI login expired",
+				"GitHub rejected the token from the gh CLI — the login has likely expired or been revoked. Run `gh auth refresh` (or `gh auth login`), then press r."
+		default:
+			return "Authentication failed",
+				"GitHub rejected the request. Set $GITHUB_TOKEN or run `gh auth login`, then press r."
+		}
+	case github.ReasonAuthScope:
+		d := "The token was accepted but is missing a scope this data needs"
+		if scopes := github.MissingScopes(err); len(scopes) > 0 {
+			d += " (" + strings.Join(scopes, ", ") + ")"
+		}
+		return "Token missing a scope",
+			d + ". Regenerate it with the extra scope at " + tokensSettingsURL + ", then press r."
 	case github.ReasonNetwork:
 		return "Network error", "Couldn't reach GitHub (network issue or timeout). Check your connection and press r."
 	default:
@@ -1081,7 +1107,12 @@ func renderErrorLine(m Model) string {
 	case github.ReasonRateLimitSecondary:
 		return warn.Render("throttled briefly · backing off")
 	case github.ReasonAuth:
+		if m.client.TokenSource() == auth.SourceGHCLI {
+			return errorStyle.Render("token rejected · run gh auth refresh")
+		}
 		return errorStyle.Render("token rejected · check $GITHUB_TOKEN")
+	case github.ReasonAuthScope:
+		return errorStyle.Render("token missing a scope · regenerate it")
 	case github.ReasonNetwork:
 		return warn.Render("offline · retrying")
 	case github.ReasonServer:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -308,12 +308,16 @@ func fetchErrorMessage(reason github.FetchErrorReason, err error, rl *github.Rat
 				"GitHub rejected the request. Set $GITHUB_TOKEN or run `gh auth login`, then press r."
 		}
 	case github.ReasonAuthScope:
-		d := "The token was accepted but is missing a scope this data needs"
+		// Only claim "missing scope" when the API actually named one.
+		// The same reason also covers permission failures (fine-grained
+		// PAT limits, admin-rights requirements) where regenerating a
+		// classic token with more scopes would be the wrong advice.
 		if scopes := github.MissingScopes(err); len(scopes) > 0 {
-			d += " (" + strings.Join(scopes, ", ") + ")"
+			return "Token missing a scope",
+				"The token was accepted but is missing a scope this data needs (" + strings.Join(scopes, ", ") + "). Regenerate it with the extra scope at " + tokensSettingsURL + ", then press r."
 		}
-		return "Token missing a scope",
-			d + ". Regenerate it with the extra scope at " + tokensSettingsURL + ", then press r."
+		return "Missing permission",
+			"GitHub accepted the token but denied access — a fine-grained token may need a broader permission, or your account may lack access to the resource. Review the token at " + tokensSettingsURL + " or check your access, then press r."
 	case github.ReasonNetwork:
 		return "Network error", "Couldn't reach GitHub (network issue or timeout). Check your connection and press r."
 	default:
@@ -1107,12 +1111,16 @@ func renderErrorLine(m Model) string {
 	case github.ReasonRateLimitSecondary:
 		return warn.Render("throttled briefly · backing off")
 	case github.ReasonAuth:
-		if m.client.TokenSource() == auth.SourceGHCLI {
+		switch m.client.TokenSource() {
+		case auth.SourceGHCLI:
 			return errorStyle.Render("token rejected · run gh auth refresh")
+		case auth.SourceEnv:
+			return errorStyle.Render("token rejected · check $GITHUB_TOKEN")
+		default:
+			return errorStyle.Render("auth failed · set $GITHUB_TOKEN or gh auth login")
 		}
-		return errorStyle.Render("token rejected · check $GITHUB_TOKEN")
 	case github.ReasonAuthScope:
-		return errorStyle.Render("token missing a scope · regenerate it")
+		return errorStyle.Render("token lacks a scope or permission")
 	case github.ReasonNetwork:
 		return warn.Render("offline · retrying")
 	case github.ReasonServer:


### PR DESCRIPTION
## Summary

Closes #36. An expired / revoked PAT and an under-scoped token both surfaced as the generic "Authentication failed" screen, leaving the user to guess the fix. This PR classifies the two failure modes apart and points each at its actual fix — without ever echoing the token.

## Changes

- **`internal/auth`**: new `TokenSource()` reports where the resolved token came from (`$GITHUB_TOKEN` env var, gh CLI, or none); `Token()` is now a thin delegation. The source is what lets the error screen suggest the *right* fix: regenerating a PAT doesn't repair an expired `gh` login, and vice versa.
- **`internal/github`**: new `ReasonAuthScope` splits scope/permission failures (GraphQL "has not been granted the required scopes", fine-grained "Resource not accessible by personal access token", REST admin-rights wording) from plain token rejection (`ReasonAuth`: 401 / bad credentials). New `MissingScopes()` extracts the required scope names from GitHub's GraphQL error wording — anchored on "following scopes:" so the granted-list is never captured — with names `Sanitize`d, deduped and capped (the boundary rule applies to error strings the same as to field data). The client records the token source (nil-safe accessor for render paths).
- **`internal/ui`**: the full-screen error view and the footer error line tailor the message per source:
  - env token → "Token expired or revoked" + https://github.com/settings/tokens
  - gh CLI token → "GitHub CLI login expired" + `gh auth refresh` / `gh auth login`
  - no token → today's generic guidance (graceful fallback)
  - under-scoped → "Token missing a scope", naming the scopes when the API provides them, + the tokens URL

  The URL is rendered as plain text on purpose: the detail line word-wraps through lipgloss and an OSC 8 pair split across wrapped lines would break — terminals auto-link the plain text anyway.

## Acceptance criteria (from #36)

- [x] Expired / revoked token → clear "expired or revoked" message with the regenerate URL
- [x] Under-scoped token → names the missing scope where the API tells us, links token settings
- [x] Falls back gracefully to the generic message when the cause can't be determined
- [x] No token value is ever echoed — pinned by a test that plants a token-shaped string in the raw error and asserts it never reaches title/detail

## Test plan

- `go test ./...` green. New table-driven cases in `classify_test.go` (401 body, classic-PAT scope wording, fine-grained wording, admin-rights) plus `TestMissingScopes` (extraction, granted-list exclusion, hostile-name sanitization, dedupe, cap). `auth_test.go` extended with per-source assertions and the `Token()` delegation check. `TestFetchErrorMessageAuth` pins the per-source copy and the no-echo property.
- Verified live: `GITHUB_TOKEN=<invalid> ./octoscope` boots into "Token expired or revoked" with the `$GITHUB_TOKEN` wording and the regen URL (pty capture of the real TUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sign-in and error handling by detecting whether a token came from environment settings or the GitHub CLI.
  * Added clearer guidance for authentication failures, including missing permissions/scopes.

* **Bug Fixes**
  * Authentication errors now surface more specific recovery steps instead of a generic message.
  * Missing-scope issues now show the relevant scope names when available.
  * Reduced the chance of exposing token-like values in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->