### PR TITLE
feat(ui): expand the Checks section in place with 'c'

### DIFF
--- a/internal/ui/checks.go
+++ b/internal/ui/checks.go
@@ -20,6 +20,15 @@ import (
 // overflow count keeps the total honest.
 const checksMaxVisible = 8
 
+// checksExpandable reports whether expanding the Checks section would
+// reveal any row the collapsed cap hides — i.e. more rows were fetched
+// than checksMaxVisible shows. Drill-ins use it to gate the `c` expand
+// keybind and its title hint, so the key is never a no-op press (and so
+// the hint never advertises an action that would do nothing).
+func checksExpandable(checks []github.CheckSummary) bool {
+	return len(checks) > checksMaxVisible
+}
+
 // checkMarker renders the per-check status glyph. SUCCESS = ✓ (ok);
 // failure-flavoured conclusions = ✗; muted neutrals = ·; everything
 // pending or in flight = ⏳.
@@ -121,7 +130,7 @@ func checksRollupSummary(state string) string {
 // provider reporting through the Checks API points at its own
 // dashboard, and those render as plain text rather than becoming
 // one-click targets from a GitHub-looking row.
-func renderCheckList(checks []github.CheckSummary, total, width int) string {
+func renderCheckList(checks []github.CheckSummary, total, width int, expanded bool) string {
 	if len(checks) == 0 {
 		return ""
 	}
@@ -137,8 +146,18 @@ func renderCheckList(checks []github.CheckSummary, total, width int) string {
 		return checkOutcome(ordered[i]) < checkOutcome(ordered[j])
 	})
 
-	if len(ordered) > checksMaxVisible {
-		ordered = ordered[:checksMaxVisible]
+	// Collapsed shows the first checksMaxVisible rows and counts the
+	// rest as "+N more"; expanded (#87) lifts the cap to the whole
+	// fetched list. Either way overflow counts against total, so past
+	// the fetch cap (50) an "+N more" can survive even when expanded —
+	// those rows were never fetched, and the heading rollup stays their
+	// only signal.
+	visible := checksMaxVisible
+	if expanded {
+		visible = len(ordered)
+	}
+	if len(ordered) > visible {
+		ordered = ordered[:visible]
 	}
 	overflow := total - len(ordered)
 

--- a/internal/ui/checks_test.go
+++ b/internal/ui/checks_test.go
@@ -29,7 +29,7 @@ func TestRenderCheckListFailuresFirst(t *testing.T) {
 		URL:        "https://github.com/o/r/actions/runs/1",
 	})
 
-	out := ansi.Strip(renderCheckList(checks, len(checks), 60))
+	out := ansi.Strip(renderCheckList(checks, len(checks), 60, false))
 	if !strings.Contains(out, "govulncheck") {
 		t.Fatalf("the failing check fell off the visible list:\n%s", out)
 	}
@@ -52,7 +52,7 @@ func TestRenderCheckListStablePerBucket(t *testing.T) {
 		{Name: "test", Conclusion: "SUCCESS"},
 		{Name: "build", Conclusion: "SUCCESS"},
 	}
-	out := ansi.Strip(renderCheckList(checks, len(checks), 60))
+	out := ansi.Strip(renderCheckList(checks, len(checks), 60, false))
 	if strings.Index(out, "lint") > strings.Index(out, "test") ||
 		strings.Index(out, "test") > strings.Index(out, "build") {
 		t.Errorf("stable order lost within a bucket:\n%s", out)
@@ -71,7 +71,7 @@ func TestRenderCheckListLinksOnlyVouchedURLs(t *testing.T) {
 		{Name: "vendor-job", Conclusion: "FAILURE", URL: "https://circleci.com/gh/o/r/1"},
 		{Name: "no-url-job", Conclusion: "FAILURE"},
 	}
-	out := renderCheckList(checks, len(checks), 60)
+	out := renderCheckList(checks, len(checks), 60, false)
 
 	if !strings.Contains(out, ansi.SetHyperlink("https://github.com/o/r/actions/runs/1")) {
 		t.Error("the github.com run URL should be an OSC 8 target")
@@ -101,14 +101,14 @@ func TestRenderCheckListOverflowCountsTheRealTotal(t *testing.T) {
 	}
 
 	// 41 exist, 20 came back, 8 are shown -> 33 hidden.
-	out := ansi.Strip(renderCheckList(checks, 41, 60))
+	out := ansi.Strip(renderCheckList(checks, 41, 60, false))
 	if !strings.Contains(out, "+33 more") {
 		t.Errorf("overflow must count against the rollup total (41), not the fetched slice (20):\n%s", out)
 	}
 
 	// A total that under-reports the slice must not produce a negative
 	// or missing count — the fetched length is the floor.
-	out = ansi.Strip(renderCheckList(checks, 0, 60))
+	out = ansi.Strip(renderCheckList(checks, 0, 60, false))
 	if !strings.Contains(out, "+12 more") {
 		t.Errorf("a stale total must fall back to the fetched length:\n%s", out)
 	}
@@ -118,8 +118,67 @@ func TestRenderCheckListOverflowCountsTheRealTotal(t *testing.T) {
 // contract intact: an empty list renders nothing, so the repo drill-in
 // can omit the heading instead of printing an orphan.
 func TestRenderCheckListEmpty(t *testing.T) {
-	if got := renderCheckList(nil, 0, 60); got != "" {
+	if got := renderCheckList(nil, 0, 60, false); got != "" {
 		t.Errorf("renderCheckList(nil) = %q, want empty", got)
+	}
+}
+
+// TestRenderCheckListExpanded pins #87: expanded lifts the 8-row cap so
+// the whole fetched list shows, while collapsed still summarises. Past
+// the fetch cap the overflow survives even when expanded — those rows
+// were never fetched.
+func TestRenderCheckListExpanded(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	var checks []github.CheckSummary
+	for i := 0; i < 12; i++ {
+		checks = append(checks, github.CheckSummary{Name: "job" + itoa(i), Conclusion: "SUCCESS"})
+	}
+
+	t.Run("collapsed caps at 8 with overflow", func(t *testing.T) {
+		out := ansi.Strip(renderCheckList(checks, len(checks), 60, false))
+		if strings.Contains(out, "job8") {
+			t.Errorf("collapsed must hide the 9th row:\n%s", out)
+		}
+		if !strings.Contains(out, "+4 more") {
+			t.Errorf("collapsed must summarise the 4 hidden rows:\n%s", out)
+		}
+	})
+
+	t.Run("expanded shows all fetched, no overflow", func(t *testing.T) {
+		out := ansi.Strip(renderCheckList(checks, len(checks), 60, true))
+		if !strings.Contains(out, "job11") {
+			t.Errorf("expanded must show the last fetched row:\n%s", out)
+		}
+		if strings.Contains(out, "more") {
+			t.Errorf("expanded must not summarise when all fetched are shown:\n%s", out)
+		}
+	})
+
+	t.Run("expanded still reports the un-fetched remainder", func(t *testing.T) {
+		// 30 exist, 12 fetched: expanding shows the 12, still names the 18.
+		out := ansi.Strip(renderCheckList(checks, 30, 60, true))
+		if !strings.Contains(out, "+18 more") {
+			t.Errorf("expanded must still count checks past the fetch cap:\n%s", out)
+		}
+	})
+}
+
+// TestChecksExpandable gates the `c` keybind and its hint: only
+// meaningful when more rows were fetched than the collapsed cap shows.
+func TestChecksExpandable(t *testing.T) {
+	mk := func(n int) []github.CheckSummary {
+		cs := make([]github.CheckSummary, n)
+		for i := range cs {
+			cs[i] = github.CheckSummary{Name: "j"}
+		}
+		return cs
+	}
+	if checksExpandable(mk(checksMaxVisible)) {
+		t.Error("exactly checksMaxVisible rows: nothing hidden, not expandable")
+	}
+	if !checksExpandable(mk(checksMaxVisible + 1)) {
+		t.Error("one row past the cap: expandable")
 	}
 }
 

--- a/internal/ui/pr_detail.go
+++ b/internal/ui/pr_detail.go
@@ -45,6 +45,11 @@ type PRDetailModel struct {
 	// rendering its own body and forwards keys to the sub-view;
 	// closing the sub-view returns control here transparently.
 	files PRFilesModel
+
+	// checksExpanded lifts the Checks section's 8-row cap so the full
+	// fetched list shows in place, toggled by `c` (#87). Collapsed by
+	// default (Open builds a fresh model).
+	checksExpanded bool
 }
 
 // IsOpen reports whether the detail view is currently active.
@@ -114,6 +119,17 @@ func (pd PRDetailModel) Update(msg tea.KeyMsg, client *github.Client, width, hei
 		}
 		pd.files = pd.files.Open(pd.detail.Files, owner, name, num)
 		return pd, nil
+	case "c":
+		// Toggle the Checks section between the 8-row summary and the
+		// full fetched list (#87). Guarded so the key only fires when
+		// there are hidden rows; invalidate the body cache so the next
+		// paint recomputes at the new cap.
+		if pd.detail != nil && checksExpandable(pd.detail.ChecksContexts) {
+			pd.checksExpanded = !pd.checksExpanded
+			pd.bodyCache = ""
+			pd.bodyCacheWidth = 0
+			return pd.syncViewport(width, height), nil
+		}
 	}
 
 	pd = pd.syncViewport(width, height)
@@ -249,12 +265,20 @@ func (pd PRDetailModel) renderTitle() string {
 			"o", "open in github",
 		)
 	default:
-		hints = keyHints(
+		hintPairs := []string{
 			"esc", "back",
 			"o", "open in github",
 			"r", "refresh",
 			"f", "inspect",
-		)
+		}
+		if pd.detail != nil && checksExpandable(pd.detail.ChecksContexts) {
+			label := "expand checks"
+			if pd.checksExpanded {
+				label = "collapse checks"
+			}
+			hintPairs = append(hintPairs, "c", label)
+		}
+		hints = keyHints(hintPairs...)
 	}
 	return activeTabStyle.Render(breadcrumb) + "  " + hints
 }
@@ -311,7 +335,7 @@ func (pd PRDetailModel) computeBody(width int) string {
 		}
 		b.WriteString(title)
 		b.WriteString("\n")
-		b.WriteString(prDetailChecks(d, width))
+		b.WriteString(prDetailChecks(d, width, pd.checksExpanded))
 		b.WriteString("\n\n")
 	}
 
@@ -465,8 +489,8 @@ func prDetailChecksSummary(d *github.PRDetail) string {
 // prDetailChecks renders one line per CI / status context on the
 // PR's head commit. Shared with the repo drill-in — see
 // renderCheckList in checks.go.
-func prDetailChecks(d *github.PRDetail, width int) string {
-	return renderCheckList(d.ChecksContexts, d.ChecksTotal, width)
+func prDetailChecks(d *github.PRDetail, width int, expanded bool) string {
+	return renderCheckList(d.ChecksContexts, d.ChecksTotal, width, expanded)
 }
 
 // prDetailTimeline renders the most recent ~10 events as a

--- a/internal/ui/pr_detail_test.go
+++ b/internal/ui/pr_detail_test.go
@@ -29,7 +29,7 @@ func TestPRDetailChecksWiring(t *testing.T) {
 		t.Errorf("summary = %q, want %q", got, "failing")
 	}
 
-	out := prDetailChecks(d, 80)
+	out := prDetailChecks(d, 80, false)
 	plain := ansi.Strip(out)
 
 	if first := strings.SplitN(plain, "\n", 2)[0]; !strings.Contains(first, "e2e") {
@@ -54,7 +54,7 @@ func TestPRDetailChecksEmpty(t *testing.T) {
 	if got := prDetailChecksSummary(d); got != "" {
 		t.Errorf("summary = %q, want empty for a PR with no rollup", got)
 	}
-	if got := prDetailChecks(d, 80); got != "" {
+	if got := prDetailChecks(d, 80, false); got != "" {
 		t.Errorf("list = %q, want empty for a PR with no checks", got)
 	}
 }

--- a/internal/ui/repo_detail.go
+++ b/internal/ui/repo_detail.go
@@ -40,6 +40,12 @@ type RepoDetailModel struct {
 	// an `r` refresh but the next Open starts from the default again.
 	starMode StarHistoryMode
 
+	// checksExpanded lifts the Checks section's 8-row cap so the full
+	// fetched list shows in place, toggled by `c` (#87). Zero value
+	// (collapsed) is the fresh-detail default — Open builds a new model,
+	// so every drill-in starts summarised.
+	checksExpanded bool
+
 	// viewport wraps the body so a long detail (many languages,
 	// many open issues / PRs, long topic list) stays inside the
 	// tab-content height instead of pushing the pinned footer off
@@ -129,6 +135,15 @@ func (rd RepoDetailModel) Update(msg tea.KeyMsg, client *github.Client, width, h
 			rd.starMode = rd.starMode.next()
 			// Re-sync so the viewport's content reflects the new
 			// reducer immediately (heading + bars change shape).
+			return rd.syncViewport(width, height), nil
+		}
+	case "c":
+		// Toggle the Checks section between the 8-row summary and the
+		// full fetched list (#87). Guarded like `v`: only when there are
+		// hidden rows, else fall through to the viewport so the key isn't
+		// a no-op press.
+		if rd.detail != nil && checksExpandable(rd.detail.Checks) {
+			rd.checksExpanded = !rd.checksExpanded
 			return rd.syncViewport(width, height), nil
 		}
 	}
@@ -270,6 +285,13 @@ func (rd RepoDetailModel) renderTitle() string {
 	if rd.detail != nil && len(rd.detail.StarHistory) > 0 {
 		hints = append(hints, "v", "star view")
 	}
+	if rd.detail != nil && checksExpandable(rd.detail.Checks) {
+		label := "expand checks"
+		if rd.checksExpanded {
+			label = "collapse checks"
+		}
+		hints = append(hints, "c", label)
+	}
 	return activeTabStyle.Render(titleText) + "  " + keyHints(hints...)
 }
 
@@ -317,7 +339,7 @@ func (rd RepoDetailModel) computeBody(width int) string {
 		title := subSectionTitleStyle.Render("Checks")
 		b.WriteString(title + "   " + summary)
 		b.WriteString("\n")
-		if list := renderCheckList(d.Checks, d.ChecksTotal, width); list != "" {
+		if list := renderCheckList(d.Checks, d.ChecksTotal, width, rd.checksExpanded); list != "" {
 			b.WriteString(list)
 			b.WriteString("\n")
 		}


### PR DESCRIPTION
Third PR of the 0.26.0 batch. Closes #87 (follow-up from #86).

## Problem
The repo and PR drill-ins render at most 8 check rows and summarise the rest as `+N more`. `charmbracelet/bubbletea` runs 41 checks, so 33 are only ever a count — with no way to see them without leaving octoscope.

## Approach
Option 1 from the issue: **expand in place**, mirroring how `v` cycles the star-history mode (no new sub-view).

- `renderCheckList` gains an `expanded` flag — collapsed caps at 8, expanded shows the whole fetched list.
- `RepoDetailModel` / `PRDetailModel` each hold a `checksExpanded` bool toggled by `c`.
- `checksExpandable()` gates the keybind **and** its title hint (`c expand checks` / `c collapse checks`), so the key is never a no-op and the hint never advertises a dead action — same discipline as `v`.
- Past the fetch cap (50) the `+N more` survives even when expanded: those rows were never fetched, so the heading rollup stays their only signal (kept honest by the overflow-counts-total logic).

The 8-row default is unchanged — the section stays a summary until you ask for more.

## Tests
`TestRenderCheckListExpanded` (collapsed cap / expanded full / beyond-fetch-cap remainder) + `TestChecksExpandable`. Existing check tests updated to the new signature. Full suite green · `gofmt`/`vet` clean.

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)