### PR TITLE
perf(ui): reuse repos table rule across divider rows

### DIFF
--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -913,10 +913,9 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed+"  "+release)
 
 		// Insert the section dividers exactly once each, after
-		// the last row of the pinned and rest segments. Re-uses
-		// the header width so the rule spans the same band as
-		// the table.
-		rule := tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header)))
+		// the last row of the pinned and rest segments. Re-use
+		// the header-width rule built once above the row loop
+		// (see #57) so we don't re-allocate it every row.
 		if pinDivider > 0 && i == pinDivider-1 && i+1 < len(repos) {
 			out = append(out, rule)
 		}


### PR DESCRIPTION
## Summary

`renderReposTable` rebuilt the section-divider rule on every row. The header-width
rule is already computed once before the loop — reuse it for pin/watch dividers.

Fixes #57

## Test plan

- [x] `go test ./internal/ui/` — ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved repository table rendering efficiency.
  * Ensured row dividers consistently match the table’s header width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->