### PR TITLE
feat(repos): surface skipped watch_repos entries instead of silent drops

### DIFF
--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -28,6 +28,8 @@ func TestClassifyErr(t *testing.T) {
 		{"classic PAT missing a scope", errors.New("Your token has not been granted the required scopes to execute this query. The 'starredRepositories' field requires one of the following scopes: ['read:user'], but your token has only been granted the: ['repo'] scopes."), ReasonAuthScope},
 		{"fine-grained PAT missing a permission", errors.New("Resource not accessible by personal access token"), ReasonAuthScope},
 		{"REST admin-rights 403", errors.New("Must have admin rights to Repository."), ReasonAuthScope},
+		{"graphql not-found (deleted or renamed)", errors.New("Could not resolve to a Repository with the name 'owner/gone'."), ReasonNotFound},
+		{"rest 404", errors.New(`non-200 OK status code: 404 Not Found body: "{\"message\":\"Not Found\"}"`), ReasonNotFound},
 		{"network unreachable", errors.New("dial tcp: network is unreachable"), ReasonNetwork},
 		{"tls handshake", errors.New("tls: handshake failure"), ReasonNetwork},
 		{"unknown", errors.New("something weird happened"), ReasonUnknown},

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -246,6 +246,7 @@ const (
 	ReasonRateLimitSecondary                  // short-term abuse throttle
 	ReasonAuth                                // 401: token rejected — expired, revoked, or invalid
 	ReasonAuthScope                           // token authenticated but lacks a scope / permission for the data
+	ReasonNotFound                            // queried resource doesn't exist for this token (deleted / renamed / invisible)
 	ReasonNetwork                             // DNS, TCP, TLS, context timeout
 	ReasonServer                              // 5xx, HTTP/2 stream error (RST_STREAM/GOAWAY), or GraphQL-level error
 )
@@ -350,6 +351,13 @@ type Stats struct {
 	// can render in their own section and never get folded into
 	// the owned aggregates (TotalStars, ForksReceived, …).
 	WatchedRepos []Repo
+
+	// WatchedSkipped lists the `watch_repos` config refs that no
+	// longer resolve (renamed, deleted, gone private, or malformed)
+	// — the Repos tab surfaces them so a stale entry doesn't vanish
+	// silently (#37). Input (config) order. Transient fetch failures
+	// are NOT counted: only NOT_FOUND marks an entry as skipped.
+	WatchedSkipped []string
 
 	// ReviewRequests are open pull requests where the viewer has
 	// been asked to review (v0.15.0+). Populated only when the
@@ -481,6 +489,11 @@ func (s *Stats) Public() *Stats {
 		}
 		out.ReviewRequests = append(out.ReviewRequests, pr)
 	}
+
+	// WatchedSkipped names watch_repos refs that failed to resolve —
+	// one may reference a repo that just went private, so screenshot
+	// mode drops the notice entirely rather than leak the name.
+	out.WatchedSkipped = nil
 
 	return &out
 }
@@ -940,6 +953,7 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		rlP, rlR, rlC    rateLimitFields
 		errP, errR, errC error
 		watched          []Repo
+		watchedSkipped   []string
 		reviewRequests   []PullRequest
 		errRR            error
 	)
@@ -999,13 +1013,14 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 
 	// Fourth parallel branch — external watched repos. Each entry
 	// resolves to its own singleRepoQuery (FetchWatchedRepos
-	// fans out further internally). Failures are dropped silently:
-	// a stale `watch_repos` entry mustn't fail the whole
-	// dashboard.
+	// fans out further internally). A failed entry never fails the
+	// whole dashboard: unresolvable refs come back in watchedSkipped
+	// so the Repos tab can surface them (#37); transient failures
+	// are dropped for this refresh.
 	if len(watchRefs) > 0 {
 		go func() {
 			defer wg.Done()
-			watched = c.FetchWatchedRepos(ctx, watchRefs)
+			watched, watchedSkipped = c.FetchWatchedRepos(ctx, watchRefs)
 		}()
 	}
 
@@ -1047,6 +1062,7 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	stats := c.extractStats(profile, repos, repoCI)
 	stats.RateLimit = mergeRateLimit3(rlP, rlR, rlC)
 	stats.WatchedRepos = watched
+	stats.WatchedSkipped = watchedSkipped
 	stats.ReviewRequests = reviewRequests
 	return stats, nil
 }
@@ -1155,6 +1171,12 @@ func classifyErr(ctx context.Context, err error) FetchErrorReason {
 		strings.Contains(msg, "401"),
 		strings.Contains(msg, "requires authentication"):
 		return ReasonAuth
+	// NOT_FOUND: the queried resource doesn't exist for this token
+	// (deleted, renamed, or private-and-invisible). Distinct from the
+	// transient classes — retrying won't make it reappear.
+	case strings.Contains(msg, "could not resolve to"),
+		strings.Contains(msg, "404"):
+		return ReasonNotFound
 	case strings.Contains(msg, "no such host"),
 		strings.Contains(msg, "connection refused"),
 		strings.Contains(msg, "network is unreachable"),

--- a/internal/github/public_test.go
+++ b/internal/github/public_test.go
@@ -32,6 +32,7 @@ func TestPublicStripsPrivateFromKnownLists(t *testing.T) {
 			{Number: 20, Title: "review me", Repo: "someone/pub", AuthorLogin: "alice"},
 			{Number: 21, Title: "secret review", Repo: "someone/private", AuthorLogin: "bob", IsPrivate: true},
 		},
+		WatchedSkipped: []string{"gone/repo"},
 	}
 
 	got := s.Public()
@@ -65,6 +66,12 @@ func TestPublicStripsPrivateFromKnownLists(t *testing.T) {
 
 	if len(got.OpenIssuesList) != 1 || got.OpenIssuesList[0].Title != "public issue" {
 		t.Errorf("OpenIssuesList = %+v, want only the public issue", got.OpenIssuesList)
+	}
+
+	// A skipped watch_repos ref may name a repo that just went private
+	// — screenshot mode must drop the notice, not leak the ref.
+	if got.WatchedSkipped != nil {
+		t.Errorf("WatchedSkipped = %v, want nil in public mode", got.WatchedSkipped)
 	}
 
 	// Aggregates recomputed off the kept (public) repos only.

--- a/internal/github/watched_repo_fetch_test.go
+++ b/internal/github/watched_repo_fetch_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/shurcooL/githubv4"
@@ -115,7 +117,56 @@ func TestFetchWatchedRepoGraphQLError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for a GraphQL errors response, got nil")
 	}
-	if _, ok := err.(*FetchError); !ok {
-		t.Errorf("err type = %T, want *FetchError", err)
+	fe, ok := err.(*FetchError)
+	if !ok {
+		t.Fatalf("err type = %T, want *FetchError", err)
+	}
+	if fe.Reason != ReasonNotFound {
+		t.Errorf("Reason = %d, want ReasonNotFound (drives the #37 skipped notice)", fe.Reason)
+	}
+}
+
+// TestFetchWatchedReposSplitsSkippedFromTransient pins the #37
+// contract: NOT_FOUND refs and malformed entries come back in the
+// skipped list (input order), transient failures (5xx) are dropped
+// silently for the refresh, and resolvable entries land in the Repo
+// slice.
+func TestFetchWatchedReposSplitsSkippedFromTransient(t *testing.T) {
+	const okBody = `{"data":{"repository":{
+		"name":"good","nameWithOwner":"owner/good",
+		"url":"https://github.com/owner/good","isPrivate":false,
+		"pushedAt":"2026-01-02T03:04:05Z","primaryLanguage":null,
+		"stargazerCount":1,"forkCount":0,
+		"issues":{"totalCount":0},"pullRequests":{"totalCount":0},
+		"defaultBranchRef":null,"releases":{"nodes":[]}
+	}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(string(body), `"gone"`):
+			_, _ = io.WriteString(w, `{"errors":[{"message":"Could not resolve to a Repository with the name 'owner/gone'."}]}`)
+		case strings.Contains(string(body), `"flaky"`):
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = io.WriteString(w, "502 Bad Gateway")
+		default:
+			_, _ = io.WriteString(w, okBody)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c := &Client{
+		gql:           githubv4.NewClient(&http.Client{Transport: &rewriteHost{host: srv.URL}}),
+		authenticated: true,
+	}
+
+	repos, skipped := c.FetchWatchedRepos(context.Background(),
+		[]string{"owner/good", "owner/gone", "malformed-no-slash", "owner/flaky"})
+
+	if len(repos) != 1 || repos[0].Name != "good" {
+		t.Errorf("repos = %+v, want just owner/good", repos)
+	}
+	want := []string{"owner/gone", "malformed-no-slash"}
+	if !reflect.DeepEqual(skipped, want) {
+		t.Errorf("skipped = %v, want %v (transient 502 must NOT be flagged)", skipped, want)
 	}
 }

--- a/internal/github/watched_repo_fetch_test.go
+++ b/internal/github/watched_repo_fetch_test.go
@@ -160,13 +160,15 @@ func TestFetchWatchedReposSplitsSkippedFromTransient(t *testing.T) {
 	}
 
 	repos, skipped := c.FetchWatchedRepos(context.Background(),
-		[]string{"owner/good", "owner/gone", "malformed-no-slash", "owner/flaky"})
+		[]string{"owner/good", "owner/gone", "malformed-no-slash", "owner/flaky", "evil\x1b[2Jentry"})
 
 	if len(repos) != 1 || repos[0].Name != "good" {
 		t.Errorf("repos = %+v, want just owner/good", repos)
 	}
-	want := []string{"owner/gone", "malformed-no-slash"}
+	// The hostile ref comes back sanitized: config shape-checks
+	// owner/name but doesn't strip escapes, and the UI renders these.
+	want := []string{"owner/gone", "malformed-no-slash", "evilentry"}
 	if !reflect.DeepEqual(skipped, want) {
-		t.Errorf("skipped = %v, want %v (transient 502 must NOT be flagged)", skipped, want)
+		t.Errorf("skipped = %v, want %v (transient 502 must NOT be flagged; ANSI must be stripped)", skipped, want)
 	}
 }

--- a/internal/github/watched_repos.go
+++ b/internal/github/watched_repos.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -60,11 +61,11 @@ type singleRepoQuery struct {
 // All user-controlled strings are scrubbed at the boundary via
 // Sanitize — same defence-in-depth pattern as extractStats.
 //
-// A 404 from GitHub (repo removed, renamed, made private) is
-// reported as a FetchError with ReasonServer; callers can choose
-// to drop the entry silently instead of failing the whole
-// dashboard. v0.14.0 takes the "drop silently" path so a single
-// stale `watch_repos` entry doesn't break refresh for the user.
+// A repo that no longer resolves (removed, renamed, made private)
+// is reported as a FetchError with ReasonNotFound; FetchWatchedRepos
+// uses that to tell "stale config entry" (surfaced, #37) apart from
+// a transient failure (dropped for this refresh) without ever
+// failing the whole dashboard.
 func (c *Client) FetchWatchedRepo(ctx context.Context, owner, name string) (Repo, error) {
 	var q singleRepoQuery
 	vars := map[string]interface{}{
@@ -110,19 +111,24 @@ const watchedRepoConcurrency = 10
 
 // FetchWatchedRepos resolves a list of "owner/name" identifiers
 // into Repo structs by running FetchWatchedRepo for each entry
-// in parallel, bounded by watchedRepoConcurrency. Failed
-// entries (404, private, network blip) are dropped silently —
-// the dashboard mustn't fail over a single stale config line.
+// in parallel, bounded by watchedRepoConcurrency. The second
+// return value lists the refs that are unresolvable — malformed
+// entries and NOT_FOUND responses (renamed / deleted / now-private
+// repos) — so the UI can surface them instead of letting a stale
+// config line vanish silently (#37). Transient failures (network,
+// 5xx, rate limit) are dropped for this refresh without being
+// flagged: a flaky round-trip is not config rot.
 //
-// Order is preserved: the returned slice matches the input
-// order, so the Watched section under the Repos tab renders in
+// Order is preserved in both slices: each matches the input
+// order, so the Watched section and the skipped notice render in
 // the order the user wrote in their config file.
-func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) []Repo {
+func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) ([]Repo, []string) {
 	if len(refs) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]Repo, len(refs))
 	ok := make([]bool, len(refs))
+	skipped := make([]bool, len(refs))
 
 	// Buffered channel as a semaphore — each goroutine takes
 	// a slot before issuing the query and releases it on exit.
@@ -133,6 +139,7 @@ func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) []Repo {
 	for i, ref := range refs {
 		owner, name := splitOwnerNameKey(ref)
 		if owner == "" || name == "" {
+			skipped[i] = true // malformed entry — can never resolve
 			continue
 		}
 		wg.Add(1)
@@ -142,22 +149,29 @@ func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) []Repo {
 			defer func() { <-sem }()
 			r, err := c.FetchWatchedRepo(ctx, owner, name)
 			if err != nil {
-				return // drop silently
+				var fe *FetchError
+				if errors.As(err, &fe) && fe.Reason == ReasonNotFound {
+					skipped[idx] = true
+				}
+				return
 			}
 			out[idx] = r
 			ok[idx] = true
 		}(i, owner, name)
 	}
 	wg.Wait()
-	// Compact the slice in input order, skipping failures.
+	// Compact both results in input order.
 	compact := out[:0]
-	for i, r := range out {
-		if !ok[i] {
-			continue
+	var skippedRefs []string
+	for i := range refs {
+		switch {
+		case skipped[i]:
+			skippedRefs = append(skippedRefs, refs[i])
+		case ok[i]:
+			compact = append(compact, out[i])
 		}
-		compact = append(compact, r)
 	}
-	return compact
+	return compact, skippedRefs
 }
 
 // splitOwnerNameKey parses an "owner/name" config string. Mirror

--- a/internal/github/watched_repos.go
+++ b/internal/github/watched_repos.go
@@ -166,7 +166,12 @@ func (c *Client) FetchWatchedRepos(ctx context.Context, refs []string) ([]Repo, 
 	for i := range refs {
 		switch {
 		case skipped[i]:
-			skippedRefs = append(skippedRefs, refs[i])
+			// The ref comes from the user's config file, which
+			// shape-checks owner/name but doesn't strip ANSI/control
+			// bytes — and the UI renders skipped refs verbatim.
+			// Sanitize here, at the single point where they enter
+			// Stats, so every consumer gets clean strings.
+			skippedRefs = append(skippedRefs, Sanitize(refs[i]))
 		case ok[i]:
 			compact = append(compact, out[i])
 		}

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -572,22 +572,33 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 	)
 	_ = restCount // currently only the divider positions need it
 
+	// The skipped-entries notice must survive every render state —
+	// including "all watched entries failed to resolve", which is
+	// exactly when rows can be empty (#37).
+	skippedLine := renderWatchedSkippedLine(stats.WatchedSkipped, available)
+
 	if len(rows) == 0 {
 		// An active filter that matched nothing reads differently from
 		// "no repos yet" — keep the esc-to-clear affordance discoverable.
+		var empty string
 		switch {
 		case rm.query != "" && rm.work != WorkFilterNone:
-			return mutedStyle.Render(fmt.Sprintf(
+			empty = mutedStyle.Render(fmt.Sprintf(
 				"(no repositories match %q with the %s filter — esc to clear)",
 				rm.query, workFilterLabels[rm.work]))
 		case rm.work != WorkFilterNone:
-			return mutedStyle.Render(fmt.Sprintf(
+			empty = mutedStyle.Render(fmt.Sprintf(
 				"(no repositories match the %s filter — w to cycle, esc to clear)",
 				workFilterLabels[rm.work]))
 		case rm.query != "":
-			return mutedStyle.Render(fmt.Sprintf("(no repositories match %q — esc to clear)", rm.query))
+			empty = mutedStyle.Render(fmt.Sprintf("(no repositories match %q — esc to clear)", rm.query))
+		default:
+			empty = mutedStyle.Render("(no repositories to show yet — waiting for first refresh)")
 		}
-		return mutedStyle.Render("(no repositories to show yet — waiting for first refresh)")
+		if skippedLine != "" {
+			empty += "\n\n" + skippedLine
+		}
+		return empty
 	}
 
 	// Clamp the cursor in case the repo count shrank across a refresh
@@ -607,6 +618,10 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 	// line (and the search-prompt line when active). Row area is
 	// what's left.
 	overhead := 6
+	if skippedLine != "" {
+		// The skipped-entries notice adds one line under the table.
+		overhead++
+	}
 	if rm.searchActive || rm.query != "" {
 		overhead++ // search/filter line
 	}
@@ -681,8 +696,31 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 	if searchLine != "" {
 		parts = append(parts, searchLine)
 	}
-	parts = append(parts, "", table, "", hint)
+	parts = append(parts, "", table, "")
+	if skippedLine != "" {
+		parts = append(parts, skippedLine)
+	}
+	parts = append(parts, hint)
 	return strings.Join(parts, "\n")
+}
+
+// renderWatchedSkippedLine reports `watch_repos` config entries that
+// no longer resolve (renamed / deleted / now-private, or malformed)
+// so a stale entry doesn't vanish silently (#37). Names the refs so
+// the user knows which config lines to fix; the whole line truncates
+// to the available width. Zero skipped renders nothing — same
+// absence-is-default principle as the sticky sections.
+func renderWatchedSkippedLine(skipped []string, available int) string {
+	if len(skipped) == 0 {
+		return ""
+	}
+	noun := "entries"
+	if len(skipped) == 1 {
+		noun = "entry"
+	}
+	line := fmt.Sprintf("%d watched %s skipped: %s — fix watch_repos in config",
+		len(skipped), noun, strings.Join(skipped, ", "))
+	return mutedStyle.Render(truncate(line, available))
 }
 
 // renderHeaderLine produces the "N repositories · sort … · work … ·

--- a/internal/ui/repos_skipped_test.go
+++ b/internal/ui/repos_skipped_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestRenderReposTabSkippedNotice pins the #37 notice: skipped
+// watch_repos entries surface as a muted line naming the refs, the
+// line survives the empty-rows state (all watched entries stale and
+// no owned repos — exactly when the user most needs the signal), and
+// zero skipped renders nothing.
+func TestRenderReposTabSkippedNotice(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	t.Run("notice lists the refs under the table", func(t *testing.T) {
+		stats := &github.Stats{
+			Repositories:   []github.Repo{mkRepo("gfazioli", "octoscope", 100)},
+			WatchedSkipped: []string{"owner/gone", "bad-entry"},
+		}
+		out := ansi.Strip(ReposModel{}.renderReposTab(stats, 120, 40, nil))
+		if !strings.Contains(out, "2 watched entries skipped: owner/gone, bad-entry") {
+			t.Errorf("notice missing or wrong:\n%s", out)
+		}
+	})
+
+	t.Run("notice survives the empty state", func(t *testing.T) {
+		stats := &github.Stats{WatchedSkipped: []string{"owner/gone"}}
+		out := ansi.Strip(ReposModel{}.renderReposTab(stats, 120, 40, nil))
+		if !strings.Contains(out, "1 watched entry skipped: owner/gone") {
+			t.Errorf("notice must render even with zero rows:\n%s", out)
+		}
+	})
+
+	t.Run("zero skipped renders no notice", func(t *testing.T) {
+		stats := &github.Stats{Repositories: []github.Repo{mkRepo("gfazioli", "octoscope", 100)}}
+		out := ansi.Strip(ReposModel{}.renderReposTab(stats, 120, 40, nil))
+		if strings.Contains(out, "skipped") {
+			t.Errorf("no skipped entries but a notice rendered:\n%s", out)
+		}
+	})
+
+	t.Run("long ref list truncates to the available width", func(t *testing.T) {
+		stats := &github.Stats{
+			Repositories: []github.Repo{mkRepo("gfazioli", "octoscope", 100)},
+			WatchedSkipped: []string{
+				"owner/very-long-repository-name-one",
+				"owner/very-long-repository-name-two",
+				"owner/very-long-repository-name-three",
+			},
+		}
+		out := ansi.Strip(ReposModel{}.renderReposTab(stats, 60, 40, nil))
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, "skipped") && len([]rune(line)) > 60 {
+				t.Errorf("notice line wider than available (%d runes): %q", len([]rune(line)), line)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #37. A `watch_repos` entry that no longer resolves (renamed, deleted, gone private, or a misspelled owner/name) used to vanish silently from the Watched section — indistinguishable from "everything's fine". Now the Repos tab tells the user which config lines need attention.

## Changes

- **`internal/github`**:
  - New `ReasonNotFound` in the error classifier: GraphQL "Could not resolve to…" and REST 404 wording — permanent "this doesn't exist for your token" failures, distinct from the transient classes (retrying won't make the resource reappear).
  - `FetchWatchedRepos` now returns `([]Repo, []string)`: the second slice lists unresolvable refs in config order — NOT_FOUND responses plus malformed entries (defense-in-depth; the config loader already drops those at load). **Transient failures (network, 5xx, rate limit) are deliberately NOT flagged** — a flaky round-trip is not config rot, so those entries just skip one refresh, as before.
  - `Stats.WatchedSkipped []string` carries the refs to the UI. `Stats.Public()` drops the notice entirely: a skipped ref may name a repo that just went private, and screenshot mode must not leak it.
- **`internal/ui`**: the Repos tab renders a muted `N watched entries skipped: ref1, ref2 — fix watch_repos in config` line under the table. Refs come first so the actionable part survives width truncation. The line also survives the empty-rows state (all watched entries stale and no owned repos — exactly when the signal matters most), and renders nothing when the list is empty.

## Acceptance criteria (from #37)

- [x] Unresolvable entries are counted and surfaced near the watched section
- [x] The notice names the skipped refs directly, so the user knows which config lines to fix
- [x] Zero skipped → no notice (absence-is-default, like the sticky sections)

## Known limit (pre-existing, unchanged)

A malformed-shape entry (e.g. `"myrepo"` with no owner) is dropped by `config.SanitizeRepoList` at load time, before the fetch layer ever sees it — that silent drop predates this PR and is untouched. The dominant real-world cases (renamed / deleted / private / misspelled but well-formed refs) all reach the fetch layer and are surfaced.

## Test plan

- `go test ./...` green. New coverage: `ReasonNotFound` classification (GraphQL + REST wording), `TestFetchWatchedReposSplitsSkippedFromTransient` (hermetic httptest server serving mixed outcomes: resolvable / NOT_FOUND / malformed / 502 — asserts the 502 is NOT flagged), `Public()` drops `WatchedSkipped`, and `TestRenderReposTabSkippedNotice` (refs listed, survives empty state, invisible at zero, truncates to width).
- Verified live: a config with `charmbracelet/bubbletea` + a nonexistent repo boots to a dashboard whose Repos tab shows `1 watched entry skipped: gfazioli/this-repo-does-not-exist-12345 — fix watch_repos in config` while bubbletea renders normally in the Watched section (pty capture of the real TUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
