### PR TITLE
fix(github): make repo-detail star history best-effort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,14 +426,23 @@ backend):
    - **Drill-in pattern**: one query per *selected* item, on demand.
    - **Bounded fan-out**: one targeted query per *config-listed*
      item (≤ tens), capped by a semaphore. Used for `watch_repos`.
-3. **Sibling-cancellation on error.** When a fetch combines
-   multiple goroutines whose results are all needed
-   (`FetchPRDetail` GraphQL + REST, `FetchRepoDetail` GraphQL +
-   stargazers), wrap the caller's ctx in a `context.WithCancel`
-   child and use `sync.Once` to capture the first error. The
-   sibling-cancellation echo (`ReasonNetwork` from a cancelled
-   query) would otherwise clobber the real failure (Auth /
-   RateLimit / 5xx). Reference: `FetchPRDetail` v0.12.0 polish.
+3. **Sibling-cancellation on error — when results are *all
+   needed*.** When a fetch combines multiple goroutines whose
+   results are all required (`FetchPRDetail` GraphQL + REST),
+   wrap the caller's ctx in a `context.WithCancel` child and use
+   `sync.Once` to capture the first error. The sibling-
+   cancellation echo (`ReasonNetwork` from a cancelled query)
+   would otherwise clobber the real failure (Auth / RateLimit /
+   5xx). Reference: `FetchPRDetail` v0.12.0 polish.
+   - **Best-effort branches degrade, they don't abort.** When a
+     parallel branch is decorative / optional it must *not* feed
+     the shared error path: swallow its failure and leave its
+     result empty so the mandatory branch still renders.
+     `FetchRepoDetail` is the reference (since PR #47) — the
+     star-history walk hits the restricted `stargazers`
+     connection (prone to GitHub tightening + its own transient
+     5xx), so it is best-effort, while the detail query stays
+     mandatory and still `cancel()`s an in-flight walk.
 4. **Adding new fields to a query**: estimate complexity first.
    `languages(first: 10)` × 100 repos was already a meaningful
    chunk of the budget; `defaultBranchRef.target.statusCheckRollup`

--- a/internal/github/detail.go
+++ b/internal/github/detail.go
@@ -303,9 +303,12 @@ func (c *Client) FetchRepoDetail(ctx context.Context, owner, name string) (*Repo
 
 	// Detail query and star-history walk run in parallel — same
 	// pattern as v0.12.0's PR drill-in (GraphQL + REST files) and
-	// v0.10.1's dashboard split. fetchCtx + sync.Once preserves
-	// the original failure reason if one side cancels the other,
-	// mirroring FetchPRDetail.
+	// v0.10.1's dashboard split. The detail query is mandatory: its
+	// failure aborts the drill-in via setErr + cancel (fetchCtx +
+	// sync.Once preserve the original failure reason, mirroring
+	// FetchPRDetail). The star-history walk is best-effort — see the
+	// goroutine below — so only the detail query feeds firstErr; a
+	// failed or cancelled walk drops the sparkline, not the view.
 	fetchCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -331,12 +334,18 @@ func (c *Client) FetchRepoDetail(ctx context.Context, owner, name string) (*Repo
 	}()
 	go func() {
 		defer wg.Done()
-		s, trunc, err := c.FetchStarHistory(fetchCtx, owner, name)
-		if err != nil {
-			setErr(err)
-			return
+		// Star history is best-effort and decorative: it reads the
+		// stargazers connection, which GitHub has been restricting
+		// (a scoped token is now required to page it) and which can
+		// also throw a transient 5xx of its own. A failure here must
+		// degrade to "no sparkline", never abort the whole drill-in,
+		// so we drop the error and leave StarHistory empty — the UI
+		// already hides the section and the `v` hint when it is.
+		// Deliberately no setErr: only the mandatory detail query
+		// feeds firstErr, and its cancel() still stops this walk.
+		if s, trunc, err := c.FetchStarHistory(fetchCtx, owner, name); err == nil {
+			stars, starsTrunc = s, trunc
 		}
-		stars, starsTrunc = s, trunc
 	}()
 	wg.Wait()
 	if firstErr != nil {

--- a/internal/github/repo_detail_fetch_test.go
+++ b/internal/github/repo_detail_fetch_test.go
@@ -1,0 +1,98 @@
+package github
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// repoDetailHappyBody is a minimal-but-valid repoDetailQuery
+// response. The nil-able sub-nodes (license, language, previews,
+// commits, topics) are simply absent, which extractRepoDetail already
+// tolerates — enough to prove the mandatory detail branch was applied.
+const repoDetailHappyBody = `{"data":{"repository":{
+	"name":"octoscope",
+	"url":"https://github.com/gfazioli/octoscope",
+	"stargazerCount":57,
+	"forkCount":3
+}}}`
+
+// newSplitDetailServer routes the two parallel queries of
+// FetchRepoDetail by request body: the star-history walk hits the
+// stargazers connection, everything else is the detail query. The
+// stargazers branch replies with the caller-supplied status/body so a
+// test can make just the star-history walk fail while the detail query
+// succeeds.
+func newSplitDetailServer(t *testing.T, starStatus int, starBody string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(string(body), "stargazers(") {
+			w.WriteHeader(starStatus)
+			_, _ = io.WriteString(w, starBody)
+			return
+		}
+		_, _ = io.WriteString(w, repoDetailHappyBody)
+	}))
+	t.Cleanup(srv.Close)
+	return &Client{
+		gql: githubv4.NewClient(&http.Client{Transport: &rewriteHost{host: srv.URL}}),
+		// authenticated:false skips ensureViewerID's bootstrap
+		// round-trip, so only the detail + star-history queries run.
+		authenticated: false,
+	}
+}
+
+// TestFetchRepoDetailStarHistoryFailureIsNonFatal pins the best-effort
+// contract for the star-history walk: the stargazers connection that
+// GitHub has been restricting can 5xx (or be denied) without aborting
+// the whole drill-in. The detail query still succeeds; only the
+// sparkline is dropped.
+func TestFetchRepoDetailStarHistoryFailureIsNonFatal(t *testing.T) {
+	c := newSplitDetailServer(t, http.StatusBadGateway, "502 Bad Gateway")
+
+	d, err := c.FetchRepoDetail(context.Background(), "gfazioli", "octoscope")
+	if err != nil {
+		t.Fatalf("FetchRepoDetail err = %v; a failing star-history walk must NOT fail the detail view", err)
+	}
+	if d.Stars != 57 {
+		t.Errorf("Stars = %d, want 57 (the mandatory detail query must still be applied)", d.Stars)
+	}
+	if len(d.StarHistory) != 0 {
+		t.Errorf("StarHistory = %v, want empty (a failed walk yields no sparkline)", d.StarHistory)
+	}
+}
+
+// TestFetchRepoDetailQueryFailureIsFatal is the other half of the
+// contract: the detail query itself is mandatory, so its failure still
+// aborts the fetch — unlike the best-effort star-history walk.
+func TestFetchRepoDetailQueryFailureIsFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, "502 Bad Gateway")
+	}))
+	t.Cleanup(srv.Close)
+	c := &Client{
+		gql:           githubv4.NewClient(&http.Client{Transport: &rewriteHost{host: srv.URL}}),
+		authenticated: false,
+	}
+
+	_, err := c.FetchRepoDetail(context.Background(), "gfazioli", "octoscope")
+	if err == nil {
+		t.Fatal("expected an error when the mandatory detail query fails, got nil")
+	}
+	fe, ok := err.(*FetchError)
+	if !ok {
+		t.Fatalf("err type = %T, want *FetchError", err)
+	}
+	if fe.Reason != ReasonServer {
+		t.Errorf("Reason = %d, want ReasonServer (%d) for a 502", fe.Reason, ReasonServer)
+	}
+}

--- a/internal/github/repo_detail_fetch_test.go
+++ b/internal/github/repo_detail_fetch_test.go
@@ -31,7 +31,14 @@ const repoDetailHappyBody = `{"data":{"repository":{
 func newSplitDetailServer(t *testing.T, starStatus int, starBody string) *Client {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			// A read error would otherwise route to the detail branch
+			// (empty body) and fail the test confusingly — surface it.
+			t.Errorf("test server: reading request body: %v", err)
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		if strings.Contains(string(body), "stargazers(") {
 			w.WriteHeader(starStatus)


### PR DESCRIPTION
## What

Makes the repo drill-in's 12-month star-history sparkline **best-effort**. If the `stargazers` walk fails, the drill-in still renders (description, license, latest release, recent commits, issue/PR previews, topics) — it just omits the sparkline, instead of failing the whole view with a `r retry · esc back` error screen.

## Why

`FetchRepoDetail` runs the detail query and the star-history walk in parallel, but both fed the same `sync.Once`/`cancel` error path — so **any** star-history failure aborted the entire drill-in.

The star-history walk reads the `stargazers` connection, which is exactly the endpoint GitHub has been restricting (a scoped token is now required to page it — this is why the `star-history.com` badge in our README stopped rendering; removed in e761eda). It can also throw a transient 5xx of its own. A decorative, optional sparkline shouldn't be able to deny the user the rest of the detail view.

This is a **robustness** fix, not a live outage: with octoscope's normal auth (`gh auth token` or a scoped `$GITHUB_TOKEN`) the endpoint still works today — verified against both an owned repo and a third-party one. The fix hardens against further GitHub tightening, unusual fine-grained tokens, and a 5xx landing specifically on that query.

The **star count** (`stargazerCount`) is unaffected: it's a public scalar, not the restricted stargazers list. Counters like "Stars received" and per-repo stars keep working regardless.

## How

- `internal/github/detail.go`: the star-history goroutine now swallows its error and leaves `StarHistory` empty; only the mandatory detail query feeds `firstErr`. Its `cancel()` still stops an in-flight walk, so a failing detail query is unaffected.
- `internal/github/repo_detail_fetch_test.go` (new): hermetic tests via the existing `rewriteHost` harness — one pins "failing star-history walk is non-fatal", the other pins "failing detail query is still fatal". The mock routes the two parallel queries by request body (`stargazers(` → star-history).

## Test plan

- `go test ./...` — green.
- Both new tests pass, and the non-fatal test was verified to **fail** without the fix (star-history 502 → whole fetch errors), confirming it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository details now remain available when star-history data cannot be fetched.
  * Star-history information is left empty when unavailable, while essential repository details continue loading.
  * Failures retrieving essential repository details still correctly report an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->