### PR TITLE
feat(ui): context-aware footer hotkeys in drill-in views

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1235,7 +1235,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.24.1</span>
+                <span class="version-tag" id="version-pill">0.24.2</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -21,43 +21,56 @@ func loadedModel(t *testing.T) Model {
 	return m
 }
 
-// TestFooterBarListContext pins the default (no drill-in) footer: the
-// full list-level hotkey set is advertised.
-func TestFooterBarListContext(t *testing.T) {
-	m := loadedModel(t)
-
-	got := ansi.Strip(renderFooterBar(m))
-	for _, want := range []string{"switch", "public", "settings", "help", "quit"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("list-context footer missing %q:\n%s", want, got)
-		}
+// TestFooterBarHotkeys pins the context-sensitivity of the footer's
+// hotkey line. On a list tab the full list-level set is advertised;
+// inside a drill-in the footer collapses to the keys that actually
+// fire at that depth (esc back · r refresh · q quit) and drops the
+// tab-switch / public / settings / help hotkeys the drill-in swallows.
+// Regression guard for the "never advertise a key that does nothing"
+// contract the drill-in views already follow.
+func TestFooterBarHotkeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		drillIn    bool
+		wantHave   []string
+		wantAbsent []string
+	}{
+		{
+			name:       "list context advertises the full hotkey set",
+			drillIn:    false,
+			wantHave:   []string{"switch", "public", "settings", "help", "quit"},
+			wantAbsent: nil,
+		},
+		{
+			name:       "drill-in context collapses to working keys only",
+			drillIn:    true,
+			wantHave:   []string{"back", "refresh", "quit"},
+			wantAbsent: []string{"switch", "public", "settings", "help"},
+		},
 	}
-}
 
