### PR TITLE
refactor(ui): extract message types out of model.go (+ 0.26.0 release prep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ direct shortcut you can press from inside the menu to skip selection.
     release, a **Checks** section (v0.25.0+) breaking the list's CI
     dot down into the individual checks on the default branch's tip
     — failures first, each name an OSC 8 hyperlink to its run on
-    github.com — a 12-month **star-history sparkline** (press `v`,
+    github.com, `c` to expand past the first 8 on busy repos — a
+    12-month **star-history sparkline** (press `v`,
     v0.18.0+, to switch between weekly density and a cumulative
     growth curve à la star-history.com), recent commits with
     total + your-commits-in-the-last-year counts, open issues /
@@ -333,6 +334,7 @@ octoscope --compact             # dense card layout for narrow terminals
 octoscope --public-only         # hide private repos/PRs/issues (safe for demos)
 octoscope --no-sponsor          # skip the sponsor splash for this run
 octoscope --theme phosphor      # 80s green CRT theme — see Themes section
+octoscope --theme list          # preview all built-in palettes and exit
 octoscope --no-color            # force the monochrome theme (or set NO_COLOR)
 octoscope --plain               # static text summary, no TUI
 octoscope --json                # machine-readable JSON, no TUI
@@ -423,7 +425,9 @@ unavailable. Lists follow the same caps as the TUI (repositories up to
 octoscope ships with **seven built-in themes**. Pick one with
 `--theme NAME`, the `theme` config key, or cycle through them live
 in the in-app settings panel (`,` → arrow down to *Theme* → `←` /
-`→`).
+`→`). The panel also edits the **accent colour** override and the
+**sponsor splash** toggle (v0.26.0) — the last two config keys that
+were previously file-only.
 
 | Theme | Vibe |
 |-------|------|

--- a/docs/index.html
+++ b/docs/index.html
@@ -1235,7 +1235,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.25.0</span>
+                <span class="version-tag" id="version-pill">0.26.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -1,0 +1,171 @@
+package ui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gfazioli/octoscope/internal/clipboard"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// This file collects the tea.Msg types the root model's Update loop
+// dispatches on, plus the small Cmd constructors that build them. Split
+// out of model.go (#60) purely to shrink the highest-churn file — no
+// renames, no signature changes, no behaviour: the dispatcher and the
+// model itself stay put.
+
+// fetchMsg carries the outcome of a FetchStats call back to the
+// model's Update loop. `manual` marks fetches that must NOT reschedule
+// the auto-refresh tick (startup paint, manual `r`, settings save) — the
+// timer chain reschedules itself, so only timer-origin fetches do.
+type fetchMsg struct {
+	stats  *github.Stats
+	err    error
+	at     time.Time
+	manual bool
+	// gen is the auto-refresh generation that originated this fetch. A
+	// timer-origin fetch reschedules its NEXT tick under this captured
+	// gen (not the model's current gen), so a fetch that was in flight
+	// when an interval change bumped refreshGen reschedules a now-stale
+	// tick that the guard drops — keeping exactly one chain. Unused for
+	// manual fetches (they never reschedule).
+	gen int
+}
+
+// tickMsg fires at `interval` and drives the next auto-refresh. It
+// carries the generation it was scheduled under: an interval change
+// bumps Model.refreshGen, so a tick from a superseded chain is ignored
+// (and self-terminates) instead of running a second perpetual chain.
+type tickMsg struct{ gen int }
+
+// clockTickMsg fires once a second just so the footer's "Updated Xs
+// ago" label stays current. BubbleTea only re-renders when messages
+// arrive, so without this the freshness clock would stay frozen at
+// whatever value it showed at fetch time.
+type clockTickMsg time.Time
+
+// pulseExpireMsg fires once the pulse window elapses after a fetch
+// that saw changes. Its only purpose is to force a redraw so the
+// accent borders on "recently changed" cards revert to muted without
+// waiting for the next auto-refresh tick (60s).
+type pulseExpireMsg struct{}
+
+// updateCheckMsg carries the latest octoscope release tag back from a
+// (cache-aware) update check. It never carries an error: a failed
+// check stays silent — surfacing "couldn't check for updates" would be
+// noise. An empty latest just means "nothing to compare against".
+type updateCheckMsg struct{ latest string }
+
+// updateTickMsg fires on the slow (hourly) update-check chain, separate
+// from the dashboard refresh tick. Fixed interval (it never changes),
+// so unlike tickMsg it needs no generation guard — there's only ever
+// one chain, started in Init when checkForUpdates is on.
+type updateTickMsg struct{}
+
+// ---------- Action menu cmds + msgs ----------
+
+// showToastMsg requests an inline footer toast for the next ~2s.
+// The action menu's Cmds emit this when the chosen action has no
+// "real" side-effect yet (still wired to a stub) so the user gets
+// visible confirmation that the keypress was registered.
+type showToastMsg struct {
+	text string
+}
+
+// viewRepoDetailMsg is fired by the "View details" menu entry on a
+// Repos row. The root model intercepts it to switch into the
+// drill-in view (Step 2). For now (Step 1) it falls through to a
+// "coming soon" toast — the type is already in place so the wiring
+// doesn't need to change when the detail view lands.
+type viewRepoDetailMsg struct {
+	repo github.Repo
+}
+
+// viewPRDetailMsg is fired by the "View details" menu entry on a
+// PRs row (v0.11.0). Mirrors viewRepoDetailMsg.
+type viewPRDetailMsg struct {
+	pr github.PullRequest
+}
+
+// viewIssueDetailMsg is the Issues-side counterpart of
+// viewPRDetailMsg / viewRepoDetailMsg.
+type viewIssueDetailMsg struct {
+	issue github.Issue
+}
+
+// urlCopiedMsg fires after a copy-to-clipboard action — `err` is
+// nil on success, non-nil when the clipboard helper failed
+// (missing xclip/xsel on minimal Linux, headless X session, etc.).
+// The root model picks the toast wording based on the outcome.
+//
+// `text` is the payload that was placed on the clipboard. The
+// field name dropped "url" once copyPathCmd (v0.12.0) started
+// reusing the message for file paths — keeping a misleading name
+// invites bugs where someone reads msg.url and assumes a URL.
+//
+// `noun` lets the caller swap "URL" for whatever fits the
+// payload: "Path" for file paths, etc. Empty string defaults to
+// "URL" so existing call sites that don't care don't have to
+// thread the field through.
+type urlCopiedMsg struct {
+	text string
+	err  error
+	noun string
+}
+
+// viewRepoDetailCmd builds a Cmd that asks the root model to open
+// the drill-in detail for `r`. Captured at action-menu Open() time
+// so the closure carries the relevant repo through the BubbleTea
+// runtime tick — the menu itself stays oblivious to repo data.
+func viewRepoDetailCmd(r github.Repo) tea.Cmd {
+	return func() tea.Msg {
+		return viewRepoDetailMsg{repo: r}
+	}
+}
+
+// viewPRDetailCmd is the PRs-side counterpart of viewRepoDetailCmd:
+// captures the row and asks the root to open the PR drill-in.
+func viewPRDetailCmd(p github.PullRequest) tea.Cmd {
+	return func() tea.Msg {
+		return viewPRDetailMsg{pr: p}
+	}
+}
+
+// viewIssueDetailCmd captures an Issues row for the action menu.
+func viewIssueDetailCmd(it github.Issue) tea.Cmd {
+	return func() tea.Msg {
+		return viewIssueDetailMsg{issue: it}
+	}
+}
+
+// copyURLCmd builds a Cmd that copies `url` to the system
+// clipboard via the internal/clipboard helper (pbcopy on macOS,
+// clip on Windows, wl-copy/xclip/xsel on Linux). Returns a
+// urlCopiedMsg with the err field populated on failure so the
+// root can decide whether to show "URL copied" or a one-line
+// reason ("clipboard helper not found") in the footer toast.
+// Thin wrapper around copyTextCmd; see copyPathCmd for the
+// path-flavoured counterpart used by the v0.12.0 diff viewer.
+func copyURLCmd(url string) tea.Cmd {
+	return copyTextCmd(url, "URL")
+}
+
+// copyPathCmd is the file-path counterpart of copyURLCmd: same
+// pipeline, different toast noun ("Path copied" instead of
+// "URL copied"). Used by the PR diff viewer's files list (v0.12.0)
+// where the clipboard payload is a repo-relative path rather than
+// a URL.
+func copyPathCmd(path string) tea.Cmd {
+	return copyTextCmd(path, "Path")
+}
+
+// copyTextCmd is the shared underlying primitive. Captures the
+// noun so the eventual toast reflects what was actually copied
+// without each call site having to construct the urlCopiedMsg
+// itself.
+func copyTextCmd(text, noun string) tea.Cmd {
+	return func() tea.Msg {
+		err := clipboard.Copy(text)
+		return urlCopiedMsg{text: text, err: err, noun: noun}
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -11,7 +11,6 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/gfazioli/octoscope/internal/clipboard"
 	"github.com/gfazioli/octoscope/internal/config"
 	"github.com/gfazioli/octoscope/internal/github"
 	"github.com/gfazioli/octoscope/internal/notify"
@@ -262,54 +261,6 @@ type Model struct {
 // label. Long enough to read, short enough not to outstay its
 // welcome.
 const toastDuration = 2 * time.Second
-
-// fetchMsg carries the outcome of a FetchStats call back to the
-// model's Update loop. `manual` marks fetches that must NOT reschedule
-// the auto-refresh tick (startup paint, manual `r`, settings save) — the
-// timer chain reschedules itself, so only timer-origin fetches do.
-type fetchMsg struct {
-	stats  *github.Stats
-	err    error
-	at     time.Time
-	manual bool
-	// gen is the auto-refresh generation that originated this fetch. A
-	// timer-origin fetch reschedules its NEXT tick under this captured
-	// gen (not the model's current gen), so a fetch that was in flight
-	// when an interval change bumped refreshGen reschedules a now-stale
-	// tick that the guard drops — keeping exactly one chain. Unused for
-	// manual fetches (they never reschedule).
-	gen int
-}
-
-// tickMsg fires at `interval` and drives the next auto-refresh. It
-// carries the generation it was scheduled under: an interval change
-// bumps Model.refreshGen, so a tick from a superseded chain is ignored
-// (and self-terminates) instead of running a second perpetual chain.
-type tickMsg struct{ gen int }
-
-// clockTickMsg fires once a second just so the footer's "Updated Xs
-// ago" label stays current. BubbleTea only re-renders when messages
-// arrive, so without this the freshness clock would stay frozen at
-// whatever value it showed at fetch time.
-type clockTickMsg time.Time
-
-// pulseExpireMsg fires once the pulse window elapses after a fetch
-// that saw changes. Its only purpose is to force a redraw so the
-// accent borders on "recently changed" cards revert to muted without
-// waiting for the next auto-refresh tick (60s).
-type pulseExpireMsg struct{}
-
-// updateCheckMsg carries the latest octoscope release tag back from a
-// (cache-aware) update check. It never carries an error: a failed
-// check stays silent — surfacing "couldn't check for updates" would be
-// noise. An empty latest just means "nothing to compare against".
-type updateCheckMsg struct{ latest string }
-
-// updateTickMsg fires on the slow (hourly) update-check chain, separate
-// from the dashboard refresh tick. Fixed interval (it never changes),
-// so unlike tickMsg it needs no generation guard — there's only ever
-// one chain, started in Init when checkForUpdates is on.
-type updateTickMsg struct{}
 
 // diffIDs maps a Stats field to the card id used by the view. Only
 // the integer fields that appear as cards are tracked; profile-text
@@ -1611,112 +1562,4 @@ func updateTickCmd() tea.Cmd {
 	return tea.Tick(updateCheckInterval, func(t time.Time) tea.Msg {
 		return updateTickMsg{}
 	})
-}
-
-// ---------- Action menu cmds + msgs ----------
-
-// showToastMsg requests an inline footer toast for the next ~2s.
-// The action menu's Cmds emit this when the chosen action has no
-// "real" side-effect yet (still wired to a stub) so the user gets
-// visible confirmation that the keypress was registered.
-type showToastMsg struct {
-	text string
-}
-
-// viewRepoDetailMsg is fired by the "View details" menu entry on a
-// Repos row. The root model intercepts it to switch into the
-// drill-in view (Step 2). For now (Step 1) it falls through to a
-// "coming soon" toast — the type is already in place so the wiring
-// doesn't need to change when the detail view lands.
-type viewRepoDetailMsg struct {
-	repo github.Repo
-}
-
-// viewPRDetailMsg is fired by the "View details" menu entry on a
-// PRs row (v0.11.0). Mirrors viewRepoDetailMsg.
-type viewPRDetailMsg struct {
-	pr github.PullRequest
-}
-
-// viewIssueDetailMsg is the Issues-side counterpart of
-// viewPRDetailMsg / viewRepoDetailMsg.
-type viewIssueDetailMsg struct {
-	issue github.Issue
-}
-
-// urlCopiedMsg fires after a copy-to-clipboard action — `err` is
-// nil on success, non-nil when the clipboard helper failed
-// (missing xclip/xsel on minimal Linux, headless X session, etc.).
-// The root model picks the toast wording based on the outcome.
-//
-// `text` is the payload that was placed on the clipboard. The
-// field name dropped "url" once copyPathCmd (v0.12.0) started
-// reusing the message for file paths — keeping a misleading name
-// invites bugs where someone reads msg.url and assumes a URL.
-//
-// `noun` lets the caller swap "URL" for whatever fits the
-// payload: "Path" for file paths, etc. Empty string defaults to
-// "URL" so existing call sites that don't care don't have to
-// thread the field through.
-type urlCopiedMsg struct {
-	text string
-	err  error
-	noun string
-}
-
-// viewRepoDetailCmd builds a Cmd that asks the root model to open
-// the drill-in detail for `r`. Captured at action-menu Open() time
-// so the closure carries the relevant repo through the BubbleTea
-// runtime tick — the menu itself stays oblivious to repo data.
-func viewRepoDetailCmd(r github.Repo) tea.Cmd {
-	return func() tea.Msg {
-		return viewRepoDetailMsg{repo: r}
-	}
-}
-
-// viewPRDetailCmd is the PRs-side counterpart of viewRepoDetailCmd:
-// captures the row and asks the root to open the PR drill-in.
-func viewPRDetailCmd(p github.PullRequest) tea.Cmd {
-	return func() tea.Msg {
-		return viewPRDetailMsg{pr: p}
-	}
-}
-
-// viewIssueDetailCmd captures an Issues row for the action menu.
-func viewIssueDetailCmd(it github.Issue) tea.Cmd {
-	return func() tea.Msg {
-		return viewIssueDetailMsg{issue: it}
-	}
-}
-
-// copyURLCmd builds a Cmd that copies `url` to the system
-// clipboard via the internal/clipboard helper (pbcopy on macOS,
-// clip on Windows, wl-copy/xclip/xsel on Linux). Returns a
-// urlCopiedMsg with the err field populated on failure so the
-// root can decide whether to show "URL copied" or a one-line
-// reason ("clipboard helper not found") in the footer toast.
-// Thin wrapper around copyTextCmd; see copyPathCmd for the
-// path-flavoured counterpart used by the v0.12.0 diff viewer.
-func copyURLCmd(url string) tea.Cmd {
-	return copyTextCmd(url, "URL")
-}
-
-// copyPathCmd is the file-path counterpart of copyURLCmd: same
-// pipeline, different toast noun ("Path copied" instead of
-// "URL copied"). Used by the PR diff viewer's files list (v0.12.0)
-// where the clipboard payload is a repo-relative path rather than
-// a URL.
-func copyPathCmd(path string) tea.Cmd {
-	return copyTextCmd(path, "Path")
-}
-
-// copyTextCmd is the shared underlying primitive. Captures the
-// noun so the eventual toast reflects what was actually copied
-// without each call site having to construct the urlCopiedMsg
-// itself.
-func copyTextCmd(text, noun string) tea.Cmd {
-	return func() tea.Msg {
-		err := clipboard.Copy(text)
-		return urlCopiedMsg{text: text, err: err, noun: noun}
-	}
 }

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,27 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.26.0": {
+		headline: "Improvements & polish — a batch of long-standing backlog items.",
+		items: []whatsNewItem{
+			{
+				title: "See the whole Checks list",
+				desc:  "In a repo or PR drill-in, press c to expand the Checks section past the first 8 rows and back — handy on busy repos that run dozens of checks.",
+			},
+			{
+				title: "Preview themes without guessing",
+				desc:  "octoscope --theme list prints all seven palettes with a colour swatch each (names only under NO_COLOR), so you can pick one without trial-and-error.",
+			},
+			{
+				title: "Accent colour & sponsor splash in Settings",
+				desc:  "The in-app settings panel (,) now edits accent_color and the sponsor splash toggle too — the last two config keys that were file-only.",
+			},
+			{
+				title: "Honest coverage & clearer empty states",
+				desc:  "A partial integrity scan now says so instead of reading as a clean all-clear; the footer stops advertising keys that don't work in modals or while filtering; and a filter that hides every PR/issue tells you how to clear it.",
+			},
+		},
+	},
 	"0.25.0": {
 		headline: "A red CI dot now tells you what broke.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.25.0"
+const version = "0.26.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Final PR of the 0.26.0 batch — the #60 refactor, with the release-prep in the last commit so `main` is taggable at merge.

## #60 — extract message types
`model.go` is the highest-churn file in the repo. This moves the `tea.Msg` type declarations **and the small Cmd constructors that sit alongside them** (the action-menu view/copy cmds) into a new `messages.go` in the same package.

**Mechanical cut** — no renames, no signature changes, no behavioural diff. The modal dispatch and the "one modal open at a time" / deepest-sub-view-first routing invariants stay in `model.go`, **deliberately out of scope** per the issue. `model.go` drops ~160 lines (1722 → 1565).

`go test ./...`, `go vet ./...`, `gofmt -l .` all clean; the suite is unchanged.

## Release prep (atomic, last commit)
- `main.go` → **0.26.0**
- `whatsnew.go` → 0.26.0 highlights (expand Checks with `c`, `--theme list`, accent/sponsor in Settings, honest scan coverage + clearer empty states)
- `docs/index.html` hero pill fallback → 0.26.0
- `README.md` → `--theme list` example, `c` expands Checks, settings panel edits `accent_color` + `show_sponsor`

## The 0.26.0 batch
Closes the improvements milestone: #62, #64 (footer/empty-state honesty), #56, #57 (render hygiene), #87 (expand Checks), #63 (`--theme list`), #61 (settings accent/sponsor), #85 (scan partial coverage), #55, #82 (test coverage), and #60 (this).

Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)