### PR TITLE
feat(ui): honest footer for every overlay + esc-to-clear on empty PRs/Issues

### DIFF
--- a/internal/ui/empty_states_test.go
+++ b/internal/ui/empty_states_test.go
@@ -27,6 +27,10 @@ func TestPRsTabFilteredEmpty(t *testing.T) {
 		if !strings.Contains(out, "no pull requests match") || !strings.Contains(out, "esc to clear") {
 			t.Errorf("want filtered-empty affordance, got:\n%s", out)
 		}
+		// The affordance must name the active query — that's the point.
+		if !strings.Contains(out, "zzz-no-match") {
+			t.Errorf("filtered-empty message should name the query, got:\n%s", out)
+		}
 	})
 
 	t.Run("genuinely empty reads differently", func(t *testing.T) {
@@ -51,6 +55,10 @@ func TestIssuesTabFilteredEmpty(t *testing.T) {
 		out := ansi.Strip(im.renderIssuesTab(stats, 120, 40, nil))
 		if !strings.Contains(out, "no issues match") || !strings.Contains(out, "esc to clear") {
 			t.Errorf("want filtered-empty affordance, got:\n%s", out)
+		}
+		// The affordance must name the active query — that's the point.
+		if !strings.Contains(out, "zzz-no-match") {
+			t.Errorf("filtered-empty message should name the query, got:\n%s", out)
 		}
 	})
 

--- a/internal/ui/empty_states_test.go
+++ b/internal/ui/empty_states_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestPRsTabFilteredEmpty pins #64 for the PRs tab: PRs exist but the
+// active filter hides them all, so the tab shows the esc-to-clear
+// affordance naming the query — not a blank table — and distinct from
+// the genuinely-empty "no PRs authored" case.
+func TestPRsTabFilteredEmpty(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	stats := &github.Stats{
+		OpenPullRequests: []github.PullRequest{
+			{Number: 1, Title: "add feature", Repo: "me/app"},
+		},
+	}
+
+	t.Run("filter matches nothing", func(t *testing.T) {
+		pm := PRsModel{query: "zzz-no-match"}
+		out := ansi.Strip(pm.renderPRsTab(stats, 120, 40))
+		if !strings.Contains(out, "no pull requests match") || !strings.Contains(out, "esc to clear") {
+			t.Errorf("want filtered-empty affordance, got:\n%s", out)
+		}
+	})
+
+	t.Run("genuinely empty reads differently", func(t *testing.T) {
+		out := ansi.Strip(PRsModel{}.renderPRsTab(&github.Stats{}, 120, 40))
+		if !strings.Contains(out, "no open pull requests you authored") {
+			t.Errorf("want genuinely-empty message, got:\n%s", out)
+		}
+		if strings.Contains(out, "esc to clear") {
+			t.Errorf("genuinely-empty must not show the filter affordance:\n%s", out)
+		}
+	})
+}
+
+// TestIssuesTabFilteredEmpty pins #64 for the Issues tab (same contract).
+func TestIssuesTabFilteredEmpty(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	stats := &github.Stats{OpenIssuesList: []github.Issue{mkIssue("me/app", 1)}}
+
+	t.Run("filter matches nothing", func(t *testing.T) {
+		im := IssuesModel{query: "zzz-no-match"}
+		out := ansi.Strip(im.renderIssuesTab(stats, 120, 40, nil))
+		if !strings.Contains(out, "no issues match") || !strings.Contains(out, "esc to clear") {
+			t.Errorf("want filtered-empty affordance, got:\n%s", out)
+		}
+	})
+
+	t.Run("genuinely empty reads differently", func(t *testing.T) {
+		out := ansi.Strip(IssuesModel{}.renderIssuesTab(&github.Stats{}, 120, 40, nil))
+		if !strings.Contains(out, "no open issues you authored") {
+			t.Errorf("want genuinely-empty message, got:\n%s", out)
+		}
+		if strings.Contains(out, "esc to clear") {
+			t.Errorf("genuinely-empty must not show the filter affordance:\n%s", out)
+		}
+	})
+}

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -84,6 +84,21 @@ func TestFooterBarHotkeys(t *testing.T) {
 			wantHave:   []string{"dismiss"},
 			wantAbsent: []string{"switch", "public", "settings", "help", "quit"},
 		},
+		{
+			name: "list filter input advertises enter/esc, not global hotkeys",
+			open: func(m Model) Model {
+				u, _ := m.Update(key("2")) // Repos tab
+				m = u.(Model)
+				u, _ = m.Update(key("/")) // enter filter input
+				m = u.(Model)
+				if !m.listInputMode() {
+					t.Fatal("'/' on the Repos tab should enter filter input mode")
+				}
+				return m
+			},
+			wantHave:   []string{"confirm", "cancel"},
+			wantAbsent: []string{"switch", "public", "settings", "help", "quit"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
@@ -22,45 +23,73 @@ func loadedModel(t *testing.T) Model {
 }
 
 // TestFooterBarHotkeys pins the context-sensitivity of the footer's
-// hotkey line. On a list tab the full list-level set is advertised;
-// inside a drill-in the footer collapses to the keys that actually
-// fire at that depth (esc back · r refresh · q quit) and drops the
-// tab-switch / public / settings / help hotkeys the drill-in swallows.
-// Regression guard for the "never advertise a key that does nothing"
-// contract the drill-in views already follow.
+// hotkey line. On a plain list tab the full list-level set is
+// advertised; the moment an overlay (a drill-in or any modal) captures
+// the keyboard, the footer must collapse to exactly the keys that fire
+// there — never the tab-switch / public / settings / help hotkeys the
+// overlay swallows. q only appears where q genuinely quits (rate-limit
+// panel, action menu, drill-in); help / sponsor dismiss on any key and
+// settings takes q as field input, so none of those claim "q quit".
 func TestFooterBarHotkeys(t *testing.T) {
 	tests := []struct {
 		name       string
-		drillIn    bool
+		open       func(m Model) Model
 		wantHave   []string
 		wantAbsent []string
 	}{
 		{
-			name:       "list context advertises the full hotkey set",
-			drillIn:    false,
-			wantHave:   []string{"switch", "public", "settings", "help", "quit"},
-			wantAbsent: nil,
+			name:     "list context advertises the full hotkey set",
+			open:     func(m Model) Model { return m },
+			wantHave: []string{"switch", "public", "settings", "help", "quit"},
 		},
 		{
-			name:       "drill-in context collapses to working keys only",
-			drillIn:    true,
+			name: "drill-in collapses to esc/r/q",
+			open: func(m Model) Model {
+				m.repoDetail = m.repoDetail.Open(github.Repo{URL: "https://github.com/octocat/hello"}, StarModeDensity)
+				return m
+			},
 			wantHave:   []string{"back", "refresh", "quit"},
 			wantAbsent: []string{"switch", "public", "settings", "help"},
+		},
+		{
+			name:       "rate-limit panel keeps esc/r/q",
+			open:       func(m Model) Model { m.rateLimits = RateLimitModel{}.Open(); return m },
+			wantHave:   []string{"back", "refresh", "quit"},
+			wantAbsent: []string{"switch", "public", "settings", "help"},
+		},
+		{
+			name:       "action menu keeps esc/q",
+			open:       func(m Model) Model { m.actionMenu = ActionMenuModel{}.Open("Actions", nil); return m },
+			wantHave:   []string{"back", "quit"},
+			wantAbsent: []string{"switch", "public", "settings", "help", "refresh"},
+		},
+		{
+			name: "settings advertises only esc cancel (q is field input, not quit)",
+			open: func(m Model) Model {
+				m.settings = SettingsModel{}.Open(30*time.Second, false, false, "octoscope")
+				return m
+			},
+			wantHave:   []string{"cancel"},
+			wantAbsent: []string{"switch", "public", "settings", "help", "quit"},
+		},
+		{
+			name:       "help advertises only esc close (any key dismisses, q does not quit)",
+			open:       func(m Model) Model { m.help = HelpModel{}.Open(); return m },
+			wantHave:   []string{"close"},
+			wantAbsent: []string{"switch", "public", "settings", "help", "quit"},
+		},
+		{
+			name:       "sponsor splash advertises only esc dismiss",
+			open:       func(m Model) Model { m.sponsor = SponsorModel{}.Open("https://github.com/sponsors/gfazioli"); return m },
+			wantHave:   []string{"dismiss"},
+			wantAbsent: []string{"switch", "public", "settings", "help", "quit"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := loadedModel(t)
-			if tt.drillIn {
-				m.repoDetail = m.repoDetail.Open(github.Repo{URL: "https://github.com/octocat/hello"}, StarModeDensity)
-				if !m.drillInOpen() {
-					t.Fatal("repoDetail.Open should report drillInOpen()")
-				}
-			}
-
+			m := tt.open(loadedModel(t))
 			got := ansi.Strip(renderFooterBar(m))
-
 			for _, want := range tt.wantHave {
 				if !strings.Contains(got, want) {
 					t.Errorf("footer missing %q:\n%s", want, got)
@@ -68,7 +97,7 @@ func TestFooterBarHotkeys(t *testing.T) {
 			}
 			for _, gone := range tt.wantAbsent {
 				if strings.Contains(got, gone) {
-					t.Errorf("footer should not advertise %q (it does nothing there):\n%s", gone, got)
+					t.Errorf("footer should not advertise %q here:\n%s", gone, got)
 				}
 			}
 		})

--- a/internal/ui/issues.go
+++ b/internal/ui/issues.go
@@ -324,6 +324,14 @@ func (im IssuesModel) renderIssuesTab(stats *github.Stats, available, availableH
 	// top, then filtered+sorted rest). pinCount positions the divider.
 	rows, pinCount, _ := visibleIssuesPartitioned(stats.OpenIssuesList, im.query, im.sort, pinned)
 
+	// Filtered-empty: issues exist but the active filter hid them all.
+	// Reads differently from the genuinely-empty case above ("no open
+	// issues you authored") — name the query and keep the way out
+	// obvious. Mirrors the Repos tab affordance (#64).
+	if len(rows) == 0 {
+		return mutedStyle.Render(fmt.Sprintf("(no issues match %q — esc to clear)", im.query))
+	}
+
 	cursor := im.cursor
 	if cursor >= len(rows) {
 		cursor = len(rows) - 1

--- a/internal/ui/prs.go
+++ b/internal/ui/prs.go
@@ -234,6 +234,14 @@ func (pm PRsModel) renderPRsTab(stats *github.Stats, available, availableHeight 
 
 	rows, reviewCount, _ := visiblePRsPartitioned(stats.ReviewRequests, stats.OpenPullRequests, pm.query, pm.sort)
 
+	// Filtered-empty: PRs exist but the active filter hid them all. Reads
+	// differently from the genuinely-empty case above ("no PRs authored")
+	// — name the query and keep the way out obvious. Mirrors the Repos
+	// tab affordance (#64).
+	if len(rows) == 0 {
+		return mutedStyle.Render(fmt.Sprintf("(no pull requests match %q — esc to clear)", pm.query))
+	}
+
 	cursor := pm.cursor
 	if cursor >= len(rows) {
 		cursor = len(rows) - 1

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1017,6 +1017,23 @@ func (m Model) overlayOpen() bool {
 		m.settings.IsOpen() || m.actionMenu.IsOpen() || m.drillInOpen()
 }
 
+// listInputMode reports whether the active list tab is capturing filter
+// text (the `/` search box). While it is, model.go's Update forwards
+// every keystroke to the sub-model as a literal filter character, so the
+// global hotkeys (1-6, p, comma, ?, q, tab) don't fire — the footer must
+// not advertise them, exactly as for an open overlay.
+func (m Model) listInputMode() bool {
+	switch m.activeTab {
+	case TabRepos:
+		return m.repos.IsInputMode()
+	case TabPRs:
+		return m.prs.IsInputMode()
+	case TabIssues:
+		return m.issues.IsInputMode()
+	}
+	return false
+}
+
 // footerKeys picks the footer's hotkey line for the current context.
 // An open overlay captures every keystroke, so the footer must show
 // only the keys that actually respond at that moment — never the
@@ -1025,9 +1042,11 @@ func (m Model) overlayOpen() bool {
 // rate-limit panel and action menu bind q → quit, but help and the
 // sponsor splash dismiss on any key (q closes them, it doesn't quit)
 // and the settings panel takes q as literal field input — so neither
-// gets a "q quit" hint that would lie. Order mirrors the dispatch
-// priority in model.go Update (sponsor ▸ help ▸ rate-limit ▸ settings
-// ▸ action menu ▸ drill-in); keep the two aligned.
+// gets a "q quit" hint that would lie. A list tab in filter-input mode
+// is the same story — its keystrokes are literal filter text — so it
+// collapses to enter/esc. Order mirrors the dispatch priority in
+// model.go Update (sponsor ▸ help ▸ rate-limit ▸ settings ▸ action menu
+// ▸ drill-in ▸ list-input); keep the two aligned.
 func footerKeys(m Model) string {
 	switch {
 	case m.sponsor.IsOpen():
@@ -1042,6 +1061,10 @@ func footerKeys(m Model) string {
 		return keyHints("esc", "back", "q", "quit")
 	case m.drillInOpen():
 		return keyHints("esc", "back", "r", "refresh", "q", "quit")
+	case m.listInputMode():
+		// Typing a filter: keys are literal characters, only enter
+		// (confirm) and esc (cancel) act — mirror the search prompt.
+		return keyHints("enter", "confirm", "esc", "cancel")
 	default:
 		return keyHints(
 			"r", "refresh",

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1006,6 +1006,54 @@ func (m Model) drillInOpen() bool {
 		m.issueDetail.IsOpen() || m.scan.IsOpen()
 }
 
+// overlayOpen reports whether any overlay — a modal (sponsor splash,
+// help, rate-limit panel, settings, action menu) or a drill-in — is
+// currently covering the tab body. Each overlay captures every key and
+// returns before the global list hotkeys fire, so the footer uses this
+// to know it must NOT advertise the plain-list hotkey set (or the
+// scroll hint, whose body is no longer visible).
+func (m Model) overlayOpen() bool {
+	return m.sponsor.IsOpen() || m.help.IsOpen() || m.rateLimits.IsOpen() ||
+		m.settings.IsOpen() || m.actionMenu.IsOpen() || m.drillInOpen()
+}
+
+// footerKeys picks the footer's hotkey line for the current context.
+// An open overlay captures every keystroke, so the footer must show
+// only the keys that actually respond at that moment — never the
+// list-level set that points at nothing. Each overlay advertises its
+// own escape hatch (esc), plus q where q genuinely quits: the
+// rate-limit panel and action menu bind q → quit, but help and the
+// sponsor splash dismiss on any key (q closes them, it doesn't quit)
+// and the settings panel takes q as literal field input — so neither
+// gets a "q quit" hint that would lie. Order mirrors the dispatch
+// priority in model.go Update (sponsor ▸ help ▸ rate-limit ▸ settings
+// ▸ action menu ▸ drill-in); keep the two aligned.
+func footerKeys(m Model) string {
+	switch {
+	case m.sponsor.IsOpen():
+		return keyHints("esc", "dismiss")
+	case m.help.IsOpen():
+		return keyHints("esc", "close")
+	case m.rateLimits.IsOpen():
+		return keyHints("esc", "back", "r", "refresh", "q", "quit")
+	case m.settings.IsOpen():
+		return keyHints("esc", "cancel")
+	case m.actionMenu.IsOpen():
+		return keyHints("esc", "back", "q", "quit")
+	case m.drillInOpen():
+		return keyHints("esc", "back", "r", "refresh", "q", "quit")
+	default:
+		return keyHints(
+			"r", "refresh",
+			"1-6/tab", "switch",
+			"p", "public",
+			",", "settings",
+			"?", "help",
+			"q", "quit",
+		)
+	}
+}
+
 // renderFooterBar draws the bottom bar.
 //
 // Layout is responsive: wide terminals get a single-line footer with
@@ -1018,39 +1066,19 @@ func (m Model) drillInOpen() bool {
 func renderFooterBar(m Model) string {
 	age := time.Since(m.lastFetch).Truncate(time.Second)
 
-	// Hotkeys are context-sensitive. While a drill-in is open it swallows
-	// every key and returns before the global hotkeys run, so advertising
-	// tab-switch / public / settings / help would point at keys that do
-	// nothing there. Collapse to what actually works at that depth: esc
-	// backs out one level, r refetches the detail, q quits from any depth
-	// (the drill-in's own actions — o open, v star view — stay in its
-	// title bar). Same "never advertise a key that does nothing"
-	// principle the drill-in titles already follow.
-	var keys string
-	if m.drillInOpen() {
-		keys = keyHints(
-			"esc", "back",
-			"r", "refresh",
-			"q", "quit",
-		)
-	} else {
-		keys = keyHints(
-			"r", "refresh",
-			"1-6/tab", "switch",
-			"p", "public",
-			",", "settings",
-			"?", "help",
-			"q", "quit",
-		)
+	// Hotkeys are context-sensitive — footerKeys picks the set that
+	// actually fires for the current overlay (or the full list set when
+	// nothing is open). See its doc for the per-overlay rationale.
+	keys := footerKeys(m)
 
-		// Scroll hint surfaces only when the active tab actually overflows
-		// vertically — otherwise the keys row stays compact and the hint
-		// doesn't tease a behaviour the user can't see in action. The
-		// viewport reports total > visible only after SetContent has been
-		// called at least once, so on first paint (before any scroll key
-		// fires) we silently miss the hint; that's fine, the next
-		// keystroke or refresh will populate it. (A drill-in's own
-		// viewport scroll is advertised in its title, not here.)
+	// Scroll hint surfaces only on a plain list/overview tab that
+	// overflows vertically — never while an overlay covers the body (its
+	// own viewport scroll, if any, is advertised inside it). The viewport
+	// reports total > visible only after SetContent has been called at
+	// least once, so on first paint (before any scroll key fires) we
+	// silently miss the hint; that's fine, the next keystroke or refresh
+	// will populate it.
+	if !m.overlayOpen() {
 		var scrollHint string
 		switch m.activeTab {
 		case TabOverview:


### PR DESCRIPTION
First PR of the 0.26.0 improvements batch. Two closely-related "stop misleading the user" fixes in the UI layer.

## #62 — footer honest for every overlay
v0.24.2 made `renderFooterBar` context-aware for drill-ins. Modals had the same defect: with the rate-limit panel, settings, action menu, help overlay or sponsor splash open, `model.go`'s `Update` intercepts every key except `ctrl+c` and returns early — yet the footer kept advertising `1-6/tab switch · p public · , settings · ? help`, none of which fire there.

New `footerKeys(m)` selects the hotkey line per open overlay (order mirrors the Update dispatch priority), and `overlayOpen()` also gates the scroll hint off while an overlay covers the body. Each overlay advertises its real keys — `esc` plus `q` **only where q genuinely quits** (rate-limit panel, action menu, drill-in). `help` and the sponsor splash dismiss on any key (q closes them, doesn't quit) and `settings` takes `q` as literal field input, so none of those claim `q quit`.

## #64 — esc-to-clear on filtered-empty PRs/Issues
The Repos tab already tells the user when a filter hid every row (#37); PRs and Issues painted a blank table instead. Now they show `(no pull requests match "<query>" — esc to clear)` (and the issues equivalent), kept distinct from the genuinely-empty case ("no open … you authored") and leaving sticky-section absence untouched, per the issue.

## Tests
- `TestFooterBarHotkeys` → table over list / drill-in / all five modals.
- `TestPRsTabFilteredEmpty` / `TestIssuesTabFilteredEmpty` → filtered-empty shows the affordance, genuinely-empty keeps its own wording.

Full suite green · `gofmt`/`go vet` clean · `govulncheck` reports no reachable vulnerabilities.

Closes #62, closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear empty-state messages when filters return no matching pull requests or issues.
  * Filtered views now explain how to clear the active filter.
  * Footer shortcuts and scroll hints now accurately reflect the current modal or overlay.
  * Improved quit and dismiss shortcut behavior across settings, help, rate-limit, action, and sponsor screens.

* **Tests**
  * Expanded coverage for filtered empty states and context-sensitive footer shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->