### PR TITLE
feat(ui): expose accent_color and show_sponsor in the settings panel

### DIFF
--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -66,7 +66,7 @@ func TestFooterBarHotkeys(t *testing.T) {
 		{
 			name: "settings advertises only esc cancel (q is field input, not quit)",
 			open: func(m Model) Model {
-				m.settings = SettingsModel{}.Open(30*time.Second, false, false, "octoscope")
+				m.settings = SettingsModel{}.Open(30*time.Second, false, false, "octoscope", "", true)
 				return m
 			},
 			wantHave:   []string{"cancel"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -101,6 +101,11 @@ type Model struct {
 	// theme so launch-time and runtime sources stay in sync.
 	accentColor string
 
+	// showSponsor mirrors the config's show_sponsor knob so the settings
+	// panel can edit and persist it (#61). It gates the launch-time
+	// splash only — flipping it mid-run just changes the next start.
+	showSponsor bool
+
 	// noColor records that this run was forced to the monochrome
 	// palette by the NO_COLOR env convention or the --no-color flag
 	// (resolved in main.go). It's an environment directive for the
@@ -534,6 +539,7 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 		configPath:   opts.ConfigPath,
 		theme:        themeName,
 		accentColor:  opts.AccentColor,
+		showSponsor:  opts.ShowSponsor,
 		noColor:      opts.NoColor,
 		pinned:       append([]string(nil), opts.PinnedRepos...),
 		pinnedIssues: append([]string(nil), opts.PinnedIssues...),
@@ -821,7 +827,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// live values so the form reflects what the user is
 			// actually running. Subsequent keystrokes are absorbed by
 			// the modal until it returns actionCancel / actionSaveAndExit.
-			m.settings = m.settings.Open(m.interval, m.compact, m.client.PublicOnly(), m.theme)
+			m.settings = m.settings.Open(m.interval, m.compact, m.client.PublicOnly(), m.theme, m.accentColor, m.showSponsor)
 			return m, nil
 		case "?":
 			// Open the keyboard-shortcut overlay. Reached only outside
@@ -1372,9 +1378,10 @@ func (m *Model) persistConfig() error {
 	}
 	cfgOnDisk.PinnedRepos = m.pinned
 	cfgOnDisk.PinnedIssues = m.pinnedIssues
-	// NOTE: ShowSponsor is a user-facing knob the in-app UI never
-	// toggles, so it's left as Load read it (same treatment as
-	// WatchRepos below).
+	// ShowSponsor is editable from the settings panel (#61), so the Model
+	// tracks it and writes it back — no longer hands-off. (Unlike
+	// theme/accent it isn't gated on noColor: NO_COLOR doesn't touch it.)
+	cfgOnDisk.ShowSponsor = m.showSponsor
 	// NOTE: WatchRepos is deliberately NOT touched — it's hand-edit
 	// only (no runtime toggle), so cfgOnDisk keeps whatever Load read
 	// from disk. Re-loading the known fields instead of building a
@@ -1402,20 +1409,25 @@ func (m *Model) applySettingsAndClose() tea.Cmd {
 	newCompact := m.settings.Compact()
 	newPublicOnly := m.settings.PublicOnly()
 	newTheme := m.settings.Theme()
+	newAccent := m.settings.AccentColor()
+	newShowSponsor := m.settings.ShowSponsor()
 
 	intervalChanged := newInterval != m.interval
 	themeChanged := newTheme != m.theme
+	accentChanged := newAccent != m.accentColor
 
 	m.interval = newInterval
 	m.compact = newCompact
+	m.showSponsor = newShowSponsor
 	m.client.SetPublicOnly(newPublicOnly)
-	if themeChanged {
+	if themeChanged || accentChanged {
 		m.theme = newTheme
-		// Reapply with the (possibly-still-set) accent override so
-		// switching theme doesn't silently drop a user-customised
-		// accent. Then re-foreground the spinner so its colour
-		// tracks the new accent.
-		_ = applyTheme(newTheme, m.accentColor)
+		m.accentColor = newAccent
+		// Reapply the palette so a new theme or a new accent override
+		// takes effect immediately (the accent slot alone when only the
+		// override changed). Then re-foreground the spinner so its
+		// colour tracks the possibly-changed accent.
+		_ = applyTheme(newTheme, newAccent)
 		m.spinner.Style = lipgloss.NewStyle().Foreground(colAccent)
 	}
 

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -66,7 +66,7 @@ func TestManualFetchDoesNotReschedule(t *testing.T) {
 func TestSettingsIntervalChangeSupersedesChain(t *testing.T) {
 	m := newTestModel(t, "", false, nil) // interval 60s, refreshGen 0
 	// Stage a different interval in the settings panel.
-	m.settings = m.settings.Open(30*time.Second, m.compact, m.client.PublicOnly(), m.theme)
+	m.settings = m.settings.Open(30*time.Second, m.compact, m.client.PublicOnly(), m.theme, m.accentColor, m.showSponsor)
 
 	cmd := m.applySettingsAndClose()
 	if m.refreshGen != 1 {
@@ -119,7 +119,7 @@ func TestRescheduledTickInheritsOriginGen(t *testing.T) {
 func TestSettingsIntervalFloored(t *testing.T) {
 	m := newTestModel(t, "", false, nil)
 	m.interval = 30 * time.Second // a non-default current value, so the change is observable
-	m.settings = m.settings.Open(0, m.compact, m.client.PublicOnly(), m.theme)
+	m.settings = m.settings.Open(0, m.compact, m.client.PublicOnly(), m.theme, m.accentColor, m.showSponsor)
 
 	_ = m.applySettingsAndClose()
 	if m.interval != config.DefaultRefreshInterval {

--- a/internal/ui/persist_test.go
+++ b/internal/ui/persist_test.go
@@ -228,9 +228,10 @@ func TestApplySettingsAndClosePreservesLists(t *testing.T) {
 	m.stats = nil // viewport syncs become safe no-ops
 
 	// Stage the new values exactly as the settings modal would, keeping
-	// the theme unchanged so applySettingsAndClose doesn't touch the
-	// spinner / re-apply the theme.
-	m.settings = m.settings.Open(30*time.Second, true, true, m.theme)
+	// the theme name unchanged. The accent override changes (""→#abcdef),
+	// so applySettingsAndClose re-applies the palette — harmless here
+	// (m.stats is nil, the spinner is a zero value).
+	m.settings = m.settings.Open(30*time.Second, true, true, m.theme, "#abcdef", false)
 	_ = m.applySettingsAndClose()
 
 	got, err := config.Load(path)
@@ -246,6 +247,15 @@ func TestApplySettingsAndClosePreservesLists(t *testing.T) {
 	if !got.PublicOnly || got.RefreshInterval != 30*time.Second || !got.Compact {
 		t.Errorf("settings not applied: public=%v interval=%v compact=%v",
 			got.PublicOnly, got.RefreshInterval, got.Compact)
+	}
+	// #61: accent_color and show_sponsor now round-trip through the panel.
+	// The seed's show_sponsor defaulted true; the panel staged false, so a
+	// false on reload proves the panel value won.
+	if got.AccentColor != "#abcdef" {
+		t.Errorf("accent_color not persisted via settings: %q", got.AccentColor)
+	}
+	if got.ShowSponsor {
+		t.Error("show_sponsor not persisted via settings (want false, seed was true)")
 	}
 }
 

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -244,18 +244,20 @@ func (sm SettingsModel) Update(msg tea.Msg) (SettingsModel, settingsAction) {
 		return sm, actionNone
 	}
 
-	// Single-rune key on a text field: append. Multi-rune keys
-	// ("left", "ctrl+c", etc.) are dropped so they don't pollute
-	// the buffer. ctrl+c reaches us only because the parent forwards
-	// every key when open — but we don't want a literal "ctrl+c"
-	// string in our buffer, so the rune-length guard handles it.
-	if len(km.Runes) == 1 {
+	// Typed / pasted runes land in whichever text field has focus.
+	// Route them through sanitizeFilterInput — the same guard the list
+	// filters use — so bracketed-paste ANSI / control bytes can never
+	// reach the buffer or the persisted config. Nav / modifier keys
+	// (left, ctrl+c, …) carry no runes, so they sanitize to "" and are
+	// skipped; a genuine multi-rune paste now appends cleanly instead of
+	// being dropped by the old single-rune guard.
+	if in := sanitizeFilterInput(string(km.Runes)); in != "" {
 		switch sm.focus {
 		case fieldRefresh:
-			sm.refreshBuf += string(km.Runes)
+			sm.refreshBuf += in
 			sm.err = ""
 		case fieldAccentColor:
-			sm.accentBuf += string(km.Runes)
+			sm.accentBuf += in
 			sm.err = ""
 		}
 	}

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,8 @@ const (
 	fieldCompact
 	fieldPublicOnly
 	fieldTheme
+	fieldAccentColor
+	fieldShowSponsor
 	settingsFieldCount
 )
 
@@ -57,8 +60,17 @@ type SettingsModel struct {
 	// has focus. Always one of the names in themeOrder.
 	theme string
 
+	// accentBuf is the raw text of the accent-colour override (#RGB /
+	// #RRGGBB hex or an ANSI-256 index). Empty means "use the theme's
+	// own accent". Edited like refreshBuf; validated on save.
+	accentBuf string
+
+	// showSponsor stages the sponsor-splash toggle (v0.16.0). Purely a
+	// launch-time knob — flipping it here only changes the next start.
+	showSponsor bool
+
 	// err is shown under the form when the user tries to save with
-	// an invalid refresh value. Cleared on every keystroke.
+	// an invalid refresh or accent value. Cleared on every keystroke.
 	err string
 }
 
@@ -71,13 +83,15 @@ func (sm SettingsModel) IsOpen() bool {
 
 // Open populates the form from the current live values and shows it.
 // Call this from the root Update when the user presses the open key.
-func (sm SettingsModel) Open(refresh time.Duration, compact, publicOnly bool, theme string) SettingsModel {
+func (sm SettingsModel) Open(refresh time.Duration, compact, publicOnly bool, theme, accentColor string, showSponsor bool) SettingsModel {
 	sm.open = true
 	sm.focus = fieldRefresh
 	sm.refreshBuf = refresh.String()
 	sm.compact = compact
 	sm.publicOnly = publicOnly
 	sm.theme = theme
+	sm.accentBuf = accentColor
+	sm.showSponsor = showSponsor
 	sm.err = ""
 	return sm
 }
@@ -107,6 +121,38 @@ func (sm SettingsModel) PublicOnly() bool { return sm.publicOnly }
 // Theme returns the staged theme name.
 func (sm SettingsModel) Theme() string { return sm.theme }
 
+// AccentColor returns the staged accent override, trimmed. Empty means
+// "no override, use the theme's own accent".
+func (sm SettingsModel) AccentColor() string { return strings.TrimSpace(sm.accentBuf) }
+
+// ShowSponsor returns the staged sponsor-splash flag.
+func (sm SettingsModel) ShowSponsor() bool { return sm.showSponsor }
+
+// validAccentColor reports whether s is an accepted accent override:
+// empty (use the theme default), a #RGB / #RRGGBB hex string, or an
+// ANSI-256 index (0-255). lipgloss itself accepts opaque strings, so
+// this is a save-time guard that gives the user feedback instead of a
+// silently broken colour.
+func validAccentColor(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return true
+	}
+	if rest, ok := strings.CutPrefix(s, "#"); ok {
+		if len(rest) != 3 && len(rest) != 6 {
+			return false
+		}
+		for _, r := range rest {
+			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+				return false
+			}
+		}
+		return true
+	}
+	n, err := strconv.Atoi(s)
+	return err == nil && n >= 0 && n <= 255
+}
+
 // Update handles a key event while the panel is open. Returns the
 // updated sub-model and the action the parent should take.
 //
@@ -128,6 +174,10 @@ func (sm SettingsModel) Update(msg tea.Msg) (SettingsModel, settingsAction) {
 		// closing.
 		if _, err := sm.Refresh(); err != nil {
 			sm.err = fmt.Sprintf("invalid refresh: %v", err)
+			return sm, actionNone
+		}
+		if !validAccentColor(sm.accentBuf) {
+			sm.err = "invalid accent: use #RGB / #RRGGBB hex or 0-255 (blank = theme default)"
 			return sm, actionNone
 		}
 		sm.err = ""
@@ -157,12 +207,16 @@ func (sm SettingsModel) Update(msg tea.Msg) (SettingsModel, settingsAction) {
 			sm.compact = !sm.compact
 		case fieldPublicOnly:
 			sm.publicOnly = !sm.publicOnly
+		case fieldShowSponsor:
+			sm.showSponsor = !sm.showSponsor
 		case fieldTheme:
 			sm.theme = nextTheme(sm.theme, +1)
 		case fieldRefresh:
 			sm.refreshBuf += " "
 			sm.err = ""
 		}
+		// Accent is a text field but colour values never contain spaces,
+		// so space is a no-op there rather than an appended char.
 		return sm, actionNone
 	case "left", "h":
 		if sm.focus == fieldTheme {
@@ -175,21 +229,35 @@ func (sm SettingsModel) Update(msg tea.Msg) (SettingsModel, settingsAction) {
 		}
 		return sm, actionNone
 	case "backspace":
-		if sm.focus == fieldRefresh && len(sm.refreshBuf) > 0 {
-			sm.refreshBuf = sm.refreshBuf[:len(sm.refreshBuf)-1]
-			sm.err = ""
+		switch sm.focus {
+		case fieldRefresh:
+			if len(sm.refreshBuf) > 0 {
+				sm.refreshBuf = sm.refreshBuf[:len(sm.refreshBuf)-1]
+				sm.err = ""
+			}
+		case fieldAccentColor:
+			if len(sm.accentBuf) > 0 {
+				sm.accentBuf = sm.accentBuf[:len(sm.accentBuf)-1]
+				sm.err = ""
+			}
 		}
 		return sm, actionNone
 	}
 
-	// Single-rune key on the text field: append. Multi-rune keys
+	// Single-rune key on a text field: append. Multi-rune keys
 	// ("left", "ctrl+c", etc.) are dropped so they don't pollute
 	// the buffer. ctrl+c reaches us only because the parent forwards
 	// every key when open — but we don't want a literal "ctrl+c"
 	// string in our buffer, so the rune-length guard handles it.
-	if sm.focus == fieldRefresh && len(km.Runes) == 1 {
-		sm.refreshBuf += string(km.Runes)
-		sm.err = ""
+	if len(km.Runes) == 1 {
+		switch sm.focus {
+		case fieldRefresh:
+			sm.refreshBuf += string(km.Runes)
+			sm.err = ""
+		case fieldAccentColor:
+			sm.accentBuf += string(km.Runes)
+			sm.err = ""
+		}
 	}
 	return sm, actionNone
 }
@@ -231,6 +299,14 @@ func (sm SettingsModel) View(width int) string {
 			settingChoiceValue(sm.theme, sm.focus == fieldTheme),
 			sm.focus == fieldTheme,
 			"← / → to cycle · 7 built-ins (see --help for the full list)"),
+		renderSettingsRow("Accent colour", labelWidth,
+			settingTextValue(sm.accentBuf, sm.focus == fieldAccentColor),
+			sm.focus == fieldAccentColor,
+			"override just the accent · #RGB / #RRGGBB or 0-255 · blank = theme default"),
+		renderSettingsRow("Sponsor splash", labelWidth,
+			settingBoolValue(sm.showSponsor),
+			sm.focus == fieldShowSponsor,
+			"show the one-time sponsor splash at launch (takes effect next start)"),
 	}
 
 	body := strings.Join(rows, "\n\n")

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestValidAccentColor pins the accent save-time guard (#61): empty,
+// #RGB / #RRGGBB hex, and ANSI-256 indices pass; everything else fails.
+func TestValidAccentColor(t *testing.T) {
+	valid := []string{"", "   ", "#fff", "#FFF", "#FF0080", "#abcdef", "0", "201", "255"}
+	invalid := []string{"reed", "#ff", "#gggggg", "#12345", "256", "-1", "0x1f", "#", "12 34"}
+
+	for _, s := range valid {
+		if !validAccentColor(s) {
+			t.Errorf("validAccentColor(%q) = false, want true", s)
+		}
+	}
+	for _, s := range invalid {
+		if validAccentColor(s) {
+			t.Errorf("validAccentColor(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestSettingsAccentAndSponsor exercises the two new panel fields (#61):
+// Open seeds them, space toggles the sponsor row, the accent field takes
+// typed text, and a valid accent saves.
+func TestSettingsAccentAndSponsor(t *testing.T) {
+	sm := SettingsModel{}.Open(30*time.Second, false, false, "octoscope", "#123456", true)
+	if sm.AccentColor() != "#123456" {
+		t.Errorf("seeded AccentColor() = %q, want #123456", sm.AccentColor())
+	}
+	if !sm.ShowSponsor() {
+		t.Error("seeded ShowSponsor() = false, want true")
+	}
+
+	// Space on the sponsor row toggles it off.
+	sm.focus = fieldShowSponsor
+	sm, _ = sm.Update(key(" "))
+	if sm.ShowSponsor() {
+		t.Error("space on the sponsor row should toggle it off")
+	}
+
+	// Retype the accent field.
+	sm.focus = fieldAccentColor
+	sm.accentBuf = ""
+	for _, r := range "201" {
+		sm, _ = sm.Update(key(string(r)))
+	}
+	if sm.AccentColor() != "201" {
+		t.Errorf("AccentColor() after typing = %q, want 201", sm.AccentColor())
+	}
+
+	// A valid accent saves.
+	_, action := sm.Update(key("enter"))
+	if action != actionSaveAndExit {
+		t.Errorf("valid accent should save, got %v", action)
+	}
+}
+
+// TestSettingsRejectsInvalidAccent pins that a malformed accent keeps
+// the panel open with an inline error instead of persisting garbage.
+func TestSettingsRejectsInvalidAccent(t *testing.T) {
+	sm := SettingsModel{}.Open(30*time.Second, false, false, "octoscope", "", true)
+	sm.focus = fieldAccentColor
+	for _, r := range "nope" {
+		sm, _ = sm.Update(key(string(r)))
+	}
+
+	sm2, action := sm.Update(key("enter"))
+	if action != actionNone {
+		t.Errorf("invalid accent must not save, got %v", action)
+	}
+	if sm2.err == "" {
+		t.Error("invalid accent should surface an inline error")
+	}
+}

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"testing"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // TestValidAccentColor pins the accent save-time guard (#61): empty,
@@ -74,5 +76,20 @@ func TestSettingsRejectsInvalidAccent(t *testing.T) {
 	}
 	if sm2.err == "" {
 		t.Error("invalid accent should surface an inline error")
+	}
+}
+
+// TestSettingsSanitizesTextInput pins the boundary discipline: a paste
+// carrying ANSI escapes / control bytes into a text field is stripped
+// before it reaches the buffer (never appended raw), same as the list
+// filters.
+func TestSettingsSanitizesTextInput(t *testing.T) {
+	sm := SettingsModel{}.Open(30*time.Second, false, false, "octoscope", "", true)
+	sm.focus = fieldAccentColor
+
+	// "\x1b[31m20\x7f1" — a colour escape, "20", a DEL byte, "1".
+	sm, _ = sm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("\x1b[31m20\x7f1")})
+	if got := sm.AccentColor(); got != "201" {
+		t.Errorf("ANSI / control bytes reached the accent buffer: %q", got)
 	}
 }


### PR DESCRIPTION
Part of the 0.26.0 batch. Closes #61.

## Problem
`accent_color` and `show_sponsor` were config-file-only. Everything else the settings panel (`,`) edits persists back to the file, so these two were the odd ones out.

## What
Two new rows in the panel:
- **Accent colour** — a text field: `#RGB` / `#RRGGBB` hex or an ANSI-256 index; **blank = the theme's own accent**. Applied **live on save** even when the theme name is unchanged, so the accent slot updates immediately. `validAccentColor` guards it at save time with an inline error instead of a silently broken colour.
- **Sponsor splash** — an `[ON]/[OFF]` toggle for `show_sponsor` (a launch-time knob; takes effect next start).

## The Save trap
`config.Save` is a hand-written template, so a new editable key has to be tracked or a Load→Save round trip drops it (the trap that hit `default_sort`). Both keys are already in the template; the missing piece was the Model tracking `show_sponsor` (it was deliberately hands-off before) so `persistConfig` writes it back. The accent override rides the existing `!noColor` persist gate alongside `theme`.

## Tests
- `TestValidAccentColor` — hex / ANSI-256 / empty pass, malformed fail.
- `TestSettingsAccentAndSponsor` / `TestSettingsRejectsInvalidAccent` — Open seeds the fields, space toggles the sponsor row, the accent field takes typed text, a valid accent saves, an invalid one keeps the panel open with an inline error.
- The persist round-trip test now asserts `accent_color` + `show_sponsor` survive a settings save (with `show_sponsor` overriding the seed's default `true`).

Full suite green · `gofmt`/`vet` clean · `govulncheck` no reachable vulns.

Closes #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Accent colour** setting with support for hex values and ANSI color indices.
  * Added a **Sponsor splash** toggle in the settings panel.
  * Settings changes now apply immediately and persist across restarts.
  * Invalid accent values are rejected with an inline error message.
* **Bug Fixes**
  * Theme and accent changes now consistently refresh the application palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->