### PR TITLE
refactor(ui): render hygiene — hoist constant styles + divider rule

### DIFF
--- a/internal/ui/prs.go
+++ b/internal/ui/prs.go
@@ -433,9 +433,9 @@ func prStateCell(p github.PullRequest) string {
 	case p.IsDraft:
 		return mutedStyle.Render("draft")
 	case p.Mergeable == "CONFLICTING":
-		return lipgloss.NewStyle().Foreground(colError).Render("conflicts")
+		return errorTextStyle.Render("conflicts")
 	case p.Mergeable == "MERGEABLE":
-		return lipgloss.NewStyle().Foreground(colOK).Render("ready")
+		return okStyle.Render("ready")
 	default:
 		return mutedStyle.Render("?")
 	}

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -912,11 +912,10 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 
 		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed+"  "+release)
 
-		// Insert the section dividers exactly once each, after
-		// the last row of the pinned and rest segments. Re-uses
-		// the header width so the rule spans the same band as
-		// the table.
-		rule := tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header)))
+		// Insert the section dividers exactly once each, after the last
+		// row of the pinned and rest segments. Reuses the single `rule`
+		// built once above (same header width) so the two can't drift and
+		// we don't rebuild it — strings.Repeat + Render — on every row.
 		if pinDivider > 0 && i == pinDivider-1 && i+1 < len(repos) {
 			out = append(out, rule)
 		}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -30,8 +30,10 @@ var (
 	boldStyle            lipgloss.Style
 	mutedStyle           lipgloss.Style
 	errorStyle           lipgloss.Style
+	errorTextStyle       lipgloss.Style
 	okStyle              lipgloss.Style
 	warnStyle            lipgloss.Style
+	accentStyle          lipgloss.Style
 	watchStyle           lipgloss.Style
 	valueStyle           lipgloss.Style
 	boxStyle             lipgloss.Style
@@ -65,8 +67,20 @@ func rebuildStyles() {
 
 	errorStyle = lipgloss.NewStyle().Foreground(colError).Bold(true)
 
+	// errorTextStyle is the non-bold sibling of errorStyle: an inline
+	// error-coloured status chip (a PR "conflicts" cell, a critically-low
+	// rate-limit readout) that should read at the same tonal weight as
+	// the muted / ok / warn chips beside it, not the bold error screen.
+	errorTextStyle = lipgloss.NewStyle().Foreground(colError)
+
 	okStyle = lipgloss.NewStyle().Foreground(colOK)
 	warnStyle = lipgloss.NewStyle().Foreground(colWarn)
+
+	// accentStyle is the bare accent foreground — the star glyph in Top
+	// repositories, the sponsor splash icon cell. Constant (no data or
+	// layout input), so it is built once here rather than allocated
+	// inline on every repaint.
+	accentStyle = lipgloss.NewStyle().Foreground(colAccent)
 
 	// watchStyle is the "watch" verdict accent in the integrity-scan
 	// report — value-coloured + bold, the same tonal weight as a

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -22,9 +22,11 @@ var (
 
 // Compound styles. These bake in colour values when constructed, so
 // they have to be reconstructed every time the active theme changes
-// — that's what rebuildStyles does. Code that needs a one-off style
-// builds it inline (e.g. lipgloss.NewStyle().Foreground(colAccent))
-// and picks up the live colour values on each call.
+// — that's what rebuildStyles does. A constant palette colour belongs
+// here as a named var; only a genuinely dynamic style — one whose
+// value comes from data rather than the fixed palette (e.g.
+// lipgloss.NewStyle().Foreground(lipgloss.Color(r.LanguageColor))) —
+// is built inline so it picks up the live value on each call.
 var (
 	titleStyle           lipgloss.Style
 	boldStyle            lipgloss.Style

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -658,7 +658,7 @@ func renderTopRepos(repos []github.Repo, _ int) string {
 
 	var b strings.Builder
 	b.WriteString(subSectionTitleStyle.Render("Top repositories") + "\n")
-	starGlyph := lipgloss.NewStyle().Foreground(colAccent).Render("★")
+	starGlyph := accentStyle.Render("★")
 	for _, e := range ranked {
 		count := valueStyle.Render(fmt.Sprintf("%*d", starColW, e.stars))
 		b.WriteString(fmt.Sprintf("  %s %s  %s\n", count, starGlyph, e.name))
@@ -954,7 +954,7 @@ func statBox(sp cardSpec, width int, pulsedAt time.Time) string {
 	if !pulsedAt.IsZero() && time.Since(pulsedAt) < pulseDuration {
 		style = style.BorderForeground(colAccent)
 	}
-	iconCell := lipgloss.NewStyle().Foreground(colAccent).Render(sp.icon)
+	iconCell := accentStyle.Render(sp.icon)
 	labelLine := iconCell + " " + mutedStyle.Render(sp.label)
 	valueLine := valueStyle.Render(formatCompact(sp.value))
 	return style.Render(labelLine + "\n" + valueLine)
@@ -1181,7 +1181,7 @@ func renderFooterBar(m Model) string {
 // to the generic "stale" wording for ReasonUnknown so old behaviour
 // is preserved when the classifier can't match.
 func renderErrorLine(m Model) string {
-	warn := lipgloss.NewStyle().Foreground(colWarn)
+	warn := warnStyle
 	switch m.errReason {
 	case github.ReasonRateLimitPrimary:
 		msg := "rate-limited"
@@ -1225,9 +1225,9 @@ func renderRateLimitChip(rl *github.RateLimit) string {
 	style := mutedStyle
 	switch {
 	case pct < 0.05:
-		style = lipgloss.NewStyle().Foreground(colError)
+		style = errorTextStyle
 	case pct < 0.20:
-		style = lipgloss.NewStyle().Foreground(colWarn)
+		style = warnStyle
 	}
 
 	label := fmt.Sprintf("rate %d/%d", rl.Remaining, rl.Limit)


### PR DESCRIPTION
Two good-first-issue cleanups in the Repos render path. Pure refactors, no behaviour change.

## #56 — constant inline styles → styles.go
`styles.go` is meant to be the only place styles are built (theming = one-file change). A handful of views allocated a fresh `lipgloss.NewStyle()` per repaint for a style that never varies: the Top-repositories star glyph and sponsor splash icon (accent), the rate-limit chip and PR mergeable chips (error/warn/ok).

Adds `accentStyle` and `errorTextStyle` (the **non-bold** sibling of the bold `errorStyle`, for inline status chips) and reuses the existing `okStyle`/`warnStyle`. Each named var reproduces the exact foreground the inline style used — **no visual change**, including under the monochromatic themes. Data/layout-driven styles (language hex, widths, heatmap) stay inline, per the issue's out-of-scope note.

## #57 — build the divider rule once
`renderReposTable` computed the section-divider rule outside the loop (for the header) and **again inside** the row loop with an identical `strings.Repeat` + `Render` — ~100 discarded allocations per repaint on a 100-repo account, every keypress. The inner declaration also shadowed the outer, so the two could drift. Drop the shadow, reuse the single rule.

## Tests
Pure refactors with byte-identical output — covered by the existing `repos_render_test.go` / render suite. Full suite green · `gofmt`/`go vet` clean.

Closes #56, closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)