### PR TITLE
feat(scan): declare partial branch coverage in the report

### DIFF
--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -430,6 +430,27 @@ func (s *RepoScan) ScoredFindings() []Finding {
 	return out
 }
 
+// BranchesNotScanned reports how many branches the scan did not walk —
+// the gap between the repo's real branch count and the number actually
+// scanned. It folds together both blind spots: branches past the
+// enumeration cap (the refs query stops at 100) and enumerated branches
+// past the bounded tree-walk fan-out. Never negative, even if a caller
+// passes an under-reported total.
+func (s *RepoScan) BranchesNotScanned() int {
+	if n := s.BranchesTotal - s.BranchesScanned; n > 0 {
+		return n
+	}
+	return 0
+}
+
+// PartialCoverage reports whether the scan left any gap — unscanned
+// branches or a bounded tree walk. A security report must disclose this
+// so a Clean verdict can't be read as "complete": a false negative is
+// the expensive direction to be wrong in (#85).
+func (s *RepoScan) PartialCoverage() bool {
+	return s.BranchesNotScanned() > 0 || s.Truncated
+}
+
 // ---------------------------------------------------------------------------
 // Axis 2 — blob heuristics (pure)
 // ---------------------------------------------------------------------------

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -317,3 +317,33 @@ func TestEvaluateScanUnsignedDelta(t *testing.T) {
 		t.Error("expected a side-branch divergence finding")
 	}
 }
+
+// TestBranchCoverageDisclosure pins the #85 coverage math: the gap
+// between real and scanned branch counts, and whether the scan should
+// admit partial coverage (unscanned branches or a bounded tree walk).
+func TestBranchCoverageDisclosure(t *testing.T) {
+	cases := []struct {
+		name           string
+		scanned, total int
+		truncated      bool
+		wantNotScanned int
+		wantPartial    bool
+	}{
+		{"all scanned", 5, 5, false, 0, false},
+		{"enumeration cap: 20 of 250", 20, 250, true, 230, true},
+		{"bounded fan-out only", 20, 30, true, 10, true},
+		{"deep-tree truncation, no branch gap", 5, 5, true, 0, true},
+		{"under-reported total floors at zero", 5, 0, false, 0, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &RepoScan{BranchesScanned: tt.scanned, BranchesTotal: tt.total, Truncated: tt.truncated}
+			if got := s.BranchesNotScanned(); got != tt.wantNotScanned {
+				t.Errorf("BranchesNotScanned() = %d, want %d", got, tt.wantNotScanned)
+			}
+			if got := s.PartialCoverage(); got != tt.wantPartial {
+				t.Errorf("PartialCoverage() = %v, want %v", got, tt.wantPartial)
+			}
+		})
+	}
+}

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -177,13 +177,35 @@ func (sm ScanModel) computeBody(width int) string {
 	}
 	b.WriteString("\n")
 
-	// ---- Scan summary
-	summary := fmt.Sprintf("Scanned %d of %d branches", s.BranchesScanned, s.BranchesTotal)
-	if s.Truncated {
-		summary += " (bounded — some branches / deep trees not fully walked)"
+	// ---- Scan summary + coverage disclosure
+	b.WriteString(mutedStyle.Render(
+		fmt.Sprintf("Scanned %d of %d branches", s.BranchesScanned, s.BranchesTotal)))
+	b.WriteString("\n")
+
+	// A scan that didn't reach every branch (the refs enumeration cap at
+	// 100, the bounded tree-walk fan-out) must SAY it's partial — in a
+	// security tool a clean verdict that silently means "clean in the
+	// part I looked at" is the false-negative trap #85 exists to close.
+	// Name the gap, and when the verdict is Clean, qualify it so it can't
+	// read as complete.
+	if s.PartialCoverage() {
+		note := "Partial coverage: "
+		if gap := s.BranchesNotScanned(); gap > 0 {
+			unit := "branches"
+			if gap == 1 {
+				unit = "branch"
+			}
+			note += fmt.Sprintf("%d %s not scanned", gap, unit)
+		} else {
+			note += "some deep trees were not fully walked"
+		}
+		if s.Verdict == github.VerdictClean {
+			note += " — a clean result covers only what was scanned"
+		}
+		b.WriteString(warnStyle.Render(note))
+		b.WriteString("\n")
 	}
-	b.WriteString(mutedStyle.Render(summary))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
 
 	// ---- Scored findings (the evidence behind the verdict)
 	if scored := s.ScoredFindings(); len(scored) > 0 {

--- a/internal/ui/scan_test.go
+++ b/internal/ui/scan_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/gfazioli/octoscope/internal/github"
 )
 
@@ -26,6 +27,38 @@ func compromisedScan() *github.RepoScan {
 			{Name: "next", TipOID: "feedface1234", Signed: true},
 		},
 	}
+}
+
+// TestScanReportPartialCoverage pins #85: a scan that didn't reach every
+// branch says so, and a Clean verdict with a gap is qualified so it can't
+// read as a complete all-clear. A fully-scanned repo shows no such note.
+func TestScanReportPartialCoverage(t *testing.T) {
+	t.Run("clean but partial names the gap and qualifies the verdict", func(t *testing.T) {
+		s := &github.RepoScan{
+			Owner: "octocat", Name: "big", DefaultBranch: "main",
+			BranchesScanned: 20, BranchesTotal: 250, Truncated: true,
+			Verdict: github.VerdictClean,
+		}
+		out := ansi.Strip(ScanModel{scan: s}.computeBody(100))
+		if !strings.Contains(out, "230 branches not scanned") {
+			t.Errorf("report must state how many branches weren't scanned:\n%s", out)
+		}
+		if !strings.Contains(out, "covers only what was scanned") {
+			t.Errorf("a clean-but-partial report must qualify the verdict:\n%s", out)
+		}
+	})
+
+	t.Run("fully scanned clean shows no partial-coverage note", func(t *testing.T) {
+		s := &github.RepoScan{
+			Owner: "octocat", Name: "small", DefaultBranch: "main",
+			BranchesScanned: 3, BranchesTotal: 3, Truncated: false,
+			Verdict: github.VerdictClean,
+		}
+		out := ansi.Strip(ScanModel{scan: s}.computeBody(100))
+		if strings.Contains(out, "Partial coverage") {
+			t.Errorf("a complete scan must not claim partial coverage:\n%s", out)
+		}
+	})
 }
 
 func TestRemediationScript(t *testing.T) {


### PR DESCRIPTION
Part of the 0.26.0 batch. Closes #85 (raised by CodeRabbit on the #84 design doc).

## Problem
The integrity scan can be incomplete in ways the report didn't admit — the refs query enumerates at most 100 branches, and the tree walk is bounded to a handful. A Clean verdict could silently mean *"clean in the part I looked at"*, and in a security tool a false negative is the expensive direction to be wrong in.

## What
- `RepoScan.BranchesNotScanned()` and `RepoScan.PartialCoverage()` — fold together both blind spots (branches past the 100 enumeration cap, and enumerated branches past the bounded tree-walk fan-out).
- The report now **states the gap explicitly** (`N branches not scanned`) and, when the verdict is **Clean**, **qualifies it** (`— a clean result covers only what was scanned`), rendered in the warn style. A fully-scanned repo shows no such note.
- **Verdict tiers and scoring are untouched** — this is disclosure, not scoring (acceptance item 4).

## Scope
Acceptance items 1 (branch cap disclosure), 3 (no complete-clean with a gap) and 4 (tiers unchanged) are covered. **Item 2** (naming a 403'd elevated-scope probe) depends on the capability-escalation axis **#67**, which hasn't landed — noted for when it does.

## Tests
- `TestBranchCoverageDisclosure` (github) — the coverage math across all-scanned / enumeration-cap / fan-out / deep-tree / under-reported-total.
- `TestScanReportPartialCoverage` (ui) — a clean-but-partial report names the gap and qualifies the verdict; a complete scan stays quiet.

Full suite green · `gofmt`/`vet` clean.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)