### PR TITLE
docs: move the backlog to public issues and publish the scan design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,6 @@ coverage.html
 .env
 .env.local
 
-# Internal roadmap — kept local, not shared with the public repo
-ROADMAP.md
-
 # Claude Code per-maintainer config — slash commands, settings,
 # permission allowlists. Everything under .claude/ is intentionally
 # local: the slash commands here (octoscope-release, octoscope-smoke,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,25 +55,33 @@ A cross-platform terminal dashboard for GitHub, written in Go with BubbleTea
     ```
 - Never add `Co-Authored-By: Claude` trailers.
 - Assign new issues to `gfazioli`.
-- **Hybrid backlog model (since v0.21.0 / 2026-06-25).** The backlog
-  lives in two places by design, split by *thinking* vs *concrete work*:
-  - **`ROADMAP.md` (local, gitignored)** is the source of truth for
-    the thinking: long-form designs / RFCs (e.g. the supply-chain
-    integrity scan), the version-history archive, theme/cycle planning,
-    strategic notes ("leading candidate", feasibility gates), and
-    unripe / parking-lot ideas. None of this goes public — exposing it
-    would either make implicit promises or leak strategy.
-  - **Public GitHub issues** are for matured/decided work + community
-    signal: items ripe enough to surface for 👍 prioritization,
-    confirmed bugs, and a channel to collect external feature requests
-    (PH / Discord / etc.). This supersedes the old "only open issues
-    when explicitly asked" rule — but since issues are public-facing,
-    confirm the shortlist with the maintainer before creating them.
-  - **Keep the two in sync.** When a ROADMAP item is promoted to a
-    public issue, note the issue number on the item; the long-form
-    design stays in the file (the issue links back to it, not the
-    reverse). Reordering / dropping a *file-only* item still carries no
-    public cost — that freedom is exactly why strategy stays in the file.
+- **Issues are the backlog (since 2026-07-29).** One place, public.
+  The previous hybrid model kept a gitignored `ROADMAP.md` alongside
+  the issues; that file has been **deleted** and its open items
+  migrated to issues (#61–#83). The reason for the change: a backlog
+  nobody sees is a backlog nobody updates — the ROADMAP still read
+  "last shipped v0.21.0 / next cycle scope-locked" three releases
+  later, and the parallel `plans/` index claimed a shipped feature was
+  `TODO`. An issue closes itself when its PR merges.
+  - **Everything actionable is an issue**, including tech debt, spikes
+    and half-built features. Immature ideas are fine as issues too —
+    tag them so they read as candidates rather than commitments (the
+    `parking lot` label, or an issue body that states the open
+    questions up front, e.g. #66's complexity-ceiling gate).
+  - **Issues are public-facing**, so confirm the shortlist with the
+    maintainer before creating them, and write them for an outside
+    reader: no internal shorthand, no strategy, no implicit promises
+    about when something ships.
+  - **Long-form design goes in `docs/design/`** when it documents
+    shipped behaviour that code comments need to reference —
+    `docs/design/supply-chain-scan.md` is the reference (cited from
+    `internal/github/scan.go` and `internal/ui/model.go`). A design for
+    something not yet built belongs in the issue that proposes it.
+  - **What stays private goes in Claude's local memory**, not in a
+    tracked-or-gitignored file: release-cycle strategy (the
+    improvements/features alternation), which candidate is next, and
+    anything competitive. Memory is recalled automatically, which is
+    exactly the property `ROADMAP.md` lacked.
 
 ### Go
 

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -127,9 +127,16 @@ Not implemented yet — tracked as
   `contents: write` or `id-token: write`, using `pull_request_target`, or
   exposing secrets in a fork-triggered context
 - **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`
-  (needs admin scope; best-effort, skipped silently on 403)
+  (needs admin scope)
 - **New deploy keys and webhooks** — `GET /repos/{owner}/{repo}/keys` and
   `/hooks`, especially write keys or hooks pointing off-platform
+
+These calls need elevated scope, so a 403 must not fail the scan. But *not
+failing* is different from *not saying*: *a security report that hides its own
+blind spots is worse than one that admits them.* A 403 is not an error worth
+interrupting the user for, and it **is** coverage the report has to declare —
+"deploy keys not checked: token lacks admin scope" — so nobody reads a clean
+verdict as a complete one.
 
 ## The engine — weighted, explainable, signal not verdict
 
@@ -212,11 +219,23 @@ repository's report offers:
 
 ## Honest gaps
 
+Every gap here is a potential **false negative**, which in a security tool is
+the expensive direction to be wrong in. The rule that follows from that: a
+partial scan must present itself as partial. A clean verdict means "clean in
+what I looked at", and the report has to say what that was.
+
 - **OAuth grant enumeration is not available.** The legacy OAuth
   Authorizations API is gone, so octoscope cannot *list* a user's grants — the
   central remediation step is link-out only.
+- **Branch enumeration stops at 100.** Tier B walks
+  `refs(refPrefix: "refs/heads/", first: 100)` unpaginated, so a repository
+  with more branches than that has some unscanned — and the implant hides on
+  side branches by preference (the reference worm backdated commits on `next`).
+  Either paginate, or mark the report partial and name the number skipped.
+  Tracked as [#85](https://github.com/gfazioli/octoscope/issues/85).
 - **Self-hosted runners, deploy keys and webhooks need elevated scope**, so
-  they are best-effort and skipped silently on 403.
+  they are best-effort — and the report declares what the token could not
+  reach, rather than omitting it silently.
 - **The Axis-1 catalog is a moving target** by nature. It ships as a
   maintained data table, and the scan leans on Axes 2–4 — which do not depend
   on the catalog being exhaustive — for variants using an ignition point
@@ -239,5 +258,15 @@ detection logic itself.
 
 Tier B was validated against real repositories, including the (since cleaned)
 victims of the reference worm and unaffected controls; all scored *clean* after
-remediation. Origin of the threat research: the icflorescu dev.to series on the
-Miasma worm, 2026-06.
+remediation.
+
+The threat research this design is built on is Ionut-Cristian Florescu's dev.to
+series (June 2026), written from the position of a maintainer whose own
+repositories were hit:
+
+- [The Bot That Never Was](https://dev.to/icflorescu/the-bot-that-never-was-2mfp)
+- [The Bot that Never Was, Part 2 (Miasma worm): how a GitHub token survived and hijacked my repos from an Azure IP](https://dev.to/icflorescu/miasma-worm-part-2-how-a-github-token-survived-a-full-machine-rebuild-and-hijacked-my-repos-from-8aa)
+  — the source of this design's central remediation lesson: revoke the
+  authorization grant, not just the token
+- [If the Shai-Hulud worm reached your GitHub repos, please read this](https://dev.to/icflorescu/if-the-shai-hulud-worm-reached-your-github-repos-please-read-this-1pok)
+- [Most repos hit by the Shai-Hulud worm are still infected a week later, and the obvious fix punishes the victims](https://dev.to/icflorescu/most-repos-hit-by-the-shai-hulud-worm-are-still-infected-a-week-later-and-the-obvious-fix-punishes-2m6o)

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -1,0 +1,243 @@
+# Supply-chain integrity scan — design
+
+How octoscope's integrity scan works and why it is built the way it is. The
+on-demand per-repo scan shipped in **v0.20.0**; the axes and tiers still open
+are tracked as issues and linked below.
+
+Referenced from `internal/github/scan.go` and `internal/ui/model.go`.
+
+## Threat model
+
+A stolen token — in the reference case a `gh` CLI OAuth grant that survived a
+machine rebuild because the *token* was rotated but the underlying
+*authorization* was never revoked — is used over the GitHub **API**, not git,
+to push an implant into the repositories the victim owns.
+
+The implant is a file that **runs by itself** when a developer or an AI agent
+opens the repository (editor session hooks, folder-open tasks) or runs the
+project (`npm install` / `npm test` lifecycle scripts). On execution it
+harvests every credential it can reach — GitHub PATs, npm tokens, cloud
+metadata credentials — and re-pushes itself to more repositories. A worm.
+
+Two facts make this octoscope's job rather than a package manager's:
+
+1. The payload lives in the **GitHub source**, not the registry, so a
+   lockfile or registry audit cannot see it.
+2. It lands in the repositories **you own**, which is exactly octoscope's
+   default scope (`ownerAffiliations: OWNER`).
+
+## The generalization principle
+
+The reference indicator — a 4.3 MB obfuscated `.github/setup.js` committed as
+a forged unsigned `github-actions` bot — is a *single instance* of a class.
+Matching that filename would catch yesterday's worm and nothing else.
+
+The invariant an attacker **cannot** drop without breaking the attack is: *a
+file that auto-executes on repo-open or build, carrying a payload that doesn't
+look like the project, arriving through a commit whose provenance is
+anomalous.*
+
+So the engine matches that invariant across four filename-agnostic axes, and
+treats specific names as a data-driven seed list that is cheap to extend.
+
+## Axis 1 — auto-execution surface inventory
+
+The attack only works because some file runs without the developer choosing to
+run it. That surface is finite and enumerable, maintained as a catalog of path
+globs grouped by trigger class, so adding a future location is a one-line edit
+rather than new logic:
+
+- **AI agent / editor session hooks** — `.claude/settings.json`
+  (`hooks.SessionStart`, `PreToolUse`, …), `.gemini/settings.json`,
+  `.cursor/rules/*.mdc` (`alwaysApply: true`), `.continue/**`, `.aider*`,
+  `.windsurfrules`, MCP server configs (`.mcp.json`, `.vscode/mcp.json`)
+- **Editor auto-run** — `.vscode/tasks.json` (`runOptions.runOn: folderOpen`),
+  `.vscode/settings.json`, `.vscode/launch.json`,
+  `.devcontainer/devcontainer.json` (`postCreateCommand` / `onCreateCommand` /
+  `postStartCommand`), `.idea/**` run configurations
+- **Package lifecycle hooks** — `package.json` scripts (`preinstall`,
+  `install`, `postinstall`, `prepare`, `prepublishOnly`, `test`),
+  `pyproject.toml` and `setup.py`, `Cargo.toml` and `build.rs`,
+  `composer.json` scripts, the `Makefile` default target, Gradle init scripts
+- **VCS hooks** — committed `.husky/**`, a `core.hooksPath` in a tracked
+  `.gitconfig`, `.gitattributes` clean/smudge filters
+- **CI** — `.github/workflows/**`; see Axis 4 for the dangerous
+  permission/trigger combinations
+
+Presence alone is **low signal**: legitimate repositories have
+`.vscode/tasks.json` and `postinstall`. It only matters in combination.
+
+One lesson from running the scan against real repositories: AI-agent
+*instruction* files (`copilot-instructions.md`, `.cursor/rules`,
+`.windsurfrules`, `AGENTS.md`) are weight-0 inventory. Only code-executing
+hooks carry weight.
+
+## Axis 2 — blob anomaly
+
+Whatever it is called, a payload has physical tells, all readable cheaply
+through GraphQL `Blob` fields without pulling the whole file
+(`object(expression: "<ref>:<path>") { ... on Blob { byteSize isBinary text } }`):
+
+- **Abnormal size for the type** — a multi-megabyte `.js`, `.json` or dotfile
+  config (`byteSize`, free)
+- **High entropy, minification or encoding** — Shannon entropy over a sampled
+  prefix, very long lines, low whitespace ratio, long base64 or hex runs
+- **Obfuscation markers** — `eval(`, `new Function(`, `atob(`,
+  `Buffer.from(…, 'base64')`, dense `\x` / `\u` escapes, a ROT/Caesar
+  bootstrap, or an explicit reference to an alternate runtime (`bun`) used to
+  dodge Node-based monitors — all seen in the reference payload
+- **Indirection** — an ignition file whose command points at another file that
+  itself trips this axis
+
+This is the axis that catches **future** variants: rename the dropper all you
+like, an oversized obfuscated blob wired into an ignition point is
+intrinsically suspect.
+
+## Axis 3 — provenance anomaly
+
+The sharpest lesson of the reference case: a commit forged under the
+maintainer's own name defeats author-based detection. Detect by signature and
+shape instead.
+
+- **Unsigned tip against a signed history** — `signature { isValid state }` on
+  the branch-tip commit; flag `UNSIGNED` / `INVALID` when recent history is
+  normally `VALID`. A signature-state *delta*, not an absolute.
+- **Spoofed identity** — a `committer` or `author` of `github-actions` on an
+  account that never uses Actions, or the maintainer's own name, paired with
+  `signature.state != VALID`
+- **Backdated tip** — a branch tip whose `committedDate` is far older than its
+  siblings or than the branch's prior tip; the reference worm backdated
+  stealth commits on side branches such as `next`
+- **Side-branch divergence** — a non-default branch whose tip introduces
+  Axis-1/2 findings the default branch does not have
+- **Push burst** — many owned repositories with `PushedAt` clustered in a
+  tight window; the reference attack hit five repositories in 49 seconds from
+  one IP. Free and client-side, zero extra API cost.
+
+The unsigned-delta baseline counts only genuine author signatures
+(`Signed && !SignedByGitHub`) — a GitHub-signed `main` next to an unsigned
+feature branch is normal and must not score.
+
+## Axis 4 — capability escalation
+
+Not implemented yet — tracked as
+[#67](https://github.com/gfazioli/octoscope/issues/67).
+
+- **Workflow permissions and triggers** — `.github/workflows/**` requesting
+  `contents: write` or `id-token: write`, using `pull_request_target`, or
+  exposing secrets in a fork-triggered context
+- **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`
+  (needs admin scope; best-effort, skipped silently on 403)
+- **New deploy keys and webhooks** — `GET /repos/{owner}/{repo}/keys` and
+  `/hooks`, especially write keys or hooks pointing off-platform
+
+## The engine — weighted, explainable, signal not verdict
+
+Each matched rule contributes a **weight**; the per-repo total maps to a
+verdict tier (`clean` · `watch` · `suspicious` · `likely-compromised`). Two
+non-negotiables:
+
+1. **Every contribution is shown with its reason.** Not "INFECTED" but
+   "oversized obfuscated blob at `.github/setup.js` (4.3 MB) on branch `next`
+   · tip commit unsigned, committer `github-actions` · 5 repos pushed within
+   49 s". The user audits the *evidence*, not a black-box score.
+2. **One axis is never enough.** A lone `.vscode/tasks.json` scores near zero.
+   The high tiers require the combination — ignition point **plus** blob
+   anomaly **plus** provenance anomaly — which is what keeps the
+   false-positive rate survivable on real accounts full of legitimate
+   postinstall scripts and editor configs.
+
+## Baseline / delta
+
+Not implemented yet — tracked as
+[#68](https://github.com/gfazioli/octoscope/issues/68).
+
+Persist a per-repo fingerprint — the set of ignition-path blob OIDs plus the
+HEAD signature state — then flag **deltas** on a later scan: "a new
+`.vscode/tasks.json` appeared since the last scan", "HEAD on `main` went
+signed → unsigned".
+
+Delta detection is the most future-proof axis of all: it is both name-agnostic
+*and* content-agnostic. It just notices that something which auto-executes
+changed.
+
+## Architecture — tiers inside the complexity ceiling
+
+GitHub's GraphQL gateway enforces an undocumented per-request complexity
+budget, and per-item fan-out across many repositories reliably exceeds it. The
+scan is tiered accordingly.
+
+- **Tier A — free, on the existing dashboard fetch.** An always-on push-burst
+  banner was built and then **dropped**: timing alone cannot separate a worm
+  fan-out from an ordinary batch push (a scripted push to 17 repositories in
+  two minutes fired it), and without a recency gate any historical batch
+  re-alarmed forever. `DetectPushBurst` is kept, tested and unwired, to fold
+  into the scan later — recency-gated and combined with the other axes
+  ([#69](https://github.com/gfazioli/octoscope/issues/69)).
+- **Tier B — on-demand per-repo scan. Shipped in v0.20.0.** An action on Repos
+  rows (`s`). One targeted query per selected repository: enumerate branches
+  (`refs(refPrefix: "refs/heads/", first: 100)`), then aliased
+  `object(expression: "refs/heads/<branch>:<path>")` probes over the Axis-1
+  catalog returning `byteSize` / `isBinary` / sampled `text` (Axes 1 and 2),
+  plus each branch tip's `signature` / `committer` / `committedDate`
+  (Axis 3). Renders the explainable report. This is the endorsed drill-in
+  pattern: one query per *selected* item.
+- **Tier C — bounded account-wide sweep.** Not implemented yet, tracked as
+  [#66](https://github.com/gfazioli/octoscope/issues/66). A dedicated mode,
+  semaphore-capped like the watched-repo fan-out, probing the Axis-1 catalog
+  on the **default branch only** per owned repository. Deep all-branch
+  scanning stays on-demand. Kept out of the always-on fetch so a normal
+  refresh never pays for it.
+
+All attacker-controlled strings — branch names, commit messages, file paths,
+sampled blob text — pass through `github.Sanitize` at the extractor boundary.
+Non-negotiable here, since the whole point is rendering content from a
+*potentially hostile* repository. Severity colours honour `IsMonochromatic()`.
+
+## Fix surface — actionable, still read-only
+
+octoscope flags and **guides**; it never mutates GitHub state. A flagged
+repository's report offers:
+
+- **A copy-paste remediation script** (`y` copies it) with the safe steps:
+  `git clone --no-checkout` to inspect without executing, a branch scan,
+  **reset rather than `revert`** plus a force-push of the clean parent (a
+  `revert` leaves the payload retrievable at the old commit), and the
+  GitHub-Support garbage-collection request.
+- **Deep links** to the right pages. The central lesson is *revoke the
+  authorization grant, not just the token*:
+  <https://github.com/settings/applications> for OAuth grants,
+  <https://github.com/settings/tokens> for PATs, and the repository's
+  branch-protection / required-signed-commits settings.
+
+## Honest gaps
+
+- **OAuth grant enumeration is not available.** The legacy OAuth
+  Authorizations API is gone, so octoscope cannot *list* a user's grants — the
+  central remediation step is link-out only.
+- **Self-hosted runners, deploy keys and webhooks need elevated scope**, so
+  they are best-effort and skipped silently on 403.
+- **The Axis-1 catalog is a moving target** by nature. It ships as a
+  maintained data table, and the scan leans on Axes 2–4 — which do not depend
+  on the catalog being exhaustive — for variants using an ignition point
+  nobody has catalogued yet.
+
+## Seed indicators — data, not logic
+
+From the 2026-06 reference case: `.github/setup.js` (4.3 MB obfuscated
+dropper) · `.claude/settings.json` (SessionStart hook) ·
+`.gemini/settings.json` · `.cursor/rules/setup.mdc` (`alwaysApply`) ·
+`.vscode/tasks.json` (`runOn: folderOpen`) · `package.json` `test` pointing at
+the payload · forged unsigned `github-actions` commits with the message
+`chore: update dependencies [skip ci]` · backdated maintainer-named commits on
+`next` branches.
+
+These are **seed rows** in the Axis-1/2/3 tables, weighted high — never the
+detection logic itself.
+
+## Validation
+
+Tier B was validated against real repositories, including the (since cleaned)
+victims of the reference worm and unaffected controls; all scored *clean* after
+remediation. Origin of the threat research: the icflorescu dev.to series on the
+Miasma worm, 2026-06.

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -23,8 +23,8 @@ import (
 // generic detector for the Shai-Hulud / Miasma class of attack
 // (self-replicating implant pushed to repos you own via a stolen
 // token, auto-executing when the repo is opened in an AI editor or
-// installed, then harvesting credentials). See the design section in
-// ROADMAP.md for the full rationale.
+// installed, then harvesting credentials). See
+// docs/design/supply-chain-scan.md for the full rationale.
 //
 // The detector deliberately does NOT match a single payload filename
 // (that signature rots the moment the worm renames its dropper).
@@ -170,8 +170,8 @@ const (
 // match contributes — deliberately low (or zero) for ubiquitous,
 // usually-legitimate surfaces, because Axis 2/3 are what escalate.
 // Adding a future ignition location is a one-line edit here, not a
-// code change — this is the generic-detection contract from the
-// ROADMAP design.
+// code change — this is the generic-detection contract from
+// docs/design/supply-chain-scan.md.
 type ignitionRule struct {
 	Glob   string
 	Class  ignitionClass

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -207,7 +207,7 @@ type Model struct {
 	// the Repos action menu ("Security scan", `s`). Same drill-in
 	// idiom and mutual-exclusion contract as repoDetail / prDetail /
 	// issueDetail — only one of the four is ever open at a time. See
-	// internal/ui/scan.go and the ROADMAP integrity-scan design.
+	// internal/ui/scan.go and docs/design/supply-chain-scan.md.
 	scan ScanModel
 
 	// help is the keyboard-shortcut overlay opened with `?`. Like the

--- a/internal/ui/star_history.go
+++ b/internal/ui/star_history.go
@@ -93,8 +93,8 @@ func renderStarSparkline(stars []time.Time, truncated bool, mode StarHistoryMode
 // fetched 12-month slice, not the repo's all-time stars): what
 // it communicates is "trajectory over the last year", which is
 // exactly the at-a-glance question the cumulative view answers.
-// All-time cumulative would need a different (paged) fetch — see
-// the ROADMAP note; deliberately out of scope for v0.18.0.
+// All-time cumulative would need a different (paged) fetch —
+// deliberately out of scope for v0.18.0.
 func cumulate(buckets []int) []int {
 	out := make([]int, len(buckets))
 	sum := 0


### PR DESCRIPTION
The backlog lived in two private files, and both had drifted out of date in ways that actively misled: the gitignored `ROADMAP.md` still read *"last shipped v0.21.0 / next cycle scope-locked"* three releases after that stopped being true, and a parallel `plans/` index listed a feature that shipped in v0.21.0 as still `TODO`. A file needs someone to remember it; an issue closes itself when its PR merges.

So the backlog is now **public GitHub issues, and nothing else**.

## What moved

`ROADMAP.md`'s open items became **#61–#83**:

| Group | Issues |
|---|---|
| Improvements | #61 settings-panel keys · #62 footer lies while a modal is open · #63 `--theme list` · #64 empty states · #65 offline-first cache |
| Supply-chain scan (the half that never shipped) | #66 Tier C sweep · #67 capability-escalation axis · #68 baseline/delta · #69 push-burst folded in |
| Features | #70 commit-count column · #71 activity feed · #72 sponsors · #73 traffic · #74 inbox notifications · #75 repo-centric view · #76 gists · #77 local checkouts · #78 multi-account |
| Packaging | #79 `gh` extension · #80 Scoop + Winget · #81 Docker |
| Tooling | #82 assert TUI behaviour, not just render tapes |
| Parking lot | #83 (one collector issue, 👍 to promote an idea out of it) |

Two of those were verified against live code before being written, because the source described them with an "e.g.": **#62** is real — `renderFooterBar` (`view.go:1030`) only branches on `drillInOpen()`, while `model.go:633,642,659` show that the rate-limit, settings and action-menu modals swallow every key except `ctrl+c`, so the footer advertises four hotkeys that do nothing. **#69** is real too — `DetectPushBurst` exists and is tested but has no production caller.

Items already shipped were dropped rather than migrated (`--plain`/`--json`, NO_COLOR, persisted view prefs, token-expiry hints, watched-entry notices), as was the version-history archive: the narrative release notes and `git log` are the source of truth for what shipped.

## The scan design is now public

`internal/github/scan.go` and `internal/ui/model.go` both pointed at "the ROADMAP design" for the full rationale — a file no reader of this repo could ever open. That design is 250 lines describing **shipped** behaviour, so it moves to `docs/design/supply-chain-scan.md`: threat model, the generalization principle, the four axes, the weighted/explainable engine, the tier architecture and the honest gaps, with the still-open pieces linked to their issues. The four code comments now cite it.

## Conventions

`CLAUDE.md`'s hybrid-backlog section is rewritten: everything actionable is an issue (tech debt and spikes included, framed as candidates when immature), long-form design of shipped behaviour goes in `docs/design/`, and the private half — release-cycle strategy, which candidate is next, feasibility gates — moves to the maintainer's local assistant memory, which is recalled automatically instead of waiting to be opened.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` and `gofmt -l .` all clean. The Go changes are comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive design document for supply-chain integrity scanning, including detection areas, scan tiers, validation scope, and known limitations.
  * Updated project backlog guidance to use public issues as the single source of truth.
  * Replaced outdated roadmap references with links to the new scan design documentation.
  * Removed the local roadmap from ignore rules following its migration to issue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->