### PR TITLE
chore(release): prep 0.24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ can iterate unconditionally.
 ```jsonc
 {
   "schema_version": 1,
-  "octoscope_version": "0.24.0",
+  "octoscope_version": "0.24.1",
   "generated_at": "2026-07-08T12:00:00Z",
   "authenticated": true,
   "is_viewer": true,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1159,7 +1159,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.24.0</span>
+                <span class="version-tag" id="version-pill">0.24.1</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,19 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.24.1": {
+		headline: "A reliability & security patch.",
+		items: []whatsNewItem{
+			{
+				title: "Repo drill-in survives a flaky star history",
+				desc:  "A failed or restricted star-history fetch — GitHub now gates the stargazers endpoint behind a scoped token — no longer aborts the whole repo detail view. It degrades to just hiding the 12-month sparkline; description, release, commits and issue/PR previews still load.",
+			},
+			{
+				title: "Standard-library security fix",
+				desc:  "Built against Go 1.25.12, picking up the crypto/tls fix for GO-2026-5856.",
+			},
+		},
+	},
 	"0.24.0": {
 		headline: "octoscope outside the TUI — pipe it into your scripts.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.24.0"
+const version = "0.24.1"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## What

Release-prep for the **0.24.1** patch. The shipped fixes already landed on `main`; this makes `main` taggable.

## Ships in 0.24.1 (already merged)

- `fix(github)`: repo-detail **star-history best-effort** — a failed / restricted `stargazers` fetch no longer aborts the whole drill-in (#47).
- `fix(deps)`: bump Go directive to **1.25.12** for **GO-2026-5856** (stdlib `crypto/tls`) (#49).

## This PR (prep — checklist steps 1-4)

- `main.go`: `version` `0.24.0` → `0.24.1`
- `internal/ui/whatsnew.go`: 0.24.1 "What's new" entry (reliability + security), matching the existing patch-entry pattern (`0.20.1`, `0.20.2`)
- `docs/index.html`: version-pill inline fallback → `0.24.1` (the pill also auto-updates via the Releases API on load)
- `README.md`: `--json` example's `octoscope_version` → `0.24.1`

**Patch, not minor:** only fixes ship in the binary. The At-a-glance marquee is landing-only and already live via Pages, so it doesn't gate a binary release.

## Verification

`make build`, `gofmt -l .` and `go test ./...` are clean; `./octoscope --version` → `0.24.1`.

## After merge

Step 5 is a **post-merge, pre-tag** `chore(release): refresh landing hero screenshot` (the banner only reads the new number once built), then tag `v0.24.1` via the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
