### PR TITLE
test(github): hermetic coverage for FetchStats + the detail fetches

### DIFF
--- a/internal/github/detail_fetch_test.go
+++ b/internal/github/detail_fetch_test.go
@@ -1,0 +1,90 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// TestFetchIssueDetail covers the issue drill-in payload through the
+// single-response harness: a happy decode, and an auth failure that
+// classifies rather than leaking a raw transport error.
+func TestFetchIssueDetail(t *testing.T) {
+	t.Run("happy path decodes the issue", func(t *testing.T) {
+		const body = `{"data":{"repository":{"issue":{
+			"number":42,
+			"title":"Bug: it breaks",
+			"url":"https://github.com/octocat/proj/issues/42",
+			"state":"OPEN"
+		}}}}`
+		c := newTestGQLClient(t, http.StatusOK, body)
+
+		d, err := c.FetchIssueDetail(context.Background(), "octocat", "proj", 42)
+		if err != nil {
+			t.Fatalf("FetchIssueDetail err = %v", err)
+		}
+		if d.Number != 42 || d.Title != "Bug: it breaks" || d.State != "OPEN" {
+			t.Errorf("decoded = %+v, want #42 OPEN with the title", d)
+		}
+	})
+
+	t.Run("auth failure is classified", func(t *testing.T) {
+		c := newTestGQLClient(t, http.StatusUnauthorized, `{"message":"Bad credentials"}`)
+
+		_, err := c.FetchIssueDetail(context.Background(), "octocat", "proj", 42)
+		var fe *FetchError
+		if !errors.As(err, &fe) {
+			t.Fatalf("want a *FetchError, got %v", err)
+		}
+		if fe.Reason != ReasonAuth {
+			t.Errorf("Reason = %v, want ReasonAuth", fe.Reason)
+		}
+	})
+}
+
+// TestFetchPRDetailCancelledSiblingKeepsRealError pins the first-error
+// contract: when the GraphQL half fails with a real reason (auth), the
+// REST half's cancellation echo (context canceled → ReasonNetwork) must
+// not clobber it. The REST handler blocks until the sibling's failure
+// cancels the shared context, so the GraphQL error is deterministically
+// first.
+func TestFetchPRDetailCancelledSiblingKeepsRealError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "graphql") {
+			// GraphQL: fail fast with an auth error.
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"message":"Bad credentials"}`)
+			return
+		}
+		// REST /pulls/{n}/files: never respond on its own — only unblock
+		// when the GraphQL failure cancels the shared context. That makes
+		// this branch's only possible error a cancellation.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	httpClient := &http.Client{Transport: &rewriteHost{host: srv.URL}}
+	c := &Client{
+		gql:           githubv4.NewClient(httpClient),
+		rest:          httpClient,
+		authenticated: true,
+	}
+
+	_, err := c.FetchPRDetail(context.Background(), "octocat", "proj", 7)
+	var fe *FetchError
+	if !errors.As(err, &fe) {
+		t.Fatalf("want a *FetchError, got %v", err)
+	}
+	if fe.Reason == ReasonNetwork {
+		t.Errorf("the cancelled REST sibling clobbered the real error (got ReasonNetwork)")
+	}
+	if fe.Reason != ReasonAuth {
+		t.Errorf("Reason = %v, want ReasonAuth (the GraphQL failure)", fe.Reason)
+	}
+}

--- a/internal/github/fetch_stats_test.go
+++ b/internal/github/fetch_stats_test.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// newRoutingGQLClient is the multi-query variant of newTestGQLClient
+// (watched_repo_fetch_test.go): it dispatches each GraphQL request to a
+// canned (status, body) chosen by inspecting the query text. FetchStats
+// fires up to five distinct queries in parallel, so a single fixed body
+// can't exercise it — this routes each branch to its own response.
+// Hermetic: no network, no token.
+func newRoutingGQLClient(t *testing.T, route func(query string) (int, string)) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		status, resp := route(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	httpClient := &http.Client{Transport: &rewriteHost{host: srv.URL}}
+	return &Client{gql: githubv4.NewClient(httpClient), rest: httpClient, authenticated: true}
+}
+
+// statsRoutes serves a valid minimal response for every FetchStats
+// branch, keyed off a marker unique to each query. watchFail makes the
+// watched single-repo query 500 so the best-effort branch degrades
+// instead of aborting the whole fetch.
+func statsRoutes(watchFail bool) func(string) (int, string) {
+	const rl = `"rateLimit":{"limit":5000,"remaining":4990,"resetAt":"2026-06-01T00:00:00Z"}`
+	return func(q string) (int, string) {
+		switch {
+		case strings.Contains(q, "statusCheckRollup"):
+			return 200, `{"data":{"viewer":{"repositories":{"nodes":[{"nameWithOwner":"octocat/proj"}],"pageInfo":{"hasNextPage":false}}},` + rl + `}}`
+		case strings.Contains(q, "contributionsCollection"):
+			return 200, `{"data":{"viewer":{"login":"octocat","name":"Octo Cat"},` + rl + `}}`
+		case strings.Contains(q, "$reposCursor"), strings.Contains(q, "languages("):
+			return 200, `{"data":{"viewer":{"repositories":{"totalCount":1,"nodes":[{"name":"proj","nameWithOwner":"octocat/proj","url":"https://github.com/octocat/proj","isPrivate":false,"stargazerCount":10}],"pageInfo":{"hasNextPage":false}}},` + rl + `}}`
+		case strings.Contains(q, "search("):
+			return 200, `{"data":{"search":{"nodes":[]}}}`
+		case strings.Contains(q, "repository("):
+			if watchFail {
+				return 500, `{"errors":[{"message":"boom"}]}`
+			}
+			return 200, `{"data":{"repository":{"name":"bubbletea","nameWithOwner":"charmbracelet/bubbletea","url":"https://github.com/charmbracelet/bubbletea","isPrivate":false}}}`
+		default:
+			return 500, `{"errors":[{"message":"unrouted query"}]}`
+		}
+	}
+}
+
+// TestFetchStatsHappyPath drives the whole dashboard fetch through the
+// routing harness: profile, repo list, CI rollup and the review-requests
+// search all resolve, and FetchStats returns a renderable payload.
+func TestFetchStatsHappyPath(t *testing.T) {
+	c := newRoutingGQLClient(t, statsRoutes(false))
+
+	stats, err := c.FetchStats(context.Background())
+	if err != nil {
+		t.Fatalf("FetchStats err = %v", err)
+	}
+	if stats == nil {
+		t.Fatal("FetchStats returned nil stats")
+	}
+	if stats.Login != "octocat" {
+		t.Errorf("Login = %q, want octocat", stats.Login)
+	}
+	if len(stats.Repositories) != 1 || stats.Repositories[0].Name != "proj" {
+		t.Errorf("Repositories = %+v, want one repo named proj", stats.Repositories)
+	}
+}
+
+// TestFetchStatsBestEffortBranchDegrades pins the resilience contract: a
+// failing watched-repo branch (best-effort) must not abort the fetch —
+// the mandatory branches still produce a renderable payload.
+func TestFetchStatsBestEffortBranchDegrades(t *testing.T) {
+	c := newRoutingGQLClient(t, statsRoutes(true))
+	c.SetWatchRepos([]string{"charmbracelet/bubbletea"})
+
+	stats, err := c.FetchStats(context.Background())
+	if err != nil {
+		t.Fatalf("a best-effort branch failure must not fail FetchStats, got %v", err)
+	}
+	if stats == nil || stats.Login != "octocat" {
+		t.Fatalf("mandatory branches should still render, got %+v", stats)
+	}
+	// The failed watched repo resolved to nothing — the dashboard renders
+	// without it rather than erroring the whole refresh.
+	if len(stats.WatchedRepos) != 0 {
+		t.Errorf("a failed watched repo should not appear, got %+v", stats.WatchedRepos)
+	}
+}


### PR DESCRIPTION
Part of the 0.26.0 batch. Closes #55.

Three high-value fetch paths had no harness tests. Added through the existing `rewriteHost`/`httptest` harness — **no network, no token**.

## What
- **`newRoutingGQLClient`** — the multi-query variant of `newTestGQLClient`: dispatches each parallel `FetchStats` branch to its own canned response by a query marker (`statusCheckRollup` / `contributionsCollection` / `$reposCursor` / `search(` / `repository(`). A single fixed body can't exercise a five-branch fetch.
- **`FetchStats`** — a happy path (profile + repo list + CI rollup + review-requests all resolve into a renderable payload) and the **resilience case**: a failing best-effort watched-repo branch degrades to nothing instead of aborting the mandatory branches.
- **`FetchPRDetail`** — the first-error contract: a real GraphQL auth failure wins over the REST sibling's cancellation echo (**never `ReasonNetwork` over the real reason**). The REST handler blocks until cancelled, so the ordering is deterministic.
- **`FetchIssueDetail`** — happy decode + classified auth failure.

## Acceptance
- ✅ table-driven through `newTestGQLClient` / routing harness; no network, no token
- ✅ `FetchStats`: happy + best-effort-branch-fails-still-renders
- ✅ `FetchPRDetail`: cancelled sibling does not surface as `ReasonNetwork`
- ✅ `go test ./...` and `go test -race ./...` green; hermetic

The explicitly-optional remainder (`FetchReviewRequests`, `FetchStarHistory` — simple single-response) is left as a noted follow-up to keep the diff reviewable.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)