-// TestFooterBarDrillInContext pins the contextual collapse: while a
-// drill-in is open the footer drops the list-level hotkeys that don't
-// fire at that depth (tab-switch / public / settings / help) and
-// advertises esc-back instead. Regression guard for the "never
-// advertise a key that does nothing" contract in the drill-in views.
-func TestFooterBarDrillInContext(t *testing.T) {
-	m := loadedModel(t)
-	m.repoDetail = m.repoDetail.Open(github.Repo{URL: "https://github.com/octocat/hello"}, StarModeDensity)
-	if !m.drillInOpen() {
-		t.Fatal("repoDetail.Open should report drillInOpen()")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := loadedModel(t)
+			if tt.drillIn {
+				m.repoDetail = m.repoDetail.Open(github.Repo{URL: "https://github.com/octocat/hello"}, StarModeDensity)
+				if !m.drillInOpen() {
+					t.Fatal("repoDetail.Open should report drillInOpen()")
+				}
+			}
 
-	got := ansi.Strip(renderFooterBar(m))
+			got := ansi.Strip(renderFooterBar(m))
 
-	// The keys that actually work at drill-in depth are present.
-	for _, want := range []string{"back", "refresh", "quit"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("drill-in footer missing %q:\n%s", want, got)
-		}
-	}
-	// The keys the drill-in swallows are gone — advertising them would lie.
-	for _, gone := range []string{"switch", "public", "settings", "help"} {
-		if strings.Contains(got, gone) {
-			t.Errorf("drill-in footer should not advertise %q (it does nothing there):\n%s", gone, got)
-		}
+			for _, want := range tt.wantHave {
+				if !strings.Contains(got, want) {
+					t.Errorf("footer missing %q:\n%s", want, got)
+				}
+			}
+			for _, gone := range tt.wantAbsent {
+				if strings.Contains(got, gone) {
+					t.Errorf("footer should not advertise %q (it does nothing there):\n%s", gone, got)
+				}
+			}
+		})
 	}
 }

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// loadedModel returns a plain model past the loading screen (window
+// sized, stats present) so renderFooterBar takes its normal path.
+func loadedModel(t *testing.T) Model {
+	t.Helper()
+	m := newPlainModel(t)
+	u, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = u.(Model)
+	m.stats = &github.Stats{}
+	m.loading = false
+	return m
+}
+
+// TestFooterBarListContext pins the default (no drill-in) footer: the
+// full list-level hotkey set is advertised.
+func TestFooterBarListContext(t *testing.T) {
+	m := loadedModel(t)
+
+	got := ansi.Strip(renderFooterBar(m))
+	for _, want := range []string{"switch", "public", "settings", "help", "quit"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("list-context footer missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestFooterBarDrillInContext pins the contextual collapse: while a
+// drill-in is open the footer drops the list-level hotkeys that don't
+// fire at that depth (tab-switch / public / settings / help) and
+// advertises esc-back instead. Regression guard for the "never
+// advertise a key that does nothing" contract in the drill-in views.
+func TestFooterBarDrillInContext(t *testing.T) {
+	m := loadedModel(t)
+	m.repoDetail = m.repoDetail.Open(github.Repo{URL: "https://github.com/octocat/hello"}, StarModeDensity)
+	if !m.drillInOpen() {
+		t.Fatal("repoDetail.Open should report drillInOpen()")
+	}
+
+	got := ansi.Strip(renderFooterBar(m))
+
+	// The keys that actually work at drill-in depth are present.
+	for _, want := range []string{"back", "refresh", "quit"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("drill-in footer missing %q:\n%s", want, got)
+		}
+	}
+	// The keys the drill-in swallows are gone — advertising them would lie.
+	for _, gone := range []string{"switch", "public", "settings", "help"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("drill-in footer should not advertise %q (it does nothing there):\n%s", gone, got)
+		}
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -994,6 +994,18 @@ func formatThousands(n int) string {
 
 // ---------- Footer ----------
 
+// drillInOpen reports whether any full-body drill-in view (repo / PR /
+// issue detail, or the integrity scan) is currently open. Each of these
+// absorbs every keystroke while open — model.go's Update routes the key
+// to the drill-in and returns before the global hotkeys ever fire — so
+// the footer consults this to drop the list-level hotkeys that do
+// nothing at that depth. Same set, same order as the drill-in branch of
+// the View() modal switch; keep the two aligned.
+func (m Model) drillInOpen() bool {
+	return m.repoDetail.IsOpen() || m.prDetail.IsOpen() ||
+		m.issueDetail.IsOpen() || m.scan.IsOpen()
+}
+
 // renderFooterBar draws the bottom bar.
 //
 // Layout is responsive: wide terminals get a single-line footer with
@@ -1006,35 +1018,53 @@ func formatThousands(n int) string {
 func renderFooterBar(m Model) string {
 	age := time.Since(m.lastFetch).Truncate(time.Second)
 
-	keys := keyHints(
-		"r", "refresh",
-		"1-6/tab", "switch",
-		"p", "public",
-		",", "settings",
-		"?", "help",
-		"q", "quit",
-	)
+	// Hotkeys are context-sensitive. While a drill-in is open it swallows
+	// every key and returns before the global hotkeys run, so advertising
+	// tab-switch / public / settings / help would point at keys that do
+	// nothing there. Collapse to what actually works at that depth: esc
+	// backs out one level, r refetches the detail, q quits from any depth
+	// (the drill-in's own actions — o open, v star view — stay in its
+	// title bar). Same "never advertise a key that does nothing"
+	// principle the drill-in titles already follow.
+	var keys string
+	if m.drillInOpen() {
+		keys = keyHints(
+			"esc", "back",
+			"r", "refresh",
+			"q", "quit",
+		)
+	} else {
+		keys = keyHints(
+			"r", "refresh",
+			"1-6/tab", "switch",
+			"p", "public",
+			",", "settings",
+			"?", "help",
+			"q", "quit",
+		)
 
-	// Scroll hint surfaces only when the active tab actually overflows
-	// vertically — otherwise the keys row stays compact and the hint
-	// doesn't tease a behaviour the user can't see in action. The
-	// viewport reports total > visible only after SetContent has been
-	// called at least once, so on first paint (before any scroll key
-	// fires) we silently miss the hint; that's fine, the next
-	// keystroke or refresh will populate it.
-	var scrollHint string
-	switch m.activeTab {
-	case TabOverview:
-		if m.overviewVP.TotalLineCount() > m.overviewVP.VisibleLineCount() {
-			scrollHint = keyHint("↑/↓", "scroll")
+		// Scroll hint surfaces only when the active tab actually overflows
+		// vertically — otherwise the keys row stays compact and the hint
+		// doesn't tease a behaviour the user can't see in action. The
+		// viewport reports total > visible only after SetContent has been
+		// called at least once, so on first paint (before any scroll key
+		// fires) we silently miss the hint; that's fine, the next
+		// keystroke or refresh will populate it. (A drill-in's own
+		// viewport scroll is advertised in its title, not here.)
+		var scrollHint string
+		switch m.activeTab {
+		case TabOverview:
+			if m.overviewVP.TotalLineCount() > m.overviewVP.VisibleLineCount() {
+				scrollHint = keyHint("↑/↓", "scroll")
+			}
+		case TabActivity:
+			if m.activityVP.TotalLineCount() > m.activityVP.VisibleLineCount() {
+				scrollHint = keyHint("↑/↓", "scroll")
+			}
 		}
-	case TabActivity:
-		if m.activityVP.TotalLineCount() > m.activityVP.VisibleLineCount() {
-			scrollHint = keyHint("↑/↓", "scroll")
+		if scrollHint != "" {
+			keys += mutedStyle.Render(keyHintsSep) + scrollHint
 		}
-	}
-	if scrollHint != "" {
-		keys += mutedStyle.Render(keyHintsSep) + scrollHint
 	}
 
 	// freshness is the "Updated Xs ago" or, while a fetch is in

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,15 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.24.2": {
+		headline: "A small footer polish.",
+		items: []whatsNewItem{
+			{
+				title: "Context-aware footer hints",
+				desc:  "Inside a drill-in (repo, PR or issue detail, or the integrity scan) the bottom bar now advertises only the keys that actually work there — esc back · r refresh · q quit — instead of the list-level tab-switch / public / settings / help hotkeys that the drill-in swallows.",
+			},
+		},
+	},
 	"0.24.1": {
 		headline: "A reliability & security patch.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.24.1"
+const version = "0.24.2"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## What

The bottom footer bar advertised the same list-level hotkeys — `1-6/tab switch`, `p public`, `, settings`, `? help` — at **every** depth. But a drill-in view (repo / PR / issue detail, or the integrity scan) absorbs every keystroke: `model.go`'s `Update` routes the key to the open drill-in and returns *before* the global hotkeys ever fire. So while a drill-in was open, the footer pointed at four keys that do nothing there.

This makes the footer context-aware. When a drill-in is open it collapses to the keys that actually work at that depth:

```
esc back · r refresh · q quit
```

The drill-in's own actions (`o` open, `v` star view) already live in its **title bar**, so nothing is lost — it's the same "never advertise a key that does nothing" principle the drill-in titles already follow.

## How

- New `Model.drillInOpen()` helper — same set/order as the drill-in branch of the `View()` modal switch.
- `renderFooterBar` branches on it: reduced hotkeys inside a drill-in, the full list-level set (plus the Overview/Activity scroll hint) otherwise.

## Tests

- `TestFooterBarListContext` — the default footer still advertises the full hotkey set.
- `TestFooterBarDrillInContext` — with a repo detail open, the footer advertises `back`/`refresh`/`quit` and drops `switch`/`public`/`settings`/`help`.

Full suite green · `gofmt` clean · `govulncheck` (pinned @v1.4.0, stdlib included) reports no vulnerabilities.

## Release prep (atomic)

Last commit bumps to **0.24.2**: `main.go` version, `whatsnew.go` entry, `docs/index.html` hero pill fallback. `main` is taggable at the merge tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Footer hints now adapt to the current view, showing only available actions when browsing repositories, pull requests, issues, or scans.
  - Added “What’s new” information for version 0.24.2.

- **Bug Fixes**
  - Improved footer guidance and removed unavailable shortcuts from drill-in views.

- **Documentation**
  - Updated displayed application version to 0.24.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->