### PR TITLE
fix(deps): bump go directive to 1.25.12 (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gfazioli/octoscope
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from `1.25.11` to `1.25.12`.

## Why

`govulncheck` (the CI supply-chain gate, pinned `@v1.4.0`) flags **GO-2026-5856** in the standard library's `crypto/tls`:

- Found in: `crypto/tls@go1.25.11`
- Fixed in: `crypto/tls@go1.25.12`

It's a fresh **stdlib** advisory, so the gate went red on **main and every open PR** (#47, #48) regardless of what they change. Per the project's supply-chain policy the fix for a stdlib advisory is to bump the `go` directive to the patched release — CI installs the toolchain from `go-version-file: go.mod`, so the bump *is* the fix (not a suppression).

## Verification

Locally, with the same pin as CI:

```
GOTOOLCHAIN=go1.25.12 go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...
=> No vulnerabilities found.
```

`make build`, `gofmt -l .` and `go test ./...` are all clean.

## Follow-up

Once this merges, #47 (star-history best-effort) and #48 (At-a-glance marquee) get rebased onto `main` so their `govulncheck` runs go green too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go toolchain version to 1.25.12.
  * No user-facing feature or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->