### PR TITLE
feat(repos): CI insight in the repo drill-in (v0.25.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
   landing.
 - **Repos** — every owned, non-fork repository in one sortable, searchable
   list. Columns: **CI status** (a coloured dot — green / red / yellow / dim
-  — sourced from the default-branch status-check rollup), name, primary
+  — sourced from the default-branch status-check rollup; drill in with
+  `enter` to see *which* check failed and jump to its run, v0.25.0+),
+  name, primary
   language, stars, forks, open issues, open PRs, last push, **latest
   release** (tag + age, v0.14.0+). Press `s` to cycle sort (CI is in the
   cycle and surfaces failures first; "release" sort lists the most
@@ -147,7 +149,10 @@ direct shortcut you can press from inside the menu to skip selection.
   `enter` on the row (the canonical TUI convention, mirroring
   lazygit / k9s / ranger). Per tab:
   - **Repos** — description, license, languages bar, latest
-    release, a 12-month **star-history sparkline** (press `v`,
+    release, a **Checks** section (v0.25.0+) breaking the list's CI
+    dot down into the individual checks on the default branch's tip
+    — failures first, each name an OSC 8 hyperlink to its run on
+    github.com — a 12-month **star-history sparkline** (press `v`,
     v0.18.0+, to switch between weekly density and a cumulative
     growth curve à la star-history.com), recent commits with
     total + your-commits-in-the-last-year counts, open issues /

--- a/docs/index.html
+++ b/docs/index.html
@@ -1235,7 +1235,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.24.2</span>
+                <span class="version-tag" id="version-pill">0.25.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1331,6 +1331,11 @@
                  stretch) but vary in width via the w-* size classes. -->
             <div class="glance-marquee" tabindex="0" role="group" aria-label="At a glance — feature highlights">
                 <div class="glance-track">
+                <div class="feature w-m">
+                    <div class="feature-label">CI insight</div>
+                    <h3>What broke, not just that something did</h3>
+                    <p>Drill into a repo with a red rollup dot and the Checks section names the failing jobs — failures first, so a red one can't hide in a twenty-job matrix — with each name a terminal hyperlink straight to its run.</p>
+                </div>
                 <div class="feature w-m">
                     <div class="feature-label">Profile</div>
                     <h3>Who you are</h3>

--- a/internal/github/detail.go
+++ b/internal/github/detail.go
@@ -86,6 +86,15 @@ type RepoDetail struct {
 	CIState string
 	Checks  []CheckSummary
 
+	// ChecksTotal is how many checks the rollup actually has, which
+	// can exceed len(Checks): the query caps the fetch, and a busy
+	// repo can run more (41 on charmbracelet/bubbletea). The UI
+	// reports overflow against this, not against the fetched slice,
+	// so the count it shows is true. The rollup state stays
+	// authoritative for "is anything red" even when the red row
+	// itself was past the cap.
+	ChecksTotal int
+
 	RecentCommits     []Commit
 	OpenIssuesPreview []IssuePreview
 	OpenPRsPreview    []IssuePreview
@@ -273,7 +282,14 @@ type repoDetailQuery struct {
 					StatusCheckRollup *struct {
 						State    githubv4.StatusState
 						Contexts struct {
-							Nodes []struct {
+							// TotalCount is the real number of contexts,
+							// which can exceed what we fetch — 41 on
+							// charmbracelet/bubbletea against a cap of
+							// 50. Without it the UI's "+N more" would
+							// count only the fetched slice and quietly
+							// under-report.
+							TotalCount githubv4.Int
+							Nodes      []struct {
 								CheckRun struct {
 									Name       githubv4.String
 									Conclusion githubv4.CheckConclusionState
@@ -286,7 +302,7 @@ type repoDetailQuery struct {
 									TargetURL githubv4.String `graphql:"targetUrl"`
 								} `graphql:"... on StatusContext"`
 							}
-						} `graphql:"contexts(first: 20)"`
+						} `graphql:"contexts(first: 50)"`
 					}
 				} `graphql:"... on Commit"`
 			}
@@ -507,6 +523,7 @@ func extractRepoDetail(owner string, q repoDetailQuery, authorFilterApplied bool
 		}
 		if rollup := r.DefaultBranchRef.Target.Commit.StatusCheckRollup; rollup != nil {
 			d.CIState = Sanitize(string(rollup.State))
+			d.ChecksTotal = int(rollup.Contexts.TotalCount)
 			for _, ctx := range rollup.Contexts.Nodes {
 				// CheckRun and StatusContext are the two concrete
 				// types under StatusCheckRollupContext; exactly one

--- a/internal/github/detail.go
+++ b/internal/github/detail.go
@@ -290,6 +290,15 @@ type repoDetailQuery struct {
 							// under-report.
 							TotalCount githubv4.Int
 							Nodes      []struct {
+								// __typename is the canonical
+								// discriminator for a union node — see
+								// the note on issueDetailQuery's
+								// TimelineItems for why a "which field
+								// is populated?" heuristic is not
+								// trustworthy with githubv4, and note
+								// that a CheckRun with an empty name
+								// would vanish under one.
+								Typename githubv4.String `graphql:"__typename"`
 								CheckRun struct {
 									Name       githubv4.String
 									Conclusion githubv4.CheckConclusionState
@@ -526,25 +535,27 @@ func extractRepoDetail(owner string, q repoDetailQuery, authorFilterApplied bool
 			d.ChecksTotal = int(rollup.Contexts.TotalCount)
 			for _, ctx := range rollup.Contexts.Nodes {
 				// CheckRun and StatusContext are the two concrete
-				// types under StatusCheckRollupContext; exactly one
-				// is populated per node, and which one is told by
-				// its name field being non-empty. Same discrimination
-				// extractPRDetail does — see CheckSummary.
+				// types under StatusCheckRollupContext. Discriminate
+				// on __typename, not on which name field happens to
+				// be populated: the heuristic drops a node whose name
+				// is empty and would silently swallow a third union
+				// member if GitHub ever adds one. Same rule the
+				// timeline extractors follow.
 				cs := CheckSummary{}
-				switch {
-				case string(ctx.CheckRun.Name) != "":
+				switch ctx.Typename {
+				case "CheckRun":
 					cs.Name = Sanitize(string(ctx.CheckRun.Name))
 					cs.Conclusion = string(ctx.CheckRun.Conclusion)
 					cs.Status = string(ctx.CheckRun.Status)
 					cs.URL = Sanitize(string(ctx.CheckRun.DetailsURL))
-				case string(ctx.StatusContext.Context) != "":
+				case "StatusContext":
 					cs.Name = Sanitize(string(ctx.StatusContext.Context))
 					cs.Conclusion = string(ctx.StatusContext.State)
 					cs.URL = Sanitize(string(ctx.StatusContext.TargetURL))
 				default:
 					continue
 				}
-				d.Checks = append(d.Checks, cs)
+				d.Checks = append(d.Checks, namedCheck(cs))
 			}
 		}
 	}

--- a/internal/github/detail.go
+++ b/internal/github/detail.go
@@ -73,6 +73,19 @@ type RepoDetail struct {
 	// torvalds/linux this year" is a real signal.
 	AuthorFilterApplied bool
 
+	// CI status of the default branch's tip commit. CIState is the
+	// rollup — the same value the Repos-tab dot renders
+	// ("SUCCESS" / "FAILURE" / "PENDING" / "ERROR" / "EXPECTED", or
+	// "" when the repo has no checks at all). Checks is the
+	// breakdown behind it, one entry per check run or status
+	// context, in the order GitHub returned them.
+	//
+	// A red dot on the list answers "something broke"; these two
+	// answer "what broke, and where do I look" — which is the whole
+	// point of drilling in.
+	CIState string
+	Checks  []CheckSummary
+
 	RecentCommits     []Commit
 	OpenIssuesPreview []IssuePreview
 	OpenPRsPreview    []IssuePreview
@@ -234,6 +247,47 @@ type repoDetailQuery struct {
 					AuthoredYear struct {
 						TotalCount githubv4.Int
 					} `graphql:"authoredYear: history(since: $since, author: $authorFilter) @include(if: $hasAuthor)"`
+
+					// The status-check rollup of the default branch's
+					// tip: the same aggregate the Repos-tab CI dot
+					// shows, plus the per-check breakdown behind it.
+					// Nullable — a repo with no CI has no rollup.
+					//
+					// Cheap here for the reason the history windows
+					// above are: one repo, not a fan-out. Pulling
+					// statusCheckRollup inline across
+					// repositories(first: 100) is what 502'd the list
+					// query and forced the repoCIFields split; asking
+					// for it once, for the selected repo, is the
+					// drill-in pattern working as intended.
+					// The reporting URLs are githubv4.String, not
+					// githubv4.URI, on purpose. URI unmarshals through
+					// url.Parse, which errors on a URL containing a
+					// control character — and that error propagates out
+					// of the whole decode, so one malformed check URL
+					// from one third-party app would fail the entire
+					// drill-in fetch. A string always decodes; Sanitize
+					// cleans it at the boundary and isGitHubURL (in the
+					// ui package) decides whether it may be linked. The
+					// blast radius of a bad URL stays one row.
+					StatusCheckRollup *struct {
+						State    githubv4.StatusState
+						Contexts struct {
+							Nodes []struct {
+								CheckRun struct {
+									Name       githubv4.String
+									Conclusion githubv4.CheckConclusionState
+									Status     githubv4.CheckStatusState
+									DetailsURL githubv4.String `graphql:"detailsUrl"`
+								} `graphql:"... on CheckRun"`
+								StatusContext struct {
+									Context   githubv4.String
+									State     githubv4.StatusState
+									TargetURL githubv4.String `graphql:"targetUrl"`
+								} `graphql:"... on StatusContext"`
+							}
+						} `graphql:"contexts(first: 20)"`
+					}
 				} `graphql:"... on Commit"`
 			}
 		}
@@ -450,6 +504,31 @@ func extractRepoDetail(owner string, q repoDetailQuery, authorFilterApplied bool
 				CommittedDate:   c.CommittedDate.Time,
 				Author:          author,
 			})
+		}
+		if rollup := r.DefaultBranchRef.Target.Commit.StatusCheckRollup; rollup != nil {
+			d.CIState = Sanitize(string(rollup.State))
+			for _, ctx := range rollup.Contexts.Nodes {
+				// CheckRun and StatusContext are the two concrete
+				// types under StatusCheckRollupContext; exactly one
+				// is populated per node, and which one is told by
+				// its name field being non-empty. Same discrimination
+				// extractPRDetail does — see CheckSummary.
+				cs := CheckSummary{}
+				switch {
+				case string(ctx.CheckRun.Name) != "":
+					cs.Name = Sanitize(string(ctx.CheckRun.Name))
+					cs.Conclusion = string(ctx.CheckRun.Conclusion)
+					cs.Status = string(ctx.CheckRun.Status)
+					cs.URL = Sanitize(string(ctx.CheckRun.DetailsURL))
+				case string(ctx.StatusContext.Context) != "":
+					cs.Name = Sanitize(string(ctx.StatusContext.Context))
+					cs.Conclusion = string(ctx.StatusContext.State)
+					cs.URL = Sanitize(string(ctx.StatusContext.TargetURL))
+				default:
+					continue
+				}
+				d.Checks = append(d.Checks, cs)
+			}
 		}
 	}
 

--- a/internal/github/pr_detail.go
+++ b/internal/github/pr_detail.go
@@ -95,6 +95,14 @@ type CheckSummary struct {
 	Name       string
 	Conclusion string // "SUCCESS" / "FAILURE" / "NEUTRAL" / "CANCELLED" / "SKIPPED" / "TIMED_OUT" / "ACTION_REQUIRED" / "STALE" / "STARTUP_FAILURE" / ""
 	Status     string // "QUEUED" / "IN_PROGRESS" / "COMPLETED" / "WAITING" / "PENDING" / "REQUESTED"
+
+	// URL is where the check reports: a CheckRun's detailsUrl or a
+	// StatusContext's targetUrl. Empty when GitHub returns none —
+	// and not necessarily on github.com, since a third-party CI
+	// provider posting through the Checks API points at its own
+	// dashboard. The UI decides what to do with that (see
+	// githubHyperlink); this layer only sanitizes and carries it.
+	URL string
 }
 
 // TimelineEvent captures one item from the PR's timeline that we
@@ -195,10 +203,12 @@ type prDetailQuery struct {
 										Name       githubv4.String
 										Conclusion githubv4.CheckConclusionState
 										Status     githubv4.CheckStatusState
+										DetailsURL githubv4.String `graphql:"detailsUrl"`
 									} `graphql:"... on CheckRun"`
 									StatusContext struct {
-										Context githubv4.String
-										State   githubv4.StatusState
+										Context   githubv4.String
+										State     githubv4.StatusState
+										TargetURL githubv4.String `graphql:"targetUrl"`
 									} `graphql:"... on StatusContext"`
 								}
 							} `graphql:"contexts(first: 20)"`
@@ -456,9 +466,11 @@ func extractPRDetail(owner, name string, q prDetailQuery) *PRDetail {
 				cs.Name = Sanitize(string(ctx.CheckRun.Name))
 				cs.Conclusion = string(ctx.CheckRun.Conclusion)
 				cs.Status = string(ctx.CheckRun.Status)
+				cs.URL = Sanitize(string(ctx.CheckRun.DetailsURL))
 			case string(ctx.StatusContext.Context) != "":
 				cs.Name = Sanitize(string(ctx.StatusContext.Context))
 				cs.Conclusion = string(ctx.StatusContext.State)
+				cs.URL = Sanitize(string(ctx.StatusContext.TargetURL))
 			default:
 				continue
 			}

--- a/internal/github/pr_detail.go
+++ b/internal/github/pr_detail.go
@@ -61,6 +61,11 @@ type PRDetail struct {
 	ChecksState    string
 	ChecksContexts []CheckSummary
 
+	// ChecksTotal is how many checks the rollup has, which can exceed
+	// len(ChecksContexts) — the query caps the fetch. See the same
+	// field on RepoDetail.
+	ChecksTotal int
+
 	// Timeline — most recent ~10 events relevant to a PR's life.
 	// Events outside the curated set (label changes, milestones,
 	// trivia) are filtered out at query time.
@@ -198,7 +203,12 @@ type prDetailQuery struct {
 						StatusCheckRollup *struct {
 							State    githubv4.StatusState
 							Contexts struct {
-								Nodes []struct {
+								// TotalCount is the real number of
+								// contexts, which can exceed the fetched
+								// slice — see the note in
+								// repoDetailQuery.
+								TotalCount githubv4.Int
+								Nodes      []struct {
 									CheckRun struct {
 										Name       githubv4.String
 										Conclusion githubv4.CheckConclusionState
@@ -211,7 +221,7 @@ type prDetailQuery struct {
 										TargetURL githubv4.String `graphql:"targetUrl"`
 									} `graphql:"... on StatusContext"`
 								}
-							} `graphql:"contexts(first: 20)"`
+							} `graphql:"contexts(first: 50)"`
 						}
 					}
 				}
@@ -459,6 +469,7 @@ func extractPRDetail(owner, name string, q prDetailQuery) *PRDetail {
 	if len(pr.Commits.Nodes) > 0 && pr.Commits.Nodes[0].Commit.StatusCheckRollup != nil {
 		rollup := pr.Commits.Nodes[0].Commit.StatusCheckRollup
 		d.ChecksState = string(rollup.State)
+		d.ChecksTotal = int(rollup.Contexts.TotalCount)
 		for _, ctx := range rollup.Contexts.Nodes {
 			cs := CheckSummary{}
 			switch {

--- a/internal/github/pr_detail.go
+++ b/internal/github/pr_detail.go
@@ -110,6 +110,20 @@ type CheckSummary struct {
 	URL string
 }
 
+// namedCheck guarantees a check has something to render. GitHub types
+// CheckRun.name and StatusContext.context as non-null strings but
+// nowhere promises they are non-empty, and now that the union member is
+// identified by __typename rather than by which name is populated, an
+// empty one no longer disappears — it would render as a bare status
+// glyph with nothing beside it. A placeholder keeps the row readable
+// and keeps the count matching the rollup's own total.
+func namedCheck(cs CheckSummary) CheckSummary {
+	if cs.Name == "" {
+		cs.Name = "(unnamed check)"
+	}
+	return cs
+}
+
 // TimelineEvent captures one item from the PR's timeline that we
 // chose to surface. Kind is a short discriminator string the UI
 // renders directly ("review", "comment", "merged", "ready",
@@ -209,6 +223,10 @@ type prDetailQuery struct {
 								// repoDetailQuery.
 								TotalCount githubv4.Int
 								Nodes      []struct {
+									// __typename discriminates the
+									// union member — see the note in
+									// repoDetailQuery.
+									Typename githubv4.String `graphql:"__typename"`
 									CheckRun struct {
 										Name       githubv4.String
 										Conclusion githubv4.CheckConclusionState
@@ -471,21 +489,23 @@ func extractPRDetail(owner, name string, q prDetailQuery) *PRDetail {
 		d.ChecksState = string(rollup.State)
 		d.ChecksTotal = int(rollup.Contexts.TotalCount)
 		for _, ctx := range rollup.Contexts.Nodes {
+			// Discriminated on __typename for the same reason the
+			// timeline items are — see extractRepoDetail's note.
 			cs := CheckSummary{}
-			switch {
-			case string(ctx.CheckRun.Name) != "":
+			switch ctx.Typename {
+			case "CheckRun":
 				cs.Name = Sanitize(string(ctx.CheckRun.Name))
 				cs.Conclusion = string(ctx.CheckRun.Conclusion)
 				cs.Status = string(ctx.CheckRun.Status)
 				cs.URL = Sanitize(string(ctx.CheckRun.DetailsURL))
-			case string(ctx.StatusContext.Context) != "":
+			case "StatusContext":
 				cs.Name = Sanitize(string(ctx.StatusContext.Context))
 				cs.Conclusion = string(ctx.StatusContext.State)
 				cs.URL = Sanitize(string(ctx.StatusContext.TargetURL))
 			default:
 				continue
 			}
-			d.ChecksContexts = append(d.ChecksContexts, cs)
+			d.ChecksContexts = append(d.ChecksContexts, namedCheck(cs))
 		}
 	}
 

--- a/internal/github/repo_detail_fetch_test.go
+++ b/internal/github/repo_detail_fetch_test.go
@@ -121,7 +121,7 @@ const repoDetailChecksBody = `{"data":{"repository":{
 	"defaultBranchRef":{"target":{
 		"statusCheckRollup":{
 			"state":"FAILURE",
-			"contexts":{"nodes":[
+			"contexts":{"totalCount":9,"nodes":[
 				{"name":"build (ubuntu-latest)","conclusion":"SUCCESS","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/2"},
 				{"name":"govulncheck","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/3"},
 				{"context":"ci/legacy-status","state":"ERROR","targetUrl":"https://circleci.com/gh/o/r/9"},
@@ -192,6 +192,12 @@ func TestFetchRepoDetailChecks(t *testing.T) {
 	}
 	if len(d.Checks) != 3 {
 		t.Fatalf("len(Checks) = %d, want 3 (the typeless node must be skipped): %+v", len(d.Checks), d.Checks)
+	}
+	// The rollup reports 9 contexts while the fetch returned 4 (3 usable
+	// + 1 typeless). Carrying the real total is what lets the UI report
+	// overflow honestly instead of counting only what it holds.
+	if d.ChecksTotal != 9 {
+		t.Errorf("ChecksTotal = %d, want 9 (the rollup's own count, not len(Checks))", d.ChecksTotal)
 	}
 
 	// CheckRun: name / conclusion / status / detailsUrl.

--- a/internal/github/repo_detail_fetch_test.go
+++ b/internal/github/repo_detail_fetch_test.go
@@ -103,3 +103,158 @@ func TestFetchRepoDetailQueryFailureIsFatal(t *testing.T) {
 		t.Errorf("Reason = %d, want ReasonServer (%d) for a 502", fe.Reason, ReasonServer)
 	}
 }
+
+// repoDetailChecksBody exercises the status-check rollup on the default
+// branch: a CheckRun that passed, one that failed, a legacy
+// StatusContext, and an empty node. The empty node is deliberate — it
+// stands for a rollup context of neither concrete type, which the
+// extractor has to skip rather than record as a nameless check.
+//
+// Note the third entry points off github.com: a third-party CI provider
+// reporting through the Checks API is legitimate, and the extractor's
+// job is to carry that URL faithfully. Deciding whether it may become a
+// clickable link belongs to the UI (isGitHubURL), not here.
+const repoDetailChecksBody = `{"data":{"repository":{
+	"name":"octoscope",
+	"url":"https://github.com/gfazioli/octoscope",
+	"stargazerCount":57,
+	"defaultBranchRef":{"target":{
+		"statusCheckRollup":{
+			"state":"FAILURE",
+			"contexts":{"nodes":[
+				{"name":"build (ubuntu-latest)","conclusion":"SUCCESS","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/2"},
+				{"name":"govulncheck","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/3"},
+				{"context":"ci/legacy-status","state":"ERROR","targetUrl":"https://circleci.com/gh/o/r/9"},
+				{}
+			]}
+		}
+	}}
+}}}`
+
+// repoDetailChecksHostileBody puts terminal escapes in a check name and
+// its URL, as JSON \u escapes so no raw control byte lives in this
+// source file. Both fields are attacker-influenceable — a check name
+// comes from a workflow file, the URL from whatever app posted the
+// check — so both must be sanitized at this boundary, before any
+// renderer or OSC 8 escape sees them.
+const repoDetailChecksHostileBody = `{"data":{"repository":{
+	"name":"octoscope",
+	"url":"https://github.com/gfazioli/octoscope",
+	"defaultBranchRef":{"target":{
+		"statusCheckRollup":{
+			"state":"FAILURE",
+			"contexts":{"nodes":[
+				{"name":"\u001b[31mfake-red\u001b[0m","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/o/r/actions/runs/\u001b]8;;evil\u0007"}
+			]}
+		}
+	}}
+}}}`
+
+// newDetailServer serves body for the detail query and an empty
+// stargazers page for the best-effort star-history walk, so a test can
+// focus on what extractRepoDetail did with the payload.
+func newDetailServer(t *testing.T, body string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("test server: reading request body: %v", err)
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(string(reqBody), "stargazers(") {
+			_, _ = io.WriteString(w, `{"data":{"repository":{"stargazers":{"pageInfo":{"hasNextPage":false},"edges":[]}}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return &Client{
+		gql:           githubv4.NewClient(&http.Client{Transport: &rewriteHost{host: srv.URL}}),
+		authenticated: false,
+	}
+}
+
+// TestFetchRepoDetailChecks covers the CI insight payload: the rollup
+// state, both concrete context types collapsing into CheckSummary, the
+// reporting URLs, and the skip for a node that is neither type.
+func TestFetchRepoDetailChecks(t *testing.T) {
+	c := newDetailServer(t, repoDetailChecksBody)
+
+	d, err := c.FetchRepoDetail(context.Background(), "gfazioli", "octoscope")
+	if err != nil {
+		t.Fatalf("FetchRepoDetail err = %v", err)
+	}
+
+	if d.CIState != "FAILURE" {
+		t.Errorf("CIState = %q, want FAILURE", d.CIState)
+	}
+	if len(d.Checks) != 3 {
+		t.Fatalf("len(Checks) = %d, want 3 (the typeless node must be skipped): %+v", len(d.Checks), d.Checks)
+	}
+
+	// CheckRun: name / conclusion / status / detailsUrl.
+	if got := d.Checks[0]; got.Name != "build (ubuntu-latest)" || got.Conclusion != "SUCCESS" ||
+		got.Status != "COMPLETED" || got.URL != "https://github.com/gfazioli/octoscope/actions/runs/1/job/2" {
+		t.Errorf("Checks[0] = %+v, want the passing CheckRun with its detailsUrl", got)
+	}
+	if got := d.Checks[1]; got.Name != "govulncheck" || got.Conclusion != "FAILURE" {
+		t.Errorf("Checks[1] = %+v, want the failing CheckRun", got)
+	}
+
+	// StatusContext: context -> Name, state -> Conclusion, targetUrl ->
+	// URL. Status stays empty; a legacy status context has no notion of
+	// one, which is why checkOutcome falls back to Conclusion.
+	got := d.Checks[2]
+	if got.Name != "ci/legacy-status" || got.Conclusion != "ERROR" || got.Status != "" {
+		t.Errorf("Checks[2] = %+v, want the legacy StatusContext mapped onto CheckSummary", got)
+	}
+	if got.URL != "https://circleci.com/gh/o/r/9" {
+		t.Errorf("Checks[2].URL = %q, want the third-party URL carried through verbatim", got.URL)
+	}
+}
+
+// TestFetchRepoDetailChecksSanitized is the boundary contract: escape
+// sequences in a check name or its URL are stripped here, so no
+// renderer downstream has to remember to do it.
+func TestFetchRepoDetailChecksSanitized(t *testing.T) {
+	c := newDetailServer(t, repoDetailChecksHostileBody)
+
+	d, err := c.FetchRepoDetail(context.Background(), "gfazioli", "octoscope")
+	if err != nil {
+		t.Fatalf("FetchRepoDetail err = %v", err)
+	}
+	if len(d.Checks) != 1 {
+		t.Fatalf("len(Checks) = %d, want 1", len(d.Checks))
+	}
+
+	for _, field := range []struct{ label, value string }{
+		{"Name", d.Checks[0].Name},
+		{"URL", d.Checks[0].URL},
+	} {
+		for _, b := range []byte(field.value) {
+			if b < 0x20 || b == 0x7f {
+				t.Errorf("%s = %q still carries control byte %#x after Sanitize", field.label, field.value, b)
+			}
+		}
+	}
+	if !strings.Contains(d.Checks[0].Name, "fake-red") {
+		t.Errorf("Name = %q, want the visible text preserved", d.Checks[0].Name)
+	}
+}
+
+// TestFetchRepoDetailNoChecks keeps the absent-CI case honest: a repo
+// with no rollup yields no state and no checks, which is what lets the
+// drill-in drop the section entirely instead of heading an empty list.
+func TestFetchRepoDetailNoChecks(t *testing.T) {
+	c := newDetailServer(t, repoDetailHappyBody)
+
+	d, err := c.FetchRepoDetail(context.Background(), "gfazioli", "octoscope")
+	if err != nil {
+		t.Fatalf("FetchRepoDetail err = %v", err)
+	}
+	if d.CIState != "" || len(d.Checks) != 0 {
+		t.Errorf("CIState = %q, Checks = %+v; want both empty for a repo with no rollup", d.CIState, d.Checks)
+	}
+}

--- a/internal/github/repo_detail_fetch_test.go
+++ b/internal/github/repo_detail_fetch_test.go
@@ -106,9 +106,9 @@ func TestFetchRepoDetailQueryFailureIsFatal(t *testing.T) {
 
 // repoDetailChecksBody exercises the status-check rollup on the default
 // branch: a CheckRun that passed, one that failed, a legacy
-// StatusContext, and an empty node. The empty node is deliberate — it
-// stands for a rollup context of neither concrete type, which the
-// extractor has to skip rather than record as a nameless check.
+// StatusContext, and a node whose __typename is neither. That last one
+// is deliberate: it stands for a union member GitHub might add later,
+// which the extractor must skip rather than record as an empty row.
 //
 // Note the third entry points off github.com: a third-party CI provider
 // reporting through the Checks API is legitimate, and the extractor's
@@ -122,10 +122,10 @@ const repoDetailChecksBody = `{"data":{"repository":{
 		"statusCheckRollup":{
 			"state":"FAILURE",
 			"contexts":{"totalCount":9,"nodes":[
-				{"name":"build (ubuntu-latest)","conclusion":"SUCCESS","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/2"},
-				{"name":"govulncheck","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/3"},
-				{"context":"ci/legacy-status","state":"ERROR","targetUrl":"https://circleci.com/gh/o/r/9"},
-				{}
+				{"__typename":"CheckRun","name":"build (ubuntu-latest)","conclusion":"SUCCESS","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/2"},
+				{"__typename":"CheckRun","name":"govulncheck","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/gfazioli/octoscope/actions/runs/1/job/3"},
+				{"__typename":"StatusContext","context":"ci/legacy-status","state":"ERROR","targetUrl":"https://circleci.com/gh/o/r/9"},
+				{"__typename":"SomethingGitHubAddedLater","name":"future"}
 			]}
 		}
 	}}
@@ -144,7 +144,7 @@ const repoDetailChecksHostileBody = `{"data":{"repository":{
 		"statusCheckRollup":{
 			"state":"FAILURE",
 			"contexts":{"nodes":[
-				{"name":"\u001b[31mfake-red\u001b[0m","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/o/r/actions/runs/\u001b]8;;evil\u0007"}
+				{"__typename":"CheckRun","name":"\u001b[31mfake-red\u001b[0m","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/o/r/actions/runs/\u001b]8;;evil\u0007"}
 			]}
 		}
 	}}
@@ -262,5 +262,45 @@ func TestFetchRepoDetailNoChecks(t *testing.T) {
 	}
 	if d.CIState != "" || len(d.Checks) != 0 {
 		t.Errorf("CIState = %q, Checks = %+v; want both empty for a repo with no rollup", d.CIState, d.Checks)
+	}
+}
+
+// repoDetailChecksUnnamedBody is a CheckRun whose name is empty. GitHub
+// types the field as a non-null String but never promises it is
+// non-empty, and under the old "which name field is populated?"
+// discrimination such a node vanished while the rollup's totalCount
+// still counted it. Switching to __typename keeps it, so it needs a
+// label to render.
+const repoDetailChecksUnnamedBody = `{"data":{"repository":{
+	"name":"octoscope",
+	"url":"https://github.com/gfazioli/octoscope",
+	"defaultBranchRef":{"target":{
+		"statusCheckRollup":{
+			"state":"FAILURE",
+			"contexts":{"totalCount":1,"nodes":[
+				{"__typename":"CheckRun","name":"","conclusion":"FAILURE","status":"COMPLETED","detailsUrl":"https://github.com/o/r/actions/runs/7"}
+			]}
+		}
+	}}
+}}}`
+
+// TestFetchRepoDetailUnnamedCheckSurvives pins the behaviour change: a
+// nameless check is kept and labelled rather than silently dropped, so
+// the list can't disagree with the rollup's own count.
+func TestFetchRepoDetailUnnamedCheckSurvives(t *testing.T) {
+	c := newDetailServer(t, repoDetailChecksUnnamedBody)
+
+	d, err := c.FetchRepoDetail(context.Background(), "gfazioli", "octoscope")
+	if err != nil {
+		t.Fatalf("FetchRepoDetail err = %v", err)
+	}
+	if len(d.Checks) != 1 {
+		t.Fatalf("len(Checks) = %d, want 1 — a nameless CheckRun must not be dropped: %+v", len(d.Checks), d.Checks)
+	}
+	if d.Checks[0].Name != "(unnamed check)" {
+		t.Errorf("Name = %q, want the placeholder so the row renders something", d.Checks[0].Name)
+	}
+	if d.Checks[0].Conclusion != "FAILURE" {
+		t.Errorf("Conclusion = %q, want FAILURE — the outcome still matters", d.Checks[0].Conclusion)
 	}
 }

--- a/internal/ui/checks.go
+++ b/internal/ui/checks.go
@@ -1,0 +1,146 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// Rendering for CI status-check lists, shared by the PR drill-in
+// (checks on the head commit) and the repo drill-in (checks on the
+// default branch's tip). Both answer the same question — "what is the
+// state of CI, and if it's red, which check is red" — so they render
+// identically rather than drifting into two dialects.
+
+// checksMaxVisible caps how many check rows a section paints. Deep
+// enough to cover a normal matrix build, shallow enough that the
+// section stays a summary rather than becoming the whole view; the
+// overflow count keeps the total honest.
+const checksMaxVisible = 8
+
+// checkMarker renders the per-check status glyph. SUCCESS = ✓ (ok);
+// failure-flavoured conclusions = ✗; muted neutrals = ·; everything
+// pending or in flight = ⏳.
+//
+// The failure-flavoured set spans both CheckRun conclusions (FAILURE /
+// TIMED_OUT / CANCELLED / ACTION_REQUIRED / STARTUP_FAILURE) and
+// StatusContext states (FAILURE / ERROR). Keeping them in one case
+// avoids treating STARTUP_FAILURE as "still pending" — a bot whose CI
+// startup blew up is firmly in the red zone.
+//
+// The glyphs carry the meaning, not the colour, which is what makes
+// this readable under the monochromatic themes: ✓ / ✗ / · / ⏳ stay
+// distinct when every style resolves to the same tone.
+func checkMarker(c github.CheckSummary) string {
+	switch checkOutcome(c) {
+	case checkPassed:
+		return okStyle.Render("✓")
+	case checkFailed:
+		return errorStyle.Render("✗")
+	case checkNeutral:
+		return mutedStyle.Render("·")
+	default:
+		return warnStyle.Render("⏳")
+	}
+}
+
+// checkOutcome collapses a check's conclusion / status pair into the
+// four buckets the UI actually distinguishes. Conclusion wins when
+// present (a completed check), status is the fallback (still running).
+func checkOutcome(c github.CheckSummary) checkBucket {
+	state := c.Conclusion
+	if state == "" {
+		state = c.Status
+	}
+	switch state {
+	case "SUCCESS":
+		return checkPassed
+	case "FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE":
+		return checkFailed
+	case "NEUTRAL", "SKIPPED", "STALE":
+		return checkNeutral
+	default: // PENDING, IN_PROGRESS, QUEUED, WAITING, REQUESTED, COMPLETED-with-no-conclusion
+		return checkRunning
+	}
+}
+
+type checkBucket int
+
+// Ordered by how much the user needs to see it: a failure first, a
+// still-running check next, then the ones that need no attention. The
+// ordering is load-bearing — see renderCheckList.
+const (
+	checkFailed checkBucket = iota
+	checkRunning
+	checkNeutral
+	checkPassed
+)
+
+// checksRollupSummary renders the inline summary that sits next to a
+// "Checks" heading: the aggregate rollup state. Returns "" when the
+// repo or PR has no checks at all, so the caller can drop the whole
+// section instead of heading an empty list.
+func checksRollupSummary(state string) string {
+	switch state {
+	case "":
+		return ""
+	case "SUCCESS":
+		return okStyle.Render("all passing")
+	case "FAILURE":
+		return errorStyle.Render("failing")
+	case "PENDING", "EXPECTED":
+		return warnStyle.Render("pending")
+	case "ERROR":
+		return errorStyle.Render("errored")
+	default:
+		return mutedStyle.Render(strings.ToLower(state))
+	}
+}
+
+// renderCheckList renders one line per check: status glyph, then the
+// check name linked to wherever that check reports.
+//
+// Failures are floated to the top. That is not cosmetic — with the
+// visible list capped, a red check on a repo with a 20-job matrix
+// could otherwise land in the "+N more" tail, which would hide the one
+// row the user drilled in to find. Within a bucket the API's order is
+// preserved (a stable sort), since that order groups a workflow's jobs
+// together.
+//
+// Names are linked through githubHyperlink, which silently declines
+// anything that isn't an https github.com URL — a third-party CI
+// provider reporting through the Checks API points at its own
+// dashboard, and those render as plain text rather than becoming
+// one-click targets from a GitHub-looking row.
+func renderCheckList(checks []github.CheckSummary, width int) string {
+	if len(checks) == 0 {
+		return ""
+	}
+
+	ordered := make([]github.CheckSummary, len(checks))
+	copy(ordered, checks)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return checkOutcome(ordered[i]) < checkOutcome(ordered[j])
+	})
+
+	overflow := 0
+	if len(ordered) > checksMaxVisible {
+		overflow = len(ordered) - checksMaxVisible
+		ordered = ordered[:checksMaxVisible]
+	}
+
+	var lines []string
+	for _, c := range ordered {
+		// width-12 leaves room for the two-space indent, the glyph
+		// and its separator; truncate happens before linking so the
+		// OSC 8 escapes never get cut mid-sequence.
+		name := truncate(c.Name, width-12)
+		lines = append(lines, "  "+checkMarker(c)+"  "+githubHyperlink(c.URL, name))
+	}
+	if overflow > 0 {
+		lines = append(lines, mutedStyle.Render(fmt.Sprintf("    +%d more", overflow)))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/checks.go
+++ b/internal/ui/checks.go
@@ -103,20 +103,31 @@ func checksRollupSummary(state string) string {
 // check name linked to wherever that check reports.
 //
 // Failures are floated to the top. That is not cosmetic — with the
-// visible list capped, a red check on a repo with a 20-job matrix
+// visible list capped, a red check on a repo with a 40-job matrix
 // could otherwise land in the "+N more" tail, which would hide the one
 // row the user drilled in to find. Within a bucket the API's order is
 // preserved (a stable sort), since that order groups a workflow's jobs
 // together.
+//
+// total is how many checks the rollup actually has, which can exceed
+// len(checks) because the fetch itself is capped: charmbracelet/bubbletea
+// runs 41. The overflow line counts against total, so it never claims
+// there are fewer hidden checks than there really are. Callers that
+// don't know the total pass len(checks).
 //
 // Names are linked through githubHyperlink, which silently declines
 // anything that isn't an https github.com URL — a third-party CI
 // provider reporting through the Checks API points at its own
 // dashboard, and those render as plain text rather than becoming
 // one-click targets from a GitHub-looking row.
-func renderCheckList(checks []github.CheckSummary, width int) string {
+func renderCheckList(checks []github.CheckSummary, total, width int) string {
 	if len(checks) == 0 {
 		return ""
+	}
+	if total < len(checks) {
+		// A caller that passed a stale or unset total must not make
+		// the overflow line lie in the other direction either.
+		total = len(checks)
 	}
 
 	ordered := make([]github.CheckSummary, len(checks))
@@ -125,11 +136,10 @@ func renderCheckList(checks []github.CheckSummary, width int) string {
 		return checkOutcome(ordered[i]) < checkOutcome(ordered[j])
 	})
 
-	overflow := 0
 	if len(ordered) > checksMaxVisible {
-		overflow = len(ordered) - checksMaxVisible
 		ordered = ordered[:checksMaxVisible]
 	}
+	overflow := total - len(ordered)
 
 	var lines []string
 	for _, c := range ordered {

--- a/internal/ui/checks.go
+++ b/internal/ui/checks.go
@@ -46,6 +46,19 @@ func checkMarker(c github.CheckSummary) string {
 	}
 }
 
+// checkBucket is the outcome of one check, reduced to what the UI
+// distinguishes. Ordered by how much the user needs to see it: a
+// failure first, a still-running check next, then the ones that need no
+// attention. The ordering is load-bearing — see renderCheckList.
+type checkBucket int
+
+const (
+	checkFailed checkBucket = iota
+	checkRunning
+	checkNeutral
+	checkPassed
+)
+
 // checkOutcome collapses a check's conclusion / status pair into the
 // four buckets the UI actually distinguishes. Conclusion wins when
 // present (a completed check), status is the fallback (still running).
@@ -65,18 +78,6 @@ func checkOutcome(c github.CheckSummary) checkBucket {
 		return checkRunning
 	}
 }
-
-type checkBucket int
-
-// Ordered by how much the user needs to see it: a failure first, a
-// still-running check next, then the ones that need no attention. The
-// ordering is load-bearing — see renderCheckList.
-const (
-	checkFailed checkBucket = iota
-	checkRunning
-	checkNeutral
-	checkPassed
-)
 
 // checksRollupSummary renders the inline summary that sits next to a
 // "Checks" heading: the aggregate rollup state. Returns "" when the

--- a/internal/ui/checks_test.go
+++ b/internal/ui/checks_test.go
@@ -1,0 +1,160 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestRenderCheckListFailuresFirst is the ordering guarantee that makes
+// the section useful: with the visible list capped, a failure buried in
+// a long build matrix must still show, because a red check is the reason
+// someone drilled in at all.
+func TestRenderCheckListFailuresFirst(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	var checks []github.CheckSummary
+	for i := 0; i < checksMaxVisible; i++ {
+		checks = append(checks, github.CheckSummary{
+			Name:       "passing-job-" + string(rune('a'+i)),
+			Conclusion: "SUCCESS",
+		})
+	}
+	// The one that matters: last in API order, past the cap.
+	checks = append(checks, github.CheckSummary{
+		Name:       "govulncheck",
+		Conclusion: "FAILURE",
+		URL:        "https://github.com/o/r/actions/runs/1",
+	})
+
+	out := ansi.Strip(renderCheckList(checks, 60))
+	if !strings.Contains(out, "govulncheck") {
+		t.Fatalf("the failing check fell off the visible list:\n%s", out)
+	}
+	if first := strings.SplitN(out, "\n", 2)[0]; !strings.Contains(first, "govulncheck") {
+		t.Errorf("failing check is not on the first line, got %q", first)
+	}
+	if !strings.Contains(out, "+1 more") {
+		t.Errorf("overflow count missing — the total stops being honest:\n%s", out)
+	}
+}
+
+// TestRenderCheckListStablePerBucket asserts the API's order survives
+// within a bucket, so a workflow's jobs stay grouped rather than being
+// shuffled by the sort.
+func TestRenderCheckListStablePerBucket(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	checks := []github.CheckSummary{
+		{Name: "lint", Conclusion: "SUCCESS"},
+		{Name: "test", Conclusion: "SUCCESS"},
+		{Name: "build", Conclusion: "SUCCESS"},
+	}
+	out := ansi.Strip(renderCheckList(checks, 60))
+	if strings.Index(out, "lint") > strings.Index(out, "test") ||
+		strings.Index(out, "test") > strings.Index(out, "build") {
+		t.Errorf("stable order lost within a bucket:\n%s", out)
+	}
+}
+
+// TestRenderCheckListLinksOnlyVouchedURLs keeps the security gate wired
+// into the render path: a github.com run URL becomes clickable, a
+// third-party CI URL stays inert text. The visible output is identical
+// either way — only the escapes differ.
+func TestRenderCheckListLinksOnlyVouchedURLs(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	checks := []github.CheckSummary{
+		{Name: "github-job", Conclusion: "FAILURE", URL: "https://github.com/o/r/actions/runs/1"},
+		{Name: "vendor-job", Conclusion: "FAILURE", URL: "https://circleci.com/gh/o/r/1"},
+		{Name: "no-url-job", Conclusion: "FAILURE"},
+	}
+	out := renderCheckList(checks, 60)
+
+	if !strings.Contains(out, ansi.SetHyperlink("https://github.com/o/r/actions/runs/1")) {
+		t.Error("the github.com run URL should be an OSC 8 target")
+	}
+	if strings.Contains(out, "circleci.com") {
+		t.Error("a non-github.com URL leaked into the output — it must render as plain text only")
+	}
+	for _, name := range []string{"github-job", "vendor-job", "no-url-job"} {
+		if !strings.Contains(ansi.Strip(out), name) {
+			t.Errorf("check %q missing from the visible output", name)
+		}
+	}
+}
+
+// TestRenderCheckListEmpty keeps the caller's "no section at all"
+// contract intact: an empty list renders nothing, so the repo drill-in
+// can omit the heading instead of printing an orphan.
+func TestRenderCheckListEmpty(t *testing.T) {
+	if got := renderCheckList(nil, 60); got != "" {
+		t.Errorf("renderCheckList(nil) = %q, want empty", got)
+	}
+}
+
+// TestChecksRollupSummary covers the states GitHub actually returns,
+// including EXPECTED — a required check that has not reported yet, which
+// reads as pending rather than as an unknown state.
+func TestChecksRollupSummary(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	tests := []struct {
+		state string
+		want  string
+	}{
+		{"", ""},
+		{"SUCCESS", "all passing"},
+		{"FAILURE", "failing"},
+		{"PENDING", "pending"},
+		{"EXPECTED", "pending"},
+		{"ERROR", "errored"},
+		{"SOMETHING_NEW", "something_new"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			if got := ansi.Strip(checksRollupSummary(tt.state)); got != tt.want {
+				t.Errorf("checksRollupSummary(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckMarkerGlyphsAreDistinct is the monochromatic-theme
+// guarantee: the outcomes must be distinguishable by glyph alone, since
+// under monochrome / phosphor / amber every style resolves to one tone
+// and colour carries no information at all.
+func TestCheckMarkerGlyphsAreDistinct(t *testing.T) {
+	for _, theme := range []string{"octoscope", "monochrome"} {
+		t.Run(theme, func(t *testing.T) {
+			_ = applyTheme(theme, "")
+
+			glyphs := map[string]string{}
+			for name, c := range map[string]github.CheckSummary{
+				"passed":  {Conclusion: "SUCCESS"},
+				"failed":  {Conclusion: "FAILURE"},
+				"startup": {Conclusion: "STARTUP_FAILURE"},
+				"neutral": {Conclusion: "SKIPPED"},
+				"running": {Status: "IN_PROGRESS"},
+			} {
+				glyphs[name] = ansi.Strip(checkMarker(c))
+				if glyphs[name] == "" {
+					t.Errorf("%s produced no glyph", name)
+				}
+			}
+
+			if glyphs["passed"] == glyphs["failed"] {
+				t.Error("pass and fail share a glyph — indistinguishable without colour")
+			}
+			if glyphs["failed"] != glyphs["startup"] {
+				t.Errorf("STARTUP_FAILURE (%q) should read as a failure (%q), not as pending",
+					glyphs["startup"], glyphs["failed"])
+			}
+			if glyphs["running"] == glyphs["neutral"] {
+				t.Error("in-flight and neutral share a glyph")
+			}
+		})
+	}
+}

--- a/internal/ui/checks_test.go
+++ b/internal/ui/checks_test.go
@@ -29,7 +29,7 @@ func TestRenderCheckListFailuresFirst(t *testing.T) {
 		URL:        "https://github.com/o/r/actions/runs/1",
 	})
 
-	out := ansi.Strip(renderCheckList(checks, 60))
+	out := ansi.Strip(renderCheckList(checks, len(checks), 60))
 	if !strings.Contains(out, "govulncheck") {
 		t.Fatalf("the failing check fell off the visible list:\n%s", out)
 	}
@@ -52,7 +52,7 @@ func TestRenderCheckListStablePerBucket(t *testing.T) {
 		{Name: "test", Conclusion: "SUCCESS"},
 		{Name: "build", Conclusion: "SUCCESS"},
 	}
-	out := ansi.Strip(renderCheckList(checks, 60))
+	out := ansi.Strip(renderCheckList(checks, len(checks), 60))
 	if strings.Index(out, "lint") > strings.Index(out, "test") ||
 		strings.Index(out, "test") > strings.Index(out, "build") {
 		t.Errorf("stable order lost within a bucket:\n%s", out)
@@ -71,7 +71,7 @@ func TestRenderCheckListLinksOnlyVouchedURLs(t *testing.T) {
 		{Name: "vendor-job", Conclusion: "FAILURE", URL: "https://circleci.com/gh/o/r/1"},
 		{Name: "no-url-job", Conclusion: "FAILURE"},
 	}
-	out := renderCheckList(checks, 60)
+	out := renderCheckList(checks, len(checks), 60)
 
 	if !strings.Contains(out, ansi.SetHyperlink("https://github.com/o/r/actions/runs/1")) {
 		t.Error("the github.com run URL should be an OSC 8 target")
@@ -86,11 +86,39 @@ func TestRenderCheckListLinksOnlyVouchedURLs(t *testing.T) {
 	}
 }
 
+// TestRenderCheckListOverflowCountsTheRealTotal is the honesty
+// guarantee for the "+N more" line. The rollup can hold more checks than
+// the query fetches — charmbracelet/bubbletea runs 41 — so counting
+// overflow against the fetched slice would under-report. Here 50 are
+// fetched out of a real 41+9: with 8 shown, the line has to say what is
+// actually hidden, not what happens to be in memory.
+func TestRenderCheckListOverflowCountsTheRealTotal(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	var checks []github.CheckSummary
+	for i := 0; i < 20; i++ {
+		checks = append(checks, github.CheckSummary{Name: "job", Conclusion: "SUCCESS"})
+	}
+
+	// 41 exist, 20 came back, 8 are shown -> 33 hidden.
+	out := ansi.Strip(renderCheckList(checks, 41, 60))
+	if !strings.Contains(out, "+33 more") {
+		t.Errorf("overflow must count against the rollup total (41), not the fetched slice (20):\n%s", out)
+	}
+
+	// A total that under-reports the slice must not produce a negative
+	// or missing count — the fetched length is the floor.
+	out = ansi.Strip(renderCheckList(checks, 0, 60))
+	if !strings.Contains(out, "+12 more") {
+		t.Errorf("a stale total must fall back to the fetched length:\n%s", out)
+	}
+}
+
 // TestRenderCheckListEmpty keeps the caller's "no section at all"
 // contract intact: an empty list renders nothing, so the repo drill-in
 // can omit the heading instead of printing an orphan.
 func TestRenderCheckListEmpty(t *testing.T) {
-	if got := renderCheckList(nil, 60); got != "" {
+	if got := renderCheckList(nil, 0, 60); got != "" {
 		t.Errorf("renderCheckList(nil) = %q, want empty", got)
 	}
 }

--- a/internal/ui/hyperlink.go
+++ b/internal/ui/hyperlink.go
@@ -1,6 +1,11 @@
 package ui
 
-import "github.com/charmbracelet/x/ansi"
+import (
+	"net/url"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
 
 // hyperlink wraps label in an OSC 8 terminal hyperlink pointing at url.
 // Terminals that support OSC 8 render label as a clickable link;
@@ -9,13 +14,73 @@ import "github.com/charmbracelet/x/ansi"
 // safe fallback. An empty url returns label unwrapped. Width math is
 // unaffected: lipgloss.Width / ansi.Strip both ignore OSC 8.
 //
-// NOTE: only use this on TRUSTED urls (hardcoded consts). A
-// GitHub-sourced URL must pass github.Sanitize first — an unsanitised
-// URI inside an OSC 8 escape is a terminal-injection vector. That's why
-// repo / PR / issue URLs are deliberately NOT wrapped here (yet).
+// NOTE: only use this on TRUSTED urls (hardcoded consts). For a
+// GitHub-sourced URL use githubHyperlink, which validates the URI before
+// it reaches the escape sequence — an unvalidated URI inside an OSC 8
+// escape is a terminal-injection vector, and a non-GitHub target on a
+// GitHub-looking row is a phishing vector.
 func hyperlink(url, label string) string {
 	if url == "" {
 		return label
 	}
 	return ansi.SetHyperlink(url) + label + ansi.ResetHyperlink()
+}
+
+// githubHyperlink is hyperlink for URLs that came back from the GitHub
+// API. It links label only when the URL passes isGitHubURL; otherwise it
+// returns label as plain text, so a URL we don't vouch for degrades to
+// something inert rather than becoming a clickable escape sequence.
+//
+// Callers still pass strings that went through github.Sanitize at the
+// extractor boundary — this is the second gate, not the first.
+func githubHyperlink(rawURL, label string) string {
+	if !isGitHubURL(rawURL) {
+		return label
+	}
+	return hyperlink(rawURL, label)
+}
+
+// isGitHubURL reports whether rawURL is safe to embed in an OSC 8
+// escape: an absolute https URL on a github.com host, with nothing in
+// it that could terminate the escape early or smuggle a second one.
+//
+// Three separate concerns, all of which have to hold:
+//
+//   - **Escape integrity.** OSC 8 is `ESC ] 8 ; params ; URI ST`. A
+//     control byte, a `;`, or an ESC inside the URI can close the
+//     sequence early and let the rest of the string be interpreted as
+//     terminal commands. Sanitize already strips C0/C1 and ANSI, but a
+//     `;` is an ordinary character it has no reason to touch — so it
+//     gets rejected here. GitHub's own run / check URLs never contain
+//     one.
+//   - **Scheme.** Only https. `javascript:`, `file:`, `data:` and
+//     friends have no business in a terminal hyperlink, and some
+//     terminals hand the URI straight to the OS opener.
+//   - **Host.** github.com or a subdomain of it. A check's detailsUrl
+//     can legitimately point off-platform (a third-party CI provider
+//     reporting through the Checks API), and those are exactly the
+//     targets we don't want to make one-click from a row that looks
+//     like it belongs to GitHub. They render as plain text instead.
+func isGitHubURL(rawURL string) bool {
+	if rawURL == "" || len(rawURL) > 2048 {
+		return false
+	}
+	// Reject anything that could break out of the escape sequence
+	// before handing the string to url.Parse — cheaper and stricter
+	// than reasoning about what the parser normalises.
+	if strings.ContainsAny(rawURL, ";\x1b\x07") {
+		return false
+	}
+	for _, r := range rawURL {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme != "https" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "github.com" || strings.HasSuffix(host, ".github.com")
 }

--- a/internal/ui/hyperlink.go
+++ b/internal/ui/hyperlink.go
@@ -19,11 +19,11 @@ import (
 // it reaches the escape sequence — an unvalidated URI inside an OSC 8
 // escape is a terminal-injection vector, and a non-GitHub target on a
 // GitHub-looking row is a phishing vector.
-func hyperlink(url, label string) string {
-	if url == "" {
+func hyperlink(rawURL, label string) string {
+	if rawURL == "" {
 		return label
 	}
-	return ansi.SetHyperlink(url) + label + ansi.ResetHyperlink()
+	return ansi.SetHyperlink(rawURL) + label + ansi.ResetHyperlink()
 }
 
 // githubHyperlink is hyperlink for URLs that came back from the GitHub

--- a/internal/ui/hyperlink_test.go
+++ b/internal/ui/hyperlink_test.go
@@ -66,3 +66,85 @@ func TestSponsorURLsAreHyperlinked(t *testing.T) {
 		t.Error("What's new tab (fallback) should hyperlink the releases URL")
 	}
 }
+
+// TestIsGitHubURL pins the gate that decides whether a GitHub-sourced
+// URL may enter an OSC 8 escape. The rejections matter more than the
+// acceptances: each is a way an unexpected URL could either break out
+// of the escape sequence or turn a GitHub-looking row into a one-click
+// trip somewhere else.
+func TestIsGitHubURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		// Accepted — what GitHub returns for a check run.
+		{"actions run", "https://github.com/gfazioli/octoscope/actions/runs/30474260211", true},
+		{"job anchor", "https://github.com/o/r/actions/runs/1/job/2", true},
+		{"query string", "https://github.com/o/r/actions/runs/1?check_suite_focus=true", true},
+		{"fragment", "https://github.com/o/r/actions/runs/1#step:3:12", true},
+		{"subdomain", "https://api.github.com/repos/o/r", true},
+		{"host case is irrelevant", "https://GitHub.com/o/r", true},
+
+		// Rejected — scheme.
+		{"http downgrade", "http://github.com/o/r", false},
+		{"javascript", "javascript:alert(1)", false},
+		{"file", "file:///etc/passwd", false},
+		{"data", "data:text/html,<script>", false},
+		{"scheme-relative", "//github.com/o/r", false},
+		{"no scheme", "github.com/o/r", false},
+
+		// Rejected — host. A third-party CI provider reporting through
+		// the Checks API is legitimate, but must not become clickable.
+		{"third-party CI", "https://circleci.com/gh/o/r/123", false},
+		{"lookalike suffix", "https://github.com.evil.test/o/r", false},
+		{"lookalike prefix", "https://notgithub.com/o/r", false},
+		{"github in path only", "https://evil.test/github.com/o/r", false},
+
+		// Rejected — escape integrity. ';' terminates the OSC 8 URI
+		// early; ESC and BEL can open or close a sequence outright.
+		{"semicolon", "https://github.com/o/r;evil", false},
+		{"escape byte", "https://github.com/o/r\x1b]8;;evil\x07", false},
+		{"bell byte", "https://github.com/o/r\x07", false},
+		{"newline", "https://github.com/o/r\nevil", false},
+		{"tab", "https://github.com/o/\tr", false},
+		{"del", "https://github.com/o/r\x7f", false},
+
+		// Rejected — degenerate.
+		{"empty", "", false},
+		{"overlong", "https://github.com/" + strings.Repeat("a", 2100), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGitHubURL(tt.url); got != tt.want {
+				t.Errorf("isGitHubURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGitHubHyperlink asserts the two outcomes callers rely on: a
+// vouched URL becomes a real OSC 8 link, anything else degrades to
+// inert text. Either way the visible string is only ever the label,
+// which is what keeps column widths and ansi.Strip honest.
+func TestGitHubHyperlink(t *testing.T) {
+	const label = "build (ubuntu-latest)"
+
+	linked := githubHyperlink("https://github.com/o/r/actions/runs/1", label)
+	if linked == label {
+		t.Error("a github.com https URL should have been linked, got plain text")
+	}
+	if !strings.Contains(linked, "\x1b]8;") {
+		t.Errorf("linked output carries no OSC 8 sequence: %q", linked)
+	}
+	if got := ansi.Strip(linked); got != label {
+		t.Errorf("visible text = %q, want %q — width math depends on this", got, label)
+	}
+
+	for _, bad := range []string{"", "http://github.com/o/r", "https://circleci.com/x", "https://github.com/o/r;x"} {
+		if got := githubHyperlink(bad, label); got != label {
+			t.Errorf("githubHyperlink(%q) = %q, want the bare label", bad, got)
+		}
+	}
+}

--- a/internal/ui/pr_detail.go
+++ b/internal/ui/pr_detail.go
@@ -466,7 +466,7 @@ func prDetailChecksSummary(d *github.PRDetail) string {
 // PR's head commit. Shared with the repo drill-in — see
 // renderCheckList in checks.go.
 func prDetailChecks(d *github.PRDetail, width int) string {
-	return renderCheckList(d.ChecksContexts, width)
+	return renderCheckList(d.ChecksContexts, d.ChecksTotal, width)
 }
 
 // prDetailTimeline renders the most recent ~10 events as a

--- a/internal/ui/pr_detail.go
+++ b/internal/ui/pr_detail.go
@@ -456,74 +456,17 @@ func prReviewStateLabel(state string) string {
 }
 
 // prDetailChecksSummary renders the inline summary next to the
-// "Checks" sub-heading: the rollup state (success / failure /
-// pending / etc.). Returns "" when there's no rollup.
+// "Checks" sub-heading. Shared with the repo drill-in — see
+// checksRollupSummary in checks.go.
 func prDetailChecksSummary(d *github.PRDetail) string {
-	switch d.ChecksState {
-	case "":
-		return ""
-	case "SUCCESS":
-		return okStyle.Render("all passing")
-	case "FAILURE":
-		return errorStyle.Render("failing")
-	case "PENDING":
-		return warnStyle.Render("pending")
-	case "ERROR":
-		return errorStyle.Render("errored")
-	default:
-		return mutedStyle.Render(strings.ToLower(d.ChecksState))
-	}
+	return checksRollupSummary(d.ChecksState)
 }
 
-// prDetailChecks renders one line per CI / status context, capped
-// at 8 visible to keep the section compact. Excess gets a "+N
-// more" footer.
+// prDetailChecks renders one line per CI / status context on the
+// PR's head commit. Shared with the repo drill-in — see
+// renderCheckList in checks.go.
 func prDetailChecks(d *github.PRDetail, width int) string {
-	const maxVisible = 8
-	contexts := d.ChecksContexts
-	overflow := 0
-	if len(contexts) > maxVisible {
-		overflow = len(contexts) - maxVisible
-		contexts = contexts[:maxVisible]
-	}
-
-	var lines []string
-	for _, c := range contexts {
-		marker := prCheckMarker(c)
-		name := truncate(c.Name, width-12)
-		lines = append(lines, "  "+marker+"  "+name)
-	}
-	if overflow > 0 {
-		lines = append(lines, mutedStyle.Render(fmt.Sprintf("    +%d more", overflow)))
-	}
-	return strings.Join(lines, "\n")
-}
-
-// prCheckMarker renders the per-check status glyph. SUCCESS = ✓
-// (ok); failure-flavoured conclusions = ✗; muted neutrals = ·;
-// everything pending or in flight = ⏳.
-//
-// The failure-flavoured set spans both CheckRun conclusions
-// (FAILURE / TIMED_OUT / CANCELLED / ACTION_REQUIRED /
-// STARTUP_FAILURE) and StatusContext states (FAILURE / ERROR).
-// Keeping them in one case avoids treating STARTUP_FAILURE as
-// "still pending" — a bot whose CI startup blew up is firmly
-// in the red zone.
-func prCheckMarker(c github.CheckSummary) string {
-	state := c.Conclusion
-	if state == "" {
-		state = c.Status
-	}
-	switch state {
-	case "SUCCESS":
-		return okStyle.Render("✓")
-	case "FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE":
-		return errorStyle.Render("✗")
-	case "NEUTRAL", "SKIPPED", "STALE":
-		return mutedStyle.Render("·")
-	default: // PENDING, IN_PROGRESS, QUEUED, WAITING, REQUESTED, COMPLETED-with-no-conclusion
-		return warnStyle.Render("⏳")
-	}
+	return renderCheckList(d.ChecksContexts, width)
 }
 
 // prDetailTimeline renders the most recent ~10 events as a

--- a/internal/ui/pr_detail_test.go
+++ b/internal/ui/pr_detail_test.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestPRDetailChecksWiring covers the PR side of the shared checks
+// renderer. The repo drill-in has its own tests and renderCheckList has
+// unit tests, but neither would catch a PR-specific wiring regression:
+// passing 0 where ChecksTotal belongs, or reading the wrong field, would
+// leave both green while PR overflow counts and hyperlinks quietly broke.
+func TestPRDetailChecksWiring(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	d := &github.PRDetail{
+		ChecksState: "FAILURE",
+		ChecksContexts: []github.CheckSummary{
+			{Name: "lint", Conclusion: "SUCCESS"},
+			{Name: "e2e", Conclusion: "FAILURE", URL: "https://github.com/o/r/actions/runs/5"},
+		},
+		ChecksTotal: 17,
+	}
+
+	if got := ansi.Strip(prDetailChecksSummary(d)); got != "failing" {
+		t.Errorf("summary = %q, want %q", got, "failing")
+	}
+
+	out := prDetailChecks(d, 80)
+	plain := ansi.Strip(out)
+
+	if first := strings.SplitN(plain, "\n", 2)[0]; !strings.Contains(first, "e2e") {
+		t.Errorf("the failing check should lead the list, got %q", first)
+	}
+	// 17 exist, 2 fetched and shown -> 15 hidden. Counting against the
+	// fetched slice instead would say nothing at all.
+	if !strings.Contains(plain, "+15 more") {
+		t.Errorf("overflow must come from ChecksTotal, not len(ChecksContexts):\n%s", plain)
+	}
+	if !strings.Contains(out, ansi.SetHyperlink("https://github.com/o/r/actions/runs/5")) {
+		t.Error("the failing check's run should be an OSC 8 target in the PR section too")
+	}
+}
+
+// TestPRDetailChecksEmpty keeps the section droppable: no rollup means no
+// summary, which is how the PR view decides to omit the heading.
+func TestPRDetailChecksEmpty(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	d := &github.PRDetail{}
+	if got := prDetailChecksSummary(d); got != "" {
+		t.Errorf("summary = %q, want empty for a PR with no rollup", got)
+	}
+	if got := prDetailChecks(d, 80); got != "" {
+		t.Errorf("list = %q, want empty for a PR with no checks", got)
+	}
+}

--- a/internal/ui/repo_detail.go
+++ b/internal/ui/repo_detail.go
@@ -317,7 +317,7 @@ func (rd RepoDetailModel) computeBody(width int) string {
 		title := subSectionTitleStyle.Render("Checks")
 		b.WriteString(title + "   " + summary)
 		b.WriteString("\n")
-		if list := renderCheckList(d.Checks, width); list != "" {
+		if list := renderCheckList(d.Checks, d.ChecksTotal, width); list != "" {
 			b.WriteString(list)
 			b.WriteString("\n")
 		}

--- a/internal/ui/repo_detail.go
+++ b/internal/ui/repo_detail.go
@@ -309,6 +309,21 @@ func (rd RepoDetailModel) computeBody(width int) string {
 		b.WriteString("\n\n")
 	}
 
+	// ---- Checks (CI on the default branch's tip) — the breakdown
+	// behind the Repos-tab rollup dot. Hidden when the repo has no
+	// CI at all: an absent section says "no checks" more quietly
+	// than a heading over an empty list would.
+	if summary := checksRollupSummary(d.CIState); summary != "" {
+		title := subSectionTitleStyle.Render("Checks")
+		b.WriteString(title + "   " + summary)
+		b.WriteString("\n")
+		if list := renderCheckList(d.Checks, width); list != "" {
+			b.WriteString(list)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
 	// ---- Star history (12mo sparkline) — hidden when the repo
 	// had no stars in the window. `v` cycles density ↔ cumulative.
 	if hist := repoDetailStarHistory(d, rd.starMode); hist != "" {

--- a/internal/ui/repo_detail_test.go
+++ b/internal/ui/repo_detail_test.go
@@ -1,0 +1,105 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// newLoadedRepoDetail builds a drill-in already holding a fetched
+// payload, which is the only state that renders a body.
+func newLoadedRepoDetail(d *github.RepoDetail) RepoDetailModel {
+	rd := RepoDetailModel{}.Open(github.Repo{
+		Name: "octoscope",
+		URL:  "https://github.com/gfazioli/octoscope",
+	}, StarModeDensity)
+	return rd.applyFetched(d, nil)
+}
+
+// TestRepoDetailChecksSection covers the wiring, which the
+// renderCheckList unit tests can't reach: that the drill-in actually
+// paints a Checks section, with the rollup summary on the heading and
+// the failing check in the list.
+func TestRepoDetailChecksSection(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	rd := newLoadedRepoDetail(&github.RepoDetail{
+		Owner:   "gfazioli",
+		Name:    "octoscope",
+		URL:     "https://github.com/gfazioli/octoscope",
+		CIState: "FAILURE",
+		Checks: []github.CheckSummary{
+			{Name: "lint", Conclusion: "SUCCESS"},
+			{Name: "govulncheck", Conclusion: "FAILURE", URL: "https://github.com/gfazioli/octoscope/actions/runs/1"},
+		},
+		ChecksTotal: 12,
+	})
+
+	body := rd.computeBody(100)
+	plain := ansi.Strip(body)
+
+	if !strings.Contains(plain, "Checks") {
+		t.Fatalf("no Checks heading in the drill-in body:\n%s", plain)
+	}
+	if !strings.Contains(plain, "failing") {
+		t.Error("the rollup summary should read 'failing' next to the heading")
+	}
+	if !strings.Contains(plain, "govulncheck") || !strings.Contains(plain, "lint") {
+		t.Errorf("check names missing from the body:\n%s", plain)
+	}
+	// 12 exist, 2 fetched, both shown -> 10 hidden.
+	if !strings.Contains(plain, "+10 more") {
+		t.Errorf("overflow should count against ChecksTotal:\n%s", plain)
+	}
+	// The failing check's run must be a live hyperlink target, not just
+	// text — that is the second half of what #34 asked for.
+	if !strings.Contains(body, ansi.SetHyperlink("https://github.com/gfazioli/octoscope/actions/runs/1")) {
+		t.Error("the failing check's run URL should be an OSC 8 target in the rendered body")
+	}
+}
+
+// TestRepoDetailNoChecksSection is the other half: a repo with no CI at
+// all shows no heading, rather than an empty section. Absence is how the
+// drill-in says "no checks here" — the same convention the release,
+// languages and topics sections follow.
+func TestRepoDetailNoChecksSection(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	rd := newLoadedRepoDetail(&github.RepoDetail{
+		Owner: "gfazioli",
+		Name:  "octoscope",
+		URL:   "https://github.com/gfazioli/octoscope",
+		// no CIState, no Checks
+	})
+
+	if plain := ansi.Strip(rd.computeBody(100)); strings.Contains(plain, "Checks") {
+		t.Errorf("a repo with no rollup must not render a Checks heading:\n%s", plain)
+	}
+}
+
+// TestRepoDetailChecksMonochrome guards the theme contract at the
+// section level: under a monochromatic theme the section still has to
+// distinguish the failure, which it can only do by glyph.
+func TestRepoDetailChecksMonochrome(t *testing.T) {
+	_ = applyTheme("monochrome", "")
+	t.Cleanup(func() { _ = applyTheme("octoscope", "") })
+
+	rd := newLoadedRepoDetail(&github.RepoDetail{
+		Owner:   "gfazioli",
+		Name:    "octoscope",
+		URL:     "https://github.com/gfazioli/octoscope",
+		CIState: "FAILURE",
+		Checks: []github.CheckSummary{
+			{Name: "lint", Conclusion: "SUCCESS"},
+			{Name: "govulncheck", Conclusion: "FAILURE"},
+		},
+		ChecksTotal: 2,
+	})
+
+	plain := ansi.Strip(rd.computeBody(100))
+	if !strings.Contains(plain, "✗") || !strings.Contains(plain, "✓") {
+		t.Errorf("monochrome section must still separate pass from fail by glyph:\n%s", plain)
+	}
+}

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,19 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.25.0": {
+		headline: "A red CI dot now tells you what broke.",
+		items: []whatsNewItem{
+			{
+				title: "CI insight in the repo drill-in",
+				desc:  "The Repos tab has always shown a CI rollup dot per repository — green, red, amber — and stopped there. Open a repo now (Enter, or space for the action menu) and a Checks section lists the individual checks on the default branch's tip, failures floated to the top so a red job in a twenty-job matrix can't hide behind the passing ones.",
+			},
+			{
+				title: "Each check links to its run",
+				desc:  "Check names are OSC 8 terminal hyperlinks straight to the run on GitHub — click them where your terminal supports it, and they stay plain text everywhere else. Only https github.com targets are linked: a third-party CI provider reporting through the Checks API renders as text rather than becoming a one-click trip off-platform.",
+			},
+		},
+	},
 	"0.24.2": {
 		headline: "A small footer polish.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.24.2"
+const version = "0.25.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Closes #34.

The Repos tab has shown a CI rollup dot per repository since v0.13.0 and stopped there: a red dot said *something* broke, never *what*. Opening a repo now surfaces a **Checks** section built from the default branch tip's status-check rollup — the aggregate state next to the heading, then one row per check run or status context.

```
Checks                                failing
  ✗  govulncheck              ← links to the run
  ✗  build (ubuntu-latest)    ← links to the run
  ✓  lint
  ✓  test
  ⏳  deploy
    +3 more
```

## Two details that carry the feature

**Failures float to the top.** With the visible list capped at 8, a red job in a twenty-job matrix would otherwise land in the `+N more` tail — hiding the one row the user drilled in to find. Sorting is stable within a bucket, so a workflow's jobs stay grouped. `TestRenderCheckListFailuresFirst` pins it.

**Check names are OSC 8 hyperlinks to their run.** That meant lifting the restriction `hyperlink.go` documented in a NOTE — *"only use this on TRUSTED urls (hardcoded consts) … that's why repo / PR / issue URLs are deliberately NOT wrapped here (yet)"* — so the lift comes with the gate that was missing. `isGitHubURL` accepts absolute **https** URLs on **github.com** and nothing else:

- a third-party CI provider reporting through the Checks API (its `detailsUrl` points at its own dashboard) renders as plain text rather than becoming a one-click trip off-platform
- a URL carrying `;`, ESC or BEL — the bytes that can terminate the OSC 8 sequence early and let the rest be read as terminal commands — is refused outright
- `javascript:`, `file:`, `data:`, protocol-relative and lookalike hosts (`github.com.evil.test`) are all rejected, with a case for each in `TestIsGitHubURL`

## One non-obvious implementation choice

The reporting URLs are queried as `githubv4.String`, not `githubv4.URI`. `URI` unmarshals through `url.Parse`, which errors on a control character — and that error propagates out of the *whole* decode, so a single malformed URL from a single third-party app would fail the entire drill-in fetch. Found this the hard way: the sanitization test failed with `net/url: invalid control character in URL` before the drill-in ever got its payload. A string always decodes; `Sanitize` cleans it at the boundary and `isGitHubURL` decides whether it may be linked, so the blast radius of a bad URL stays one row.

## Shared, not duplicated

Rendering lives in the new `internal/ui/checks.go` and is used by both drill-ins, so the PR detail's checks section gains the same links by construction and the two cannot drift into separate dialects. `prCheckMarker` became `checkMarker` in the move.

Monochromatic fidelity is free here and now asserted: the outcomes are distinguished by glyph (`✓ ✗ · ⏳`), not colour, so they survive `monochrome` / `phosphor` / `amber` where every style resolves to one tone.

## Verification

- `go build`, `go vet`, `gofmt -l .`, `go test ./...` and `go test -race` all clean
- 14 new test cases across the URL gate, the ordering guarantee, the rollup summary, the glyph distinctness, and the fetch payload (rollup state, both context types, the third-party URL carried verbatim, a typeless node skipped, escapes stripped)
- checked against the live API with a throwaway smoke test (deleted before committing, per convention): 7 checks on this repo, 20 on `charmbracelet/bubbletea` — which also exercises the overflow count — every URL on github.com

Release-prep for **0.25.0** is in this PR: version bump, What's new entry, README, landing pill fallback and an "At a glance" card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)