### PR TITLE
feat(cli): --theme list to preview the built-in palettes

### DIFF
--- a/internal/ui/themes.go
+++ b/internal/ui/themes.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -163,6 +164,44 @@ func ThemeNames() []string {
 	out := make([]string, len(themeOrder))
 	copy(out, themeOrder)
 	return out
+}
+
+// PrintThemeList writes the built-in palettes to w, one per line in
+// display order, each with a six-slot colour swatch (accent · value ·
+// ok · warn · error · muted) so the difference is visible in the
+// terminal the user will actually run in. Under noColor it degrades to
+// names only — a colour preview with NO_COLOR set is meaningless (#63).
+// Swatches are rendered from each theme's own palette directly, so this
+// never mutates the active theme. Composes with the non-interactive
+// path (v0.24.0): print and exit, no TUI.
+func PrintThemeList(w io.Writer, noColor bool) {
+	nameW := 0
+	for _, name := range themeOrder {
+		if len(name) > nameW {
+			nameW = len(name)
+		}
+	}
+
+	fmt.Fprintln(w, "Available themes:")
+	fmt.Fprintln(w)
+	for _, name := range themeOrder {
+		t := themes[name]
+		tag := ""
+		if t.Monochromatic {
+			tag = "   monochromatic"
+		}
+		if noColor {
+			fmt.Fprintf(w, "  %s%s\n", name, tag)
+			continue
+		}
+		var swatch strings.Builder
+		for _, c := range []lipgloss.Color{t.Accent, t.Value, t.OK, t.Warn, t.Error, t.Muted} {
+			swatch.WriteString(lipgloss.NewStyle().Foreground(c).Render("██"))
+		}
+		fmt.Fprintf(w, "  %-*s  %s%s\n", nameW, name, swatch.String(), tag)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Set one with --theme <name>. accent_color in the config overrides just the accent slot.")
 }
 
 // IsValidTheme reports whether name matches a built-in theme. Used by

--- a/internal/ui/themes_test.go
+++ b/internal/ui/themes_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPrintThemeList pins #63: the colour path lists every built-in
+// palette with a swatch, and the NO_COLOR path degrades to names only
+// (a colour preview with NO_COLOR set is meaningless).
+func TestPrintThemeList(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	t.Run("with colour: every name plus swatches", func(t *testing.T) {
+		var b strings.Builder
+		PrintThemeList(&b, false)
+		out := b.String()
+		for _, name := range themeOrder {
+			if !strings.Contains(out, name) {
+				t.Errorf("theme %q missing from the list:\n%s", name, out)
+			}
+		}
+		if !strings.Contains(out, "██") {
+			t.Errorf("colour list should render swatch blocks:\n%s", out)
+		}
+	})
+
+	t.Run("NO_COLOR: names only, no swatches", func(t *testing.T) {
+		var b strings.Builder
+		PrintThemeList(&b, true)
+		out := b.String()
+		for _, name := range themeOrder {
+			if !strings.Contains(out, name) {
+				t.Errorf("theme %q missing from the names-only list:\n%s", name, out)
+			}
+		}
+		if strings.Contains(out, "██") {
+			t.Errorf("NO_COLOR list must not render colour swatches:\n%s", out)
+		}
+	})
+}

--- a/internal/ui/themes_test.go
+++ b/internal/ui/themes_test.go
@@ -9,7 +9,9 @@ import (
 // palette with a swatch, and the NO_COLOR path degrades to names only
 // (a colour preview with NO_COLOR set is meaningless).
 func TestPrintThemeList(t *testing.T) {
-	_ = applyTheme("octoscope", "")
+	if err := applyTheme("octoscope", ""); err != nil {
+		t.Fatalf("applyTheme(octoscope): %v", err)
+	}
 
 	t.Run("with colour: every name plus swatches", func(t *testing.T) {
 		var b strings.Builder

--- a/main.go
+++ b/main.go
@@ -254,10 +254,13 @@ func parseArgs(args []string) (string, string, cliOverrides, bool) {
 			t := nextValue(&i, "--theme")
 			// "--theme list" is a run mode (print palettes + exit), not a
 			// theme selection — "list" is not a valid palette name anyway.
+			// A real name after an earlier "--theme list" overrides it:
+			// last --theme wins, and list is a mode rather than a value.
 			if t == "list" {
 				cli.themeList = true
 			} else {
 				cli.theme = &t
+				cli.themeList = false
 			}
 		case strings.HasPrefix(arg, "-"):
 			fmt.Fprintf(os.Stderr,
@@ -275,6 +278,14 @@ func parseArgs(args []string) (string, string, cliOverrides, bool) {
 	if cli.plain && cli.json {
 		fmt.Fprintln(os.Stderr,
 			"octoscope: --plain and --json are mutually exclusive")
+		os.Exit(2)
+	}
+	// --theme list is its own print-and-exit run mode; combining it with a
+	// non-interactive output mode is ambiguous (which one wins?), so reject
+	// it rather than silently taking one path.
+	if cli.themeList && (cli.plain || cli.json) {
+		fmt.Fprintln(os.Stderr,
+			"octoscope: --theme list cannot be combined with --plain or --json")
 		os.Exit(2)
 	}
 	return userLogin, configPath, cli, true

--- a/main.go
+++ b/main.go
@@ -35,6 +35,11 @@ type cliOverrides struct {
 	// Mutually exclusive; parseArgs rejects both at once.
 	plain bool
 	json  bool
+
+	// themeList selects the "--theme list" run mode: print the available
+	// palettes (with a colour preview unless NO_COLOR) and exit. No fetch,
+	// no auth, no TUI.
+	themeList bool
 }
 
 func main() {
@@ -42,6 +47,14 @@ func main() {
 	if !ok {
 		// parseArgs already printed version / help / error and told
 		// the caller "done". Exit cleanly.
+		return
+	}
+
+	// --theme list: print the palettes and exit before touching config,
+	// auth or the network. Honours NO_COLOR (names only — a colour
+	// preview under NO_COLOR is meaningless).
+	if cli.themeList {
+		ui.PrintThemeList(os.Stdout, noColorActive(cli.noColor != nil, os.Getenv("NO_COLOR")))
 		return
 	}
 
@@ -239,7 +252,13 @@ func parseArgs(args []string) (string, string, cliOverrides, bool) {
 			configPath = nextValue(&i, "--config")
 		case arg == "--theme":
 			t := nextValue(&i, "--theme")
-			cli.theme = &t
+			// "--theme list" is a run mode (print palettes + exit), not a
+			// theme selection — "list" is not a valid palette name anyway.
+			if t == "list" {
+				cli.themeList = true
+			} else {
+				cli.theme = &t
+			}
 		case strings.HasPrefix(arg, "-"):
 			fmt.Fprintf(os.Stderr,
 				"octoscope: unknown flag: %s\nRun with --help for usage.\n", arg)
@@ -306,7 +325,8 @@ Flags:
                              ~/.config/octoscope/config.toml
     --theme NAME             Visual theme. Built-in: octoscope (default),
                              high-contrast, terminal, monochrome,
-                             stranger-things, phosphor, amber
+                             stranger-things, phosphor, amber.
+                             Use --theme list to preview them and exit.
     --no-color               Force the zero-chroma monochrome theme,
                              overriding --theme / config. Also honoured
                              via the NO_COLOR environment variable

--- a/main_test.go
+++ b/main_test.go
@@ -107,3 +107,34 @@ func TestParseArgsNoSponsor(t *testing.T) {
 		}
 	})
 }
+
+// TestParseArgsThemeList covers the --theme list run mode (#63): the
+// literal value "list" selects the print-and-exit mode without picking
+// a theme, while a real name still sets cli.theme as before.
+func TestParseArgsThemeList(t *testing.T) {
+	t.Run("list selects the run mode", func(t *testing.T) {
+		_, _, cli, ok := parseArgs([]string{"--theme", "list"})
+		if !ok {
+			t.Fatal("parseArgs returned !ok for --theme list")
+		}
+		if !cli.themeList {
+			t.Error("--theme list should set cli.themeList")
+		}
+		if cli.theme != nil {
+			t.Errorf("--theme list must not select a theme, got %q", *cli.theme)
+		}
+	})
+
+	t.Run("a real name still selects a theme", func(t *testing.T) {
+		_, _, cli, ok := parseArgs([]string{"--theme", "phosphor"})
+		if !ok {
+			t.Fatal("parseArgs returned !ok for --theme phosphor")
+		}
+		if cli.themeList {
+			t.Error("--theme phosphor must not trip the list mode")
+		}
+		if cli.theme == nil || *cli.theme != "phosphor" {
+			t.Errorf("--theme phosphor should set cli.theme, got %v", cli.theme)
+		}
+	})
+}

--- a/main_test.go
+++ b/main_test.go
@@ -137,4 +137,17 @@ func TestParseArgsThemeList(t *testing.T) {
 			t.Errorf("--theme phosphor should set cli.theme, got %v", cli.theme)
 		}
 	})
+
+	t.Run("a real name after list clears the mode (last --theme wins)", func(t *testing.T) {
+		_, _, cli, ok := parseArgs([]string{"--theme", "list", "--theme", "phosphor"})
+		if !ok {
+			t.Fatal("parseArgs returned !ok")
+		}
+		if cli.themeList {
+			t.Error("--theme phosphor after --theme list should clear list mode")
+		}
+		if cli.theme == nil || *cli.theme != "phosphor" {
+			t.Errorf("last --theme should win, got %v", cli.theme)
+		}
+	})
 }


### PR DESCRIPTION
Part of the 0.26.0 batch. (Split from the settings-panel item #61, which follows as its own PR.)

## What
`octoscope --theme list` prints the seven built-in palettes, each with a six-slot colour swatch (accent · value · ok · warn · error · muted), and tags the three monochromatic ones. Picking a theme was trial-and-error before; now you can see them in the terminal you'll actually use.

```
Available themes:

  octoscope        ████████████
  high-contrast    ████████████
  terminal         ████████████
  monochrome       ████████████   monochromatic
  stranger-things  ████████████
  phosphor         ████████████   monochromatic
  amber            ████████████   monochromatic
```

## How
- New `ui.PrintThemeList(w, noColor)` renders swatches **from each theme's own palette directly**, so it never mutates the active theme.
- `--theme list` is a run mode in `parseArgs` (like `--plain`/`--json`): it prints and exits **before** config load, auth or any network — no fetch.
- **Honours NO_COLOR / --no-color**: a colour preview under NO_COLOR is meaningless (per the issue's open question), so it degrades to names only.
- `--help` documents it under `--theme`.

## Tests
`TestPrintThemeList` (colour → names + swatches; NO_COLOR → names only) and `TestParseArgsThemeList` (run-mode wiring vs a real theme name). Verified live both ways. Full suite green · `gofmt`/`vet` clean.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)