### PR TITLE
feat(config): persist view preferences via default_* keys (v0.23.0 release-prep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,16 @@ quiet days sit on the surface grey). Underneath:
   self-updates** — the package manager owns the binary. Turn the check
   off with `check_for_updates = false`; it's also suppressed under
   `--public-only`.
+- **Actionable auth errors** (v0.23.0+) — an expired or revoked token
+  says so and names the fix for where the token came from:
+  `$GITHUB_TOKEN` points at the regenerate URL, a `gh` CLI login points
+  at `gh auth refresh`. A token that's valid but missing a scope names
+  the scopes GitHub asked for.
+- **Watched-entry notices** (v0.23.0+) — a `watch_repos` entry that no
+  longer resolves (renamed, deleted, gone private) surfaces as a muted
+  "N watched entries skipped" line under the Repos tab naming the stale
+  refs, instead of vanishing silently. Transient network blips still
+  pass quietly.
 
 ### What octoscope can't show
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,21 @@ compact = false
 # terminal, monochrome, stranger-things, phosphor, amber.
 theme = "octoscope"
 
+# Initial view preferences (v0.23.0+). One sort key seeds every tab
+# whose sort cycle has that column: pushed | stars | forks | name |
+# ci | release apply to the Repos tab; updated | repo | number apply
+# to the PRs and Issues tabs. Unset keys keep the built-in defaults
+# (pushed / updated, no work filter, density sparkline).
+default_sort = "pushed"
+
+# Repos work filter preset (the `w` cycle): "prs-open" | "ci-broken"
+# | "stale". Empty = no filter.
+default_work_filter = ""
+
+# Star-history sparkline mode in the repo drill-in (the `v` cycle):
+# "density" | "cumulative".
+default_star_history = "density"
+
 # Show the sponsor splash at launch (v0.16.0+). Set to false to opt
 # out, or pass --no-sponsor for a single run. Always suppressed under
 # --public-only so screenshots stay clean.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1113,7 +1113,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.22.0</span>
+                <span class="version-tag" id="version-pill">0.23.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1301,6 +1301,11 @@
                     <div class="feature-label">Accessibility</div>
                     <h3>Respects NO_COLOR</h3>
                     <p>Since v0.22.0. Set <code class="inline">NO_COLOR</code> in your environment or pass <code class="inline">--no-color</code> and octoscope drops to its <strong style="color: var(--text);">zero-chroma monochrome theme</strong>, overriding <code class="inline">--theme</code> and the config. It's per-run only &mdash; your saved theme and accent come back the moment <code class="inline">NO_COLOR</code> is unset.</p>
+                </div>
+                <div class="feature">
+                    <div class="feature-label">Polish &amp; reliability</div>
+                    <h3>Kinder errors &middot; saved views</h3>
+                    <p>Since v0.23.0. Auth failures now <strong style="color: var(--text);">name the fix</strong> &mdash; an expired token points at the regenerate URL (or <code class="inline">gh auth refresh</code>), missing scopes are named &mdash; stale <code class="inline">watch_repos</code> entries surface a notice instead of vanishing, and <code class="inline">default_sort</code> / <code class="inline">default_work_filter</code> / <code class="inline">default_star_history</code> <strong style="color: var(--text);">open octoscope the way you like it</strong>.</p>
                 </div>
                 <div class="feature">
                     <div class="feature-label">Configurable</div>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,25 @@ type Config struct {
 	// override. The other palette slots stay on the named theme.
 	AccentColor string `toml:"accent_color"`
 
+	// DefaultSort seeds the initial sort column of the list tabs
+	// (v0.23.0+). One key, applied to every tab whose sort cycle has
+	// that column: "pushed", "stars", "forks", "name", "ci" and
+	// "release" seed the Repos tab; "updated", "repo" and "number"
+	// seed the PRs and Issues tabs. Empty keeps each tab's built-in
+	// default. Validated in main.go against ui.IsValidSortKey — the
+	// config package can't import ui (cycle), same layering as Theme.
+	DefaultSort string `toml:"default_sort"`
+
+	// DefaultWorkFilter seeds the Repos tab work filter (the `w`
+	// cycle, v0.23.0+): "prs-open", "ci-broken" or "stale". Empty =
+	// no filter.
+	DefaultWorkFilter string `toml:"default_work_filter"`
+
+	// DefaultStarHistory seeds the star-history sparkline mode in
+	// the repo drill-in (the `v` cycle, v0.23.0+): "density" or
+	// "cumulative". Empty = density.
+	DefaultStarHistory string `toml:"default_star_history"`
+
 	// PinnedRepos is the list of "owner/name" identifiers that the
 	// Repos tab will surface in a dedicated section above the rest
 	// of the list, in the order written here. v0.13.0+ feature.
@@ -133,16 +152,19 @@ func NormalizeInterval(d time.Duration) time.Duration {
 // exists (or a present file leaves keys unset).
 func Defaults() Config {
 	return Config{
-		RefreshInterval: DefaultRefreshInterval,
-		PublicOnly:      false,
-		Compact:         false,
-		Theme:           "octoscope",
-		AccentColor:     "",
-		PinnedRepos:     nil,
-		PinnedIssues:    nil,
-		WatchRepos:      nil,
-		ShowSponsor:     true,
-		CheckForUpdates: true,
+		RefreshInterval:    DefaultRefreshInterval,
+		PublicOnly:         false,
+		Compact:            false,
+		Theme:              "octoscope",
+		AccentColor:        "",
+		DefaultSort:        "",
+		DefaultWorkFilter:  "",
+		DefaultStarHistory: "",
+		PinnedRepos:        nil,
+		PinnedIssues:       nil,
+		WatchRepos:         nil,
+		ShowSponsor:        true,
+		CheckForUpdates:    true,
 	}
 }
 
@@ -298,16 +320,19 @@ func Load(path string) (Config, error) {
 	// duration field; we can't tag time.Duration directly because
 	// BurntSushi/toml doesn't know it.
 	var raw struct {
-		RefreshInterval string   `toml:"refresh_interval"`
-		PublicOnly      *bool    `toml:"public_only"`
-		Compact         *bool    `toml:"compact"`
-		Theme           string   `toml:"theme"`
-		AccentColor     string   `toml:"accent_color"`
-		PinnedRepos     []string `toml:"pinned_repos"`
-		PinnedIssues    []string `toml:"pinned_issues"`
-		WatchRepos      []string `toml:"watch_repos"`
-		ShowSponsor     *bool    `toml:"show_sponsor"`
-		CheckForUpdates *bool    `toml:"check_for_updates"`
+		RefreshInterval    string   `toml:"refresh_interval"`
+		PublicOnly         *bool    `toml:"public_only"`
+		Compact            *bool    `toml:"compact"`
+		Theme              string   `toml:"theme"`
+		AccentColor        string   `toml:"accent_color"`
+		DefaultSort        string   `toml:"default_sort"`
+		DefaultWorkFilter  string   `toml:"default_work_filter"`
+		DefaultStarHistory string   `toml:"default_star_history"`
+		PinnedRepos        []string `toml:"pinned_repos"`
+		PinnedIssues       []string `toml:"pinned_issues"`
+		WatchRepos         []string `toml:"watch_repos"`
+		ShowSponsor        *bool    `toml:"show_sponsor"`
+		CheckForUpdates    *bool    `toml:"check_for_updates"`
 	}
 	if _, err := toml.DecodeFile(path, &raw); err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
@@ -332,6 +357,17 @@ func Load(path string) (Config, error) {
 	}
 	if raw.AccentColor != "" {
 		cfg.AccentColor = raw.AccentColor
+	}
+	// View-preference keys (#35) travel as raw strings — main.go
+	// validates them against the ui package (config can't import ui).
+	if raw.DefaultSort != "" {
+		cfg.DefaultSort = raw.DefaultSort
+	}
+	if raw.DefaultWorkFilter != "" {
+		cfg.DefaultWorkFilter = raw.DefaultWorkFilter
+	}
+	if raw.DefaultStarHistory != "" {
+		cfg.DefaultStarHistory = raw.DefaultStarHistory
 	}
 	cfg.PinnedRepos = SanitizeRepoList(raw.PinnedRepos)
 	cfg.PinnedIssues = SanitizeIssueList(raw.PinnedIssues)
@@ -370,6 +406,30 @@ func Save(path string, cfg Config) error {
 	accentLine := ""
 	if cfg.AccentColor != "" {
 		accentLine = fmt.Sprintf("\n# Override the active theme's accent colour. Hex (\"#FF0080\")\n# or ANSI 256 (\"201\"). Leave unset to use the theme's default.\naccent_color = %q\n", cfg.AccentColor)
+	}
+
+	// View-preference keys (#35): emit only the ones that are set so
+	// a pristine config file stays minimal. Hand-edit only — the
+	// in-app settings panel doesn't touch them, but persistConfig's
+	// Load→Save round-trip must carry them (dropping a hand-edited
+	// key on save is the data-loss class this template guards
+	// against).
+	viewPrefsLine := ""
+	if cfg.DefaultSort != "" || cfg.DefaultWorkFilter != "" || cfg.DefaultStarHistory != "" {
+		var b strings.Builder
+		b.WriteString("\n# Initial view preferences. default_sort seeds every tab whose\n")
+		b.WriteString("# sort cycle has that column (pushed|stars|forks|name|ci|release\n")
+		b.WriteString("# apply to Repos; updated|repo|number apply to PRs and Issues).\n")
+		if cfg.DefaultSort != "" {
+			fmt.Fprintf(&b, "default_sort = %q\n", cfg.DefaultSort)
+		}
+		if cfg.DefaultWorkFilter != "" {
+			fmt.Fprintf(&b, "default_work_filter = %q\n", cfg.DefaultWorkFilter)
+		}
+		if cfg.DefaultStarHistory != "" {
+			fmt.Fprintf(&b, "default_star_history = %q\n", cfg.DefaultStarHistory)
+		}
+		viewPrefsLine = b.String()
 	}
 
 	// Same idea for pinned_repos: only emit the section when the
@@ -448,7 +508,7 @@ show_sponsor = %t
 # small notice when one exists. Never auto-updates the binary — it only
 # suggests the upgrade command. Set to false to disable.
 check_for_updates = %t
-%s%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, cfg.CheckForUpdates, accentLine, pinnedLine, pinnedIssuesLine, watchLine)
+%s%s%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, cfg.CheckForUpdates, accentLine, viewPrefsLine, pinnedLine, pinnedIssuesLine, watchLine)
 
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -422,6 +422,7 @@ func Save(path string, cfg Config) error {
 		b.WriteString("# apply to Repos; updated|repo|number apply to PRs and Issues).\n")
 		b.WriteString("# default_work_filter: prs-open|ci-broken|stale.\n")
 		b.WriteString("# default_star_history: density|cumulative.\n")
+		b.WriteString("# Leave a key out (or empty) to keep its built-in default.\n")
 		if cfg.DefaultSort != "" {
 			fmt.Fprintf(&b, "default_sort = %q\n", cfg.DefaultSort)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -420,6 +420,8 @@ func Save(path string, cfg Config) error {
 		b.WriteString("\n# Initial view preferences. default_sort seeds every tab whose\n")
 		b.WriteString("# sort cycle has that column (pushed|stars|forks|name|ci|release\n")
 		b.WriteString("# apply to Repos; updated|repo|number apply to PRs and Issues).\n")
+		b.WriteString("# default_work_filter: prs-open|ci-broken|stale.\n")
+		b.WriteString("# default_star_history: density|cumulative.\n")
 		if cfg.DefaultSort != "" {
 			fmt.Fprintf(&b, "default_sort = %q\n", cfg.DefaultSort)
 		}

--- a/internal/config/viewprefs_test.go
+++ b/internal/config/viewprefs_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestViewPrefKeysLoadAndRoundTrip pins the #35 config keys: they load
+// from TOML, default to empty (no behavioural change when unset), and
+// survive the Load→Save round-trip persistConfig relies on — a settings
+// panel write must not drop a hand-edited default_* key.
+func TestViewPrefKeysLoadAndRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	src := `
+default_sort = "stars"
+default_work_filter = "ci-broken"
+default_star_history = "cumulative"
+`
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DefaultSort != "stars" || cfg.DefaultWorkFilter != "ci-broken" || cfg.DefaultStarHistory != "cumulative" {
+		t.Errorf("loaded = (%q, %q, %q), want (stars, ci-broken, cumulative)",
+			cfg.DefaultSort, cfg.DefaultWorkFilter, cfg.DefaultStarHistory)
+	}
+
+	// Round-trip: Save must carry the keys back to disk.
+	out := filepath.Join(dir, "roundtrip.toml")
+	if err := Save(out, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	back, err := Load(out)
+	if err != nil {
+		t.Fatalf("re-Load: %v", err)
+	}
+	if back.DefaultSort != "stars" || back.DefaultWorkFilter != "ci-broken" || back.DefaultStarHistory != "cumulative" {
+		t.Errorf("round-trip = (%q, %q, %q), want the same three values",
+			back.DefaultSort, back.DefaultWorkFilter, back.DefaultStarHistory)
+	}
+
+	// Unset keys stay empty — the "no behavioural change" guarantee.
+	d := Defaults()
+	if d.DefaultSort != "" || d.DefaultWorkFilter != "" || d.DefaultStarHistory != "" {
+		t.Errorf("Defaults() view prefs = (%q, %q, %q), want all empty",
+			d.DefaultSort, d.DefaultWorkFilter, d.DefaultStarHistory)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1107,11 +1107,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.prDetail = m.prDetail.Close()
 		m.issueDetail = m.issueDetail.Close()
 		m.scan = m.scan.Close()
-		m.repoDetail = m.repoDetail.Open(msg.repo)
 		// Every fresh drill-in starts from the configured star-history
 		// default (#35); the `v` cycle inside the detail stays a
 		// per-visit choice.
-		m.repoDetail.starMode = m.starModeDefault
+		m.repoDetail = m.repoDetail.Open(msg.repo, m.starModeDefault)
 		return m, fetchRepoDetailCmd(m.client, owner, name, msg.repo.URL)
 
 	case repoDetailFetchedMsg:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -157,6 +157,12 @@ type Model struct {
 	prs    PRsModel
 	issues IssuesModel
 
+	// starModeDefault seeds RepoDetailModel.starMode on every
+	// drill-in Open (config key default_star_history, #35). The
+	// in-detail `v` cycle changes the open detail only; the next
+	// Open starts from this default again.
+	starModeDefault StarHistoryMode
+
 	// overviewVP / activityVP scroll the static-content tabs
 	// vertically when the terminal is shorter than the rendered body.
 	// Repos / PRs / Issues already paginate their own row lists, so
@@ -450,6 +456,17 @@ type Options struct {
 	// environmental, not a stored preference).
 	NoColor bool
 
+	// DefaultSort / DefaultWorkFilter / DefaultStarHistory seed the
+	// initial view state (config keys default_sort /
+	// default_work_filter / default_star_history, #35): the list
+	// tabs' sort cycles, the Repos work filter, and the star-history
+	// sparkline mode. Already validated by main.go against the
+	// ui.IsValid*Key helpers; empty strings keep the built-in
+	// defaults.
+	DefaultSort        string
+	DefaultWorkFilter  string
+	DefaultStarHistory string
+
 	// PinnedRepos is the persisted list of "owner/name" identifiers
 	// that the Repos tab renders in a sticky section at the top.
 	// Already sanitised (see config.SanitizeRepoList) by the
@@ -510,16 +527,24 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 	}
 
 	return Model{
-		client:          client,
-		loading:         true,
-		interval:        interval,
-		compact:         opts.Compact,
-		configPath:      opts.ConfigPath,
-		theme:           themeName,
-		accentColor:     opts.AccentColor,
-		noColor:         opts.NoColor,
-		pinned:          append([]string(nil), opts.PinnedRepos...),
-		pinnedIssues:    append([]string(nil), opts.PinnedIssues...),
+		client:       client,
+		loading:      true,
+		interval:     interval,
+		compact:      opts.Compact,
+		configPath:   opts.ConfigPath,
+		theme:        themeName,
+		accentColor:  opts.AccentColor,
+		noColor:      opts.NoColor,
+		pinned:       append([]string(nil), opts.PinnedRepos...),
+		pinnedIssues: append([]string(nil), opts.PinnedIssues...),
+		// Per-tab view state seeded from the default_* config keys
+		// (#35). A missing/empty key hits the maps' zero values —
+		// i.e. each tab's built-in default; main.go already rejected
+		// invalid non-empty values.
+		repos:           ReposModel{sort: reposSortKeys[opts.DefaultSort], work: workFilterKeys[opts.DefaultWorkFilter]},
+		prs:             PRsModel{sort: listSortKeys[opts.DefaultSort].prs},
+		issues:          IssuesModel{sort: listSortKeys[opts.DefaultSort].issues},
+		starModeDefault: starHistoryKeys[opts.DefaultStarHistory],
 		version:         version,
 		spinner:         sp,
 		pulseMap:        make(map[string]time.Time),
@@ -1083,6 +1108,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.issueDetail = m.issueDetail.Close()
 		m.scan = m.scan.Close()
 		m.repoDetail = m.repoDetail.Open(msg.repo)
+		// Every fresh drill-in starts from the configured star-history
+		// default (#35); the `v` cycle inside the detail stays a
+		// per-visit choice.
+		m.repoDetail.starMode = m.starModeDefault
 		return m, fetchRepoDetailCmd(m.client, owner, name, msg.repo.URL)
 
 	case repoDetailFetchedMsg:

--- a/internal/ui/repo_detail.go
+++ b/internal/ui/repo_detail.go
@@ -34,10 +34,10 @@ type RepoDetailModel struct {
 	loading bool
 
 	// starMode selects the star-history reducer (density vs
-	// cumulative, v0.18.0). Zero value = density, so every fresh
-	// Open starts on the pre-v0.18 default; the choice survives an
-	// in-detail `r` refresh but is intentionally not persisted to
-	// config (a default-mode key can come later if users ask).
+	// cumulative, v0.18.0). The root model seeds it on every Open
+	// from the default_star_history config key (#35; zero value =
+	// density). The in-detail `v` cycle survives an `r` refresh but
+	// the next Open starts from the configured default again.
 	starMode StarHistoryMode
 
 	// viewport wraps the body so a long detail (many languages,

--- a/internal/ui/repo_detail.go
+++ b/internal/ui/repo_detail.go
@@ -34,10 +34,10 @@ type RepoDetailModel struct {
 	loading bool
 
 	// starMode selects the star-history reducer (density vs
-	// cumulative, v0.18.0). The root model seeds it on every Open
-	// from the default_star_history config key (#35; zero value =
-	// density). The in-detail `v` cycle survives an `r` refresh but
-	// the next Open starts from the configured default again.
+	// cumulative, v0.18.0). Open takes it as a parameter so every
+	// fresh detail starts from the default_star_history config key
+	// (#35; zero value = density). The in-detail `v` cycle survives
+	// an `r` refresh but the next Open starts from the default again.
 	starMode StarHistoryMode
 
 	// viewport wraps the body so a long detail (many languages,
@@ -59,14 +59,17 @@ func (rd RepoDetailModel) IsOpen() bool {
 }
 
 // Open returns a fresh detail in the loading state, seeded with the
-// row the user picked. Caller is expected to dispatch
-// fetchRepoDetailCmd(client, owner, name) alongside this so the
-// loading state actually transitions to ready.
-func (rd RepoDetailModel) Open(repo github.Repo) RepoDetailModel {
+// row the user picked and the configured star-history default (a
+// parameter, not a post-Open field poke, so the seed can't be lost
+// if this constructor grows more reset logic). Caller is expected to
+// dispatch fetchRepoDetailCmd(client, owner, name) alongside this so
+// the loading state actually transitions to ready.
+func (rd RepoDetailModel) Open(repo github.Repo, starMode StarHistoryMode) RepoDetailModel {
 	return RepoDetailModel{
 		open:     true,
 		repo:     repo,
 		loading:  true,
+		starMode: starMode,
 		viewport: viewport.New(0, 0),
 	}
 }

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -463,10 +463,12 @@ func bashSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// sortedKeys returns the keys of a set in stable, sorted order.
-func sortedKeys(set map[string]bool) []string {
-	out := make([]string, 0, len(set))
-	for k := range set {
+// sortedKeys returns the keys of a map in stable, sorted order.
+// Generic over the value type so it serves both the scan's string
+// sets and viewprefs' enum maps (WorkFilterKeys / StarHistoryKeys).
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
 		out = append(out, k)
 	}
 	sort.Strings(out)

--- a/internal/ui/viewprefs.go
+++ b/internal/ui/viewprefs.go
@@ -1,0 +1,112 @@
+package ui
+
+import "sort"
+
+// View-preference config keys (#35). default_sort / default_work_filter
+// / default_star_history travel as raw strings through config → main.go
+// → Options (the config package can't import ui without a cycle), so
+// the canonical key names and their enum mappings live here, next to
+// the enums they seed. main.go validates with the IsValid* helpers and
+// rejects unknown non-empty values at startup — the same layering as
+// the theme name.
+
+// reposSortKeys maps config-facing sort keys to the Repos tab cycle.
+// Plain-ASCII names, no glyphs. A missing key yields the zero value
+// (ReposSortPushed) — the built-in default.
+var reposSortKeys = map[string]ReposSort{
+	"pushed":  ReposSortPushed,
+	"stars":   ReposSortStars,
+	"forks":   ReposSortForks,
+	"name":    ReposSortName,
+	"ci":      ReposSortCI,
+	"release": ReposSortRelease,
+}
+
+// listSortKeys maps the sort keys shared by the PRs and Issues tabs
+// (the two cycles are parallel by design). A missing key yields the
+// zero values (updated / updated) — the built-in defaults.
+var listSortKeys = map[string]struct {
+	prs    PRsSort
+	issues IssuesSort
+}{
+	"updated": {PRsSortUpdated, IssuesSortUpdated},
+	"repo":    {PRsSortRepo, IssuesSortRepo},
+	"number":  {PRsSortNumber, IssuesSortNumber},
+}
+
+// workFilterKeys maps config-facing keys to the Repos work-filter
+// presets; the names mirror the header chips.
+var workFilterKeys = map[string]WorkFilter{
+	"prs-open":  WorkFilterPRsOpen,
+	"ci-broken": WorkFilterCIBroken,
+	"stale":     WorkFilterStale,
+}
+
+// starHistoryKeys maps config-facing keys to the star-history
+// sparkline reducer modes.
+var starHistoryKeys = map[string]StarHistoryMode{
+	"density":    StarModeDensity,
+	"cumulative": StarModeCumulative,
+}
+
+// IsValidSortKey reports whether s names a sort column on at least
+// one list tab. One key seeds every tab whose cycle has that column
+// ("stars" → Repos; "updated" → PRs and Issues); tabs without it
+// keep their built-in default.
+func IsValidSortKey(s string) bool {
+	if _, ok := reposSortKeys[s]; ok {
+		return true
+	}
+	_, ok := listSortKeys[s]
+	return ok
+}
+
+// IsValidWorkFilterKey reports whether s names a Repos work-filter
+// preset.
+func IsValidWorkFilterKey(s string) bool {
+	_, ok := workFilterKeys[s]
+	return ok
+}
+
+// IsValidStarHistoryKey reports whether s names a star-history
+// sparkline mode.
+func IsValidStarHistoryKey(s string) bool {
+	_, ok := starHistoryKeys[s]
+	return ok
+}
+
+// SortKeys returns every accepted default_sort value, sorted, for
+// startup error messages.
+func SortKeys() []string {
+	keys := make([]string, 0, len(reposSortKeys)+len(listSortKeys))
+	for k := range reposSortKeys {
+		keys = append(keys, k)
+	}
+	for k := range listSortKeys {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// WorkFilterKeys returns every accepted default_work_filter value,
+// sorted, for startup error messages.
+func WorkFilterKeys() []string {
+	keys := make([]string, 0, len(workFilterKeys))
+	for k := range workFilterKeys {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// StarHistoryKeys returns every accepted default_star_history value,
+// sorted, for startup error messages.
+func StarHistoryKeys() []string {
+	keys := make([]string, 0, len(starHistoryKeys))
+	for k := range starHistoryKeys {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/ui/viewprefs.go
+++ b/internal/ui/viewprefs.go
@@ -76,7 +76,10 @@ func IsValidStarHistoryKey(s string) bool {
 }
 
 // SortKeys returns every accepted default_sort value, sorted, for
-// startup error messages.
+// startup error messages. It unions the two sort maps (a key is valid
+// on whichever tab(s) own that column — see IsValidSortKey), which
+// hold different enum value types, so the merge stays explicit rather
+// than going through the single-map sortedKeys helper.
 func SortKeys() []string {
 	keys := make([]string, 0, len(reposSortKeys)+len(listSortKeys))
 	for k := range reposSortKeys {
@@ -91,22 +94,8 @@ func SortKeys() []string {
 
 // WorkFilterKeys returns every accepted default_work_filter value,
 // sorted, for startup error messages.
-func WorkFilterKeys() []string {
-	keys := make([]string, 0, len(workFilterKeys))
-	for k := range workFilterKeys {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
+func WorkFilterKeys() []string { return sortedKeys(workFilterKeys) }
 
 // StarHistoryKeys returns every accepted default_star_history value,
 // sorted, for startup error messages.
-func StarHistoryKeys() []string {
-	keys := make([]string, 0, len(starHistoryKeys))
-	for k := range starHistoryKeys {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
+func StarHistoryKeys() []string { return sortedKeys(starHistoryKeys) }

--- a/internal/ui/viewprefs_test.go
+++ b/internal/ui/viewprefs_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestViewPrefKeyValidation pins the accepted config values for
+// default_sort / default_work_filter / default_star_history — the
+// contract main.go validates against at startup.
+func TestViewPrefKeyValidation(t *testing.T) {
+	for _, k := range []string{"pushed", "stars", "forks", "name", "ci", "release", "updated", "repo", "number"} {
+		if !IsValidSortKey(k) {
+			t.Errorf("IsValidSortKey(%q) = false, want true", k)
+		}
+	}
+	for _, k := range []string{"", "bogus", "★ stars", "PUSHED"} {
+		if IsValidSortKey(k) {
+			t.Errorf("IsValidSortKey(%q) = true, want false", k)
+		}
+	}
+	for _, k := range []string{"prs-open", "ci-broken", "stale"} {
+		if !IsValidWorkFilterKey(k) {
+			t.Errorf("IsValidWorkFilterKey(%q) = false, want true", k)
+		}
+	}
+	if IsValidWorkFilterKey("") || IsValidWorkFilterKey("none") {
+		t.Error("empty / unknown work-filter keys must not validate")
+	}
+	if !IsValidStarHistoryKey("density") || !IsValidStarHistoryKey("cumulative") {
+		t.Error("star-history keys density/cumulative must validate")
+	}
+	if IsValidStarHistoryKey("") {
+		t.Error("empty star-history key must not validate")
+	}
+
+	// Key lists feed the startup error messages — sorted and complete.
+	wantSort := []string{"ci", "forks", "name", "number", "pushed", "release", "repo", "stars", "updated"}
+	if got := SortKeys(); !reflect.DeepEqual(got, wantSort) {
+		t.Errorf("SortKeys() = %v, want %v", got, wantSort)
+	}
+	if got, want := WorkFilterKeys(), []string{"ci-broken", "prs-open", "stale"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("WorkFilterKeys() = %v, want %v", got, want)
+	}
+	if got, want := StarHistoryKeys(), []string{"cumulative", "density"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("StarHistoryKeys() = %v, want %v", got, want)
+	}
+}
+
+// TestNewModelSeedsViewPrefs pins #35: the Default* options seed the
+// sub-models' initial state, empty options preserve the pre-#35
+// defaults, and a sort key seeds only the tabs whose cycle has it.
+func TestNewModelSeedsViewPrefs(t *testing.T) {
+	t.Run("empty options keep built-in defaults", func(t *testing.T) {
+		m := NewModel(nil, "test", Options{})
+		if m.repos.sort != ReposSortPushed || m.repos.work != WorkFilterNone {
+			t.Errorf("repos = (sort %d, work %d), want (pushed, none)", m.repos.sort, m.repos.work)
+		}
+		if m.prs.sort != PRsSortUpdated || m.issues.sort != IssuesSortUpdated {
+			t.Errorf("prs/issues sort = (%d, %d), want (updated, updated)", m.prs.sort, m.issues.sort)
+		}
+		if m.starModeDefault != StarModeDensity {
+			t.Errorf("starModeDefault = %d, want density", m.starModeDefault)
+		}
+	})
+
+	t.Run("repos-only sort key leaves PRs and Issues on their default", func(t *testing.T) {
+		m := NewModel(nil, "test", Options{DefaultSort: "stars", DefaultWorkFilter: "ci-broken", DefaultStarHistory: "cumulative"})
+		if m.repos.sort != ReposSortStars || m.repos.work != WorkFilterCIBroken {
+			t.Errorf("repos = (sort %d, work %d), want (stars, ci-broken)", m.repos.sort, m.repos.work)
+		}
+		if m.prs.sort != PRsSortUpdated || m.issues.sort != IssuesSortUpdated {
+			t.Errorf("prs/issues sort = (%d, %d), want (updated, updated) for a Repos-only key", m.prs.sort, m.issues.sort)
+		}
+		if m.starModeDefault != StarModeCumulative {
+			t.Errorf("starModeDefault = %d, want cumulative", m.starModeDefault)
+		}
+	})
+
+	t.Run("list sort key leaves Repos on its default", func(t *testing.T) {
+		m := NewModel(nil, "test", Options{DefaultSort: "repo"})
+		if m.repos.sort != ReposSortPushed {
+			t.Errorf("repos.sort = %d, want pushed for a list-only key", m.repos.sort)
+		}
+		if m.prs.sort != PRsSortRepo || m.issues.sort != IssuesSortRepo {
+			t.Errorf("prs/issues sort = (%d, %d), want (repo, repo)", m.prs.sort, m.issues.sort)
+		}
+	})
+
+	t.Run("drill-in Open starts from the configured star default", func(t *testing.T) {
+		m := NewModel(nil, "test", Options{DefaultStarHistory: "cumulative"})
+		nm, _ := m.Update(viewRepoDetailMsg{repo: github.Repo{Name: "x", URL: "https://github.com/o/x"}})
+		got := nm.(Model).repoDetail
+		if !got.IsOpen() || got.starMode != StarModeCumulative {
+			t.Errorf("after Open: open=%v starMode=%d, want open + cumulative", got.IsOpen(), got.starMode)
+		}
+	})
+}

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,23 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.23.0": {
+		headline: "Polish & reliability — kinder errors, honest notices, saved views.",
+		items: []whatsNewItem{
+			{
+				title: "Actionable auth errors",
+				desc:  "An expired or revoked token now says so and names the fix for where the token came from: $GITHUB_TOKEN points at the regenerate URL, a gh CLI login points at gh auth refresh. Under-scoped tokens name the missing scopes.",
+			},
+			{
+				title: "Watched entries never vanish silently",
+				desc:  "A watch_repos entry that no longer resolves (renamed, deleted, gone private) surfaces as a small notice under the Repos tab naming the stale refs, instead of disappearing without a trace. Transient network blips still pass quietly.",
+			},
+			{
+				title: "Your view, every launch",
+				desc:  "Three new config keys — default_sort, default_work_filter and default_star_history — seed the list tabs' sort, the Repos work filter and the star-history mode at startup, so octoscope opens the way you like it.",
+			},
+		},
+	},
 	"0.22.0": {
 		headline: "Respect NO_COLOR — a calmer, monochrome octoscope.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.22.0"
+const version = "0.23.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI

--- a/main.go
+++ b/main.go
@@ -76,25 +76,11 @@ func main() {
 
 	// Same treatment for the view-preference keys (#35): a typo'd
 	// default_sort / default_work_filter / default_star_history
-	// surfaces at startup instead of silently falling back.
-	if cfg.DefaultSort != "" && !ui.IsValidSortKey(cfg.DefaultSort) {
-		fmt.Fprintf(os.Stderr,
-			"octoscope: unknown default_sort %q (valid: %s)\n",
-			cfg.DefaultSort, strings.Join(ui.SortKeys(), ", "))
-		os.Exit(2)
-	}
-	if cfg.DefaultWorkFilter != "" && !ui.IsValidWorkFilterKey(cfg.DefaultWorkFilter) {
-		fmt.Fprintf(os.Stderr,
-			"octoscope: unknown default_work_filter %q (valid: %s)\n",
-			cfg.DefaultWorkFilter, strings.Join(ui.WorkFilterKeys(), ", "))
-		os.Exit(2)
-	}
-	if cfg.DefaultStarHistory != "" && !ui.IsValidStarHistoryKey(cfg.DefaultStarHistory) {
-		fmt.Fprintf(os.Stderr,
-			"octoscope: unknown default_star_history %q (valid: %s)\n",
-			cfg.DefaultStarHistory, strings.Join(ui.StarHistoryKeys(), ", "))
-		os.Exit(2)
-	}
+	// surfaces at startup instead of silently falling back. Unlike
+	// the theme, an empty value is fine — it means "built-in default".
+	validateViewPrefKey("default_sort", cfg.DefaultSort, ui.IsValidSortKey, ui.SortKeys)
+	validateViewPrefKey("default_work_filter", cfg.DefaultWorkFilter, ui.IsValidWorkFilterKey, ui.WorkFilterKeys)
+	validateViewPrefKey("default_star_history", cfg.DefaultStarHistory, ui.IsValidStarHistoryKey, ui.StarHistoryKeys)
 
 	// NO_COLOR (the de-facto env convention, https://no-color.org) and
 	// the --no-color flag force the zero-chroma monochrome palette,
@@ -219,6 +205,19 @@ func parseArgs(args []string) (string, string, cliOverrides, bool) {
 		}
 	}
 	return userLogin, configPath, cli, true
+}
+
+// validateViewPrefKey exits with a usage error when a view-preference
+// config key holds a value the UI layer doesn't recognise. Empty means
+// "not set, keep the built-in default" and always passes.
+func validateViewPrefKey(name, value string, valid func(string) bool, keys func() []string) {
+	if value == "" || valid(value) {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"octoscope: unknown %s %q (valid: %s)\n",
+		name, value, strings.Join(keys(), ", "))
+	os.Exit(2)
 }
 
 // noColorActive resolves whether colour output should be suppressed for

--- a/main.go
+++ b/main.go
@@ -74,6 +74,28 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Same treatment for the view-preference keys (#35): a typo'd
+	// default_sort / default_work_filter / default_star_history
+	// surfaces at startup instead of silently falling back.
+	if cfg.DefaultSort != "" && !ui.IsValidSortKey(cfg.DefaultSort) {
+		fmt.Fprintf(os.Stderr,
+			"octoscope: unknown default_sort %q (valid: %s)\n",
+			cfg.DefaultSort, strings.Join(ui.SortKeys(), ", "))
+		os.Exit(2)
+	}
+	if cfg.DefaultWorkFilter != "" && !ui.IsValidWorkFilterKey(cfg.DefaultWorkFilter) {
+		fmt.Fprintf(os.Stderr,
+			"octoscope: unknown default_work_filter %q (valid: %s)\n",
+			cfg.DefaultWorkFilter, strings.Join(ui.WorkFilterKeys(), ", "))
+		os.Exit(2)
+	}
+	if cfg.DefaultStarHistory != "" && !ui.IsValidStarHistoryKey(cfg.DefaultStarHistory) {
+		fmt.Fprintf(os.Stderr,
+			"octoscope: unknown default_star_history %q (valid: %s)\n",
+			cfg.DefaultStarHistory, strings.Join(ui.StarHistoryKeys(), ", "))
+		os.Exit(2)
+	}
+
 	// NO_COLOR (the de-facto env convention, https://no-color.org) and
 	// the --no-color flag force the zero-chroma monochrome palette,
 	// overriding any configured / --theme value and dropping the accent
@@ -97,16 +119,19 @@ func main() {
 	client.SetWatchRepos(cfg.WatchRepos)
 
 	model := ui.NewModel(client, version, ui.Options{
-		Interval:        cfg.RefreshInterval,
-		Compact:         cfg.Compact,
-		ConfigPath:      configPath,
-		Theme:           cfg.Theme,
-		AccentColor:     cfg.AccentColor,
-		PinnedRepos:     cfg.PinnedRepos,
-		PinnedIssues:    cfg.PinnedIssues,
-		ShowSponsor:     cfg.ShowSponsor,
-		CheckForUpdates: cfg.CheckForUpdates,
-		NoColor:         noColor,
+		Interval:           cfg.RefreshInterval,
+		Compact:            cfg.Compact,
+		ConfigPath:         configPath,
+		Theme:              cfg.Theme,
+		AccentColor:        cfg.AccentColor,
+		DefaultSort:        cfg.DefaultSort,
+		DefaultWorkFilter:  cfg.DefaultWorkFilter,
+		DefaultStarHistory: cfg.DefaultStarHistory,
+		PinnedRepos:        cfg.PinnedRepos,
+		PinnedIssues:       cfg.PinnedIssues,
+		ShowSponsor:        cfg.ShowSponsor,
+		CheckForUpdates:    cfg.CheckForUpdates,
+		NoColor:            noColor,
 	})
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
## Summary

Closes #35 — the last item of the "polish & reliability" cycle. Sort mode, work filter and the star-history sparkline mode reset on every launch; three new hand-edit config keys now seed them. The final commit carries the **v0.23.0 release-prep** (atomic-PR pattern): merging leaves `main` immediately taggable.

## Changes

### Feature — view preferences (#35)

- **`internal/config`**: new `default_sort`, `default_work_filter`, `default_star_history` string keys. `Load` merges them like Theme/AccentColor; `Save`'s hand-written template emits them only when set (a pristine file stays minimal) and the Load→Save round-trip carries them, so `persistConfig` can't drop a hand-edited key — the data-loss class that helper exists to prevent.
- **`internal/ui/viewprefs.go`** (new): the canonical key→enum mappings live next to the enums they seed, plus `IsValid*Key` / `*Keys()` helpers for validation and error messages.
  - `default_sort` is **one key applied to every tab whose sort cycle has that column**: `pushed|stars|forks|name|ci|release` seed Repos; `updated|repo|number` seed PRs and Issues. Tabs without the column keep their default — the "per applicable tab" semantics from the issue.
  - `default_work_filter`: `prs-open|ci-broken|stale` (mirroring the header chips).
  - `default_star_history`: `density|cumulative`. The root model re-seeds every drill-in `Open`, so the configured mode survives close/reopen (the in-detail `v` cycle stays a per-visit choice).
- **`main.go`**: validates non-empty keys at startup and exits with the valid values listed — same loud-failure layering as the theme key (config can't import ui). Unset keys keep the built-in defaults: zero behavioural change for existing users.
- **README**: the three keys documented in the config example.

### Release-prep — v0.23.0 (last commit)

- `main.go` version → `0.23.0`
- `whatsnew.go` entry for 0.23.0 covering the full cycle (#36 actionable auth errors, #37 watched-skipped notice, #35 view preferences)
- README: two new *Live feedback* bullets (auth errors, watched notices)
- `docs/index.html`: version-pill fallback → 0.23.0 + a new "Polish & reliability" card in the At-a-glance grid

## Acceptance criteria (from #35)

- [x] `default_sort` seeds the initial sort-cycle position, per applicable tab
- [x] `default_work_filter` seeds the Repos work filter
- [x] Star-history default mode configurable
- [x] Unset keys preserve today's defaults (all zero-value aligned, pinned by test)
- [x] Documented in the config example + README

## Test plan

- `go test ./...` green. New: `TestViewPrefKeyValidation` (accepted values + sorted key lists), `TestNewModelSeedsViewPrefs` (seeding per tab, cross-tab isolation of a Repos-only vs list-only key, drill-in Open picks up the star default through the real `Update` path), `TestViewPrefKeysLoadAndRoundTrip` (TOML load, Save round-trip, empty defaults).
- Verified live (pty captures of the real TUI): a config with `default_sort = "stars"` + `default_work_filter = "prs-open"` boots the Repos tab already on `★ stars` with the `PRs open` chip active; `default_sort = "bogus"` exits at startup with `unknown default_sort "bogus" (valid: ci, forks, name, number, pushed, release, repo, stars, updated)`.
- `./octoscope --version` → `octoscope 0.23.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional startup defaults for default repos sorting, default work-filter preset, and default star-history mode when opening repo drill-ins.
* **Bug Fixes**
  * Improved live banner/auth messaging for missing/expired tokens or missing scopes.
  * Watched-entry notices are now shown instead of disappearing when entries no longer resolve.
  * Invalid view-preference keys are rejected at startup with a list of valid options.
* **Documentation**
  * Updated README and the v0.23.0 “What’s new” entry to document the new configuration keys and banner/notice behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->