### PR TITLE
feat(scan): fold the push-burst signal into the scan, recency-gated

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -112,7 +112,10 @@ shape instead.
   Axis-1/2 findings the default branch does not have
 - **Push burst** — many owned repositories with `PushedAt` clustered in a
   tight window; the reference attack hit five repositories in 49 seconds from
-  one IP. Free and client-side, zero extra API cost.
+  one IP. Free and client-side, zero extra API cost. Reported under its own
+  `push-burst` label rather than as provenance evidence, because it is
+  account-wide rather than a fact about this repo's commits — see Tier A
+  below for the recency gate and the corroboration-only weighting.
 
 The unsigned-delta baseline counts only genuine author signatures
 (`Signed && !SignedByGitHub`) — a GitHub-signed `main` next to an unsigned
@@ -178,9 +181,17 @@ scan is tiered accordingly.
   banner was built and then **dropped**: timing alone cannot separate a worm
   fan-out from an ordinary batch push (a scripted push to 17 repositories in
   two minutes fired it), and without a recency gate any historical batch
-  re-alarmed forever. `DetectPushBurst` is kept, tested and unwired, to fold
-  into the scan later — recency-gated and combined with the other axes
-  ([#69](https://github.com/gfazioli/octoscope/issues/69)).
+  re-alarmed forever. Both objections are answered by folding the signal into
+  the on-demand scan instead of letting it stand alone, which is what
+  [#69](https://github.com/gfazioli/octoscope/issues/69) did:
+  `DetectPushBurst` now runs inside `FetchRepoScan`, gated on
+  `pushBurstRecency` (one hour), and contributes `wPushBurstCorroboration`
+  **only to a repo that already scored on Axes 1-3**. A burst on a repo with
+  no other finding is still reported — at weight 0, so the user sees the
+  context without it moving the verdict. The repo list comes from the caller's
+  existing dashboard fetch, so it remains free; `--public-only` narrows it, on
+  the grounds that a screenshot-safe mode must not disclose private push
+  activity even as a count.
 - **Tier B — on-demand per-repo scan. Shipped in v0.20.0.** An action on Repos
   rows (`s`). One targeted query per selected repository: enumerate branches
   (`refs(refPrefix: "refs/heads/", first: 100)`), then aliased

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -56,16 +56,28 @@ import (
 // ---------------------------------------------------------------------------
 
 // pushBurstMinRepos / pushBurstWindow define the push-burst heuristic —
-// a separate, account-wide timing signal, NOT one of the per-repo
-// scoring axes (Axis 1-3). The reference worm pushed to five repos in a
+// an account-wide timing signal rather than one of the numbered per-repo
+// axes (Axis 4 is capability escalation, a different thing entirely).
+// The reference worm pushed to five repos in a
 // 49-second window from a single IP — humans almost never push to three
 // *distinct* repos inside a two-minute window, but a fan-out script
 // does. Kept tight so the signal stays rare and meaningful rather than
-// firing on a normal cross-repo work session. See DetectPushBurst for
-// why this is currently unwired.
+// firing on a normal cross-repo work session.
 const (
 	pushBurstMinRepos = 3
 	pushBurstWindow   = 2 * time.Minute
+
+	// pushBurstRecency gates the signal in time. DetectPushBurst finds
+	// the tightest cluster in the *whole* history it is given, so
+	// without this a batch push from months ago would re-alarm on every
+	// scan — one of the two reasons the original always-on banner was
+	// pulled. An hour is deliberately tight: the reference worm hit
+	// five repos in 49 seconds, so a live fan-out is comfortably inside
+	// it, while a maintainer's scripted sweep from yesterday is not.
+	// The cost of being tight is a missed corroboration on a scan run
+	// long after the fact, which is the right way to be wrong here —
+	// the axes that carry the actual evidence do not expire.
+	pushBurstRecency = time.Hour
 )
 
 // PushBurst describes the tightest cluster of repositories pushed
@@ -86,18 +98,20 @@ type PushBurst struct {
 // zero PushedAt (never pushed) are ignored.
 //
 // Pure function — the caller passes the thresholds so the heuristic is
-// table-testable.
+// table-testable. Note it finds *any* historical cluster: it has no
+// notion of "recent", which is the caller's job.
 //
-// NOT currently wired into the UI. It shipped as an always-on dashboard
-// banner but was pulled: timing alone can't tell a worm's fan-out from
-// an ordinary batch push (a maintainer scripting an update across N
-// repos, Dependabot, a CI sweep), and — critically — this finds *any*
-// historical cluster, so without a recency gate a months-old batch
-// re-alarms on every launch. Retained as a tested building block: a
-// future use should fold it into the on-demand scan as one input
-// (e.g. "this repo was part of a push burst in the last hour"),
-// gated on recency and combined with the stronger Axis 1-3 signals
-// rather than standing alone.
+// History worth keeping: this first shipped as an always-on dashboard
+// banner and was pulled, for two reasons that still hold. Timing alone
+// cannot tell a worm's fan-out from an ordinary batch push (a maintainer
+// scripting an update across N repos, Dependabot, a CI sweep), and with
+// no recency gate a months-old batch re-alarmed on every launch.
+//
+// It is now consumed by FetchRepoScan as the account-wide signal, which
+// fixes both: the
+// result is gated on pushBurstRecency, and it only scores
+// (wPushBurstCorroboration) for a repo that already scored on Axis 1-3 —
+// so it corroborates evidence instead of manufacturing a verdict.
 func DetectPushBurst(repos []Repo, minRepos int, window time.Duration) (PushBurst, bool) {
 	pushed := make([]Repo, 0, len(repos))
 	for _, r := range repos {
@@ -278,6 +292,18 @@ const (
 	// Cross-axis bonus — the smoking gun: ignition + blob anomaly +
 	// provenance anomaly all on the same branch.
 	wCombinedSmokingGun = 4
+
+	// wPushBurstCorroboration is the account-wide timing signal's
+	// contribution, and it is applied **only to a repo that already
+	// scored on Axis 1-3**. That gate is the whole point: timing alone
+	// cannot separate a worm fan-out from a maintainer scripting an
+	// update across their repos, so a burst must never produce a
+	// verdict by itself — a push burst on its own is a Tuesday. When
+	// something in the repo *does* auto-execute or looks forged, the
+	// same repo being part of a fan-out minutes ago is genuine
+	// corroboration. 3 escalates roughly one tier (a Watch becomes
+	// Suspicious) without ever manufacturing one from nothing.
+	wPushBurstCorroboration = 3
 )
 
 // Verdict thresholds. A lone agent-hook config (weight 1) stays Clean
@@ -341,6 +367,13 @@ const (
 	AxisIgnition   FindingAxis = "ignition"
 	AxisBlob       FindingAxis = "blob"
 	AxisProvenance FindingAxis = "provenance"
+	// AxisPushBurst is account-wide rather than per-repo: it reports
+	// that this repo was pushed as part of a tight cross-repo cluster.
+	// It is reported even when it scores nothing, so the user sees the
+	// context and can judge it — the report never hides an input. Kept
+	// distinct from AxisProvenance because a `[provenance]` tag would
+	// imply a fact about this repo's commits, which it isn't.
+	AxisPushBurst FindingAxis = "push-burst"
 )
 
 // Finding is one piece of explainable evidence. Weight is the score it
@@ -617,6 +650,16 @@ type scanInput struct {
 	Truncated        bool
 	Branches         []scanBranch
 	Blobs            map[string]blobAnalysis // keyed by blob SHA
+
+	// Burst is the account-wide push cluster this scan was handed, and
+	// BurstHit reports whether *this* repo is one of its members. Both
+	// are zero when the caller had no account repo list to derive them
+	// from, which is the correct degraded behaviour: no context, no
+	// finding. Now anchors the recency gate and is injected so the
+	// scoring engine stays a pure function.
+	Burst    PushBurst
+	BurstHit bool
+	Now      time.Time
 }
 
 // evaluateScan is the pure heart of the detector: it turns gathered
@@ -802,6 +845,31 @@ func evaluateScan(in scanInput) *RepoScan {
 		}
 	}
 
+	// The account-wide push burst, evaluated last because whether it
+	// scores depends on what Axis 1-3 already found. Deliberately not
+	// numbered as an axis: "Axis 4" is capability escalation.
+	if in.BurstHit && !in.Burst.Newest.IsZero() && !in.Now.IsZero() &&
+		in.Now.Sub(in.Burst.Newest) <= pushBurstRecency {
+		// Read the score *before* this finding: corroboration means
+		// "something else already flagged", not "the burst flagged".
+		corroborates := s.Score > 0
+		weight := 0
+		reason := fmt.Sprintf(
+			"pushed as part of a burst of %d repos within %s — no scored finding in this repo for it to corroborate, so it does not affect the verdict",
+			in.Burst.Count, in.Burst.Span.Round(time.Second))
+		if corroborates {
+			weight = wPushBurstCorroboration
+			reason = fmt.Sprintf(
+				"pushed as part of a burst of %d repos within %s, alongside the findings above",
+				in.Burst.Count, in.Burst.Span.Round(time.Second))
+		}
+		add(Finding{
+			Axis:   AxisPushBurst,
+			Weight: weight,
+			Reason: reason,
+		})
+	}
+
 	s.Verdict = verdictFor(s.Score)
 	return s
 }
@@ -973,7 +1041,12 @@ type scanRefsQuery struct {
 //
 // Then the pure evaluateScan reduces the gathered facts to findings +
 // verdict.
-func (c *Client) FetchRepoScan(ctx context.Context, owner, name string) (*RepoScan, error) {
+//
+// accountRepos is the caller's already-fetched repo list, used only to
+// derive the account-wide push-burst context — pure arithmetic over
+// PushedAt, so it costs no extra API call. Pass nil when there is none:
+// the scan degrades cleanly to Axis 1-3.
+func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, accountRepos []Repo) (*RepoScan, error) {
 	var q scanRefsQuery
 	vars := map[string]interface{}{
 		"owner": githubv4.String(owner),
@@ -1158,6 +1231,20 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string) (*RepoSc
 		Truncated:     truncated,
 		Branches:      branches,
 		Blobs:         blobs,
+		Now:           time.Now(),
+	}
+	// The push burst costs no API call: it is arithmetic over PushedAt
+	// timestamps the caller already holds from the dashboard fetch. An
+	// empty accountRepos simply means no timing context — the scan still
+	// runs on Axis 1-3.
+	if burst, ok := DetectPushBurst(accountRepos, pushBurstMinRepos, pushBurstWindow); ok {
+		in.Burst = burst
+		for _, n := range burst.Repos {
+			if strings.EqualFold(n, name) {
+				in.BurstHit = true
+				break
+			}
+		}
 	}
 	return evaluateScan(in), nil
 }

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -158,6 +158,37 @@ func DetectPushBurst(repos []Repo, minRepos int, window time.Duration) (PushBurs
 	return best, true
 }
 
+// repoInBurst reports whether the repo identified by owner/name is one
+// of the repos the burst was actually computed from.
+//
+// The obvious implementation — checking owner/name's bare name against
+// PushBurst.Repos — is wrong, because a bare repo name is unique only
+// *within one owner* and the scanned repo need not belong to
+// accountRepos at all: the Repos tab lists watched repositories owned by
+// other people (Stats.WatchedRepos) and any of them can be selected and
+// scanned. Left on a name match, a fan-out across the viewer's own
+// account would be credited to a stranger's repo that merely shares a
+// name — a false corroboration in a security report, which is the exact
+// failure this signal is gated to avoid.
+//
+// So the repo is resolved by identity through its URL first, and only
+// the account's own entry is then checked for membership.
+func repoInBurst(accountRepos []Repo, burst PushBurst, owner, name string) bool {
+	for _, r := range accountRepos {
+		o, n := SplitOwnerName(r.URL)
+		if !strings.EqualFold(o, owner) || !strings.EqualFold(n, name) {
+			continue
+		}
+		for _, bn := range burst.Repos {
+			if bn == r.Name {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
 // ---------------------------------------------------------------------------
 // Axis 1 — ignition catalog
 // ---------------------------------------------------------------------------
@@ -848,8 +879,18 @@ func evaluateScan(in scanInput) *RepoScan {
 	// The account-wide push burst, evaluated last because whether it
 	// scores depends on what Axis 1-3 already found. Deliberately not
 	// numbered as an axis: "Axis 4" is capability escalation.
+	// The window is deliberately two-sided. A one-sided `age <= recency`
+	// lets a future-dated PushedAt through forever, since now.Sub(future)
+	// is negative and every negative satisfies it — a repo carrying a
+	// bogus future timestamp would then look freshly burst on every scan.
+	// Mild clock skew still counts as recent; a wildly future date does
+	// not.
+	age := in.Now.Sub(in.Burst.Newest)
+	if age < 0 {
+		age = -age
+	}
 	if in.BurstHit && !in.Burst.Newest.IsZero() && !in.Now.IsZero() &&
-		in.Now.Sub(in.Burst.Newest) <= pushBurstRecency {
+		age <= pushBurstRecency {
 		// Read the score *before* this finding: corroboration means
 		// "something else already flagged", not "the burst flagged".
 		corroborates := s.Score > 0
@@ -1237,14 +1278,9 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, accountR
 	// timestamps the caller already holds from the dashboard fetch. An
 	// empty accountRepos simply means no timing context — the scan still
 	// runs on Axis 1-3.
-	if burst, ok := DetectPushBurst(accountRepos, pushBurstMinRepos, pushBurstWindow); ok {
+	if burst, ok := DetectPushBurst(accountRepos, pushBurstMinRepos, pushBurstWindow); ok && repoInBurst(accountRepos, burst, owner, name) {
 		in.Burst = burst
-		for _, n := range burst.Repos {
-			if strings.EqualFold(n, name) {
-				in.BurstHit = true
-				break
-			}
-		}
+		in.BurstHit = true
 	}
 	return evaluateScan(in), nil
 }

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -231,6 +231,141 @@ func TestEvaluateScanWatch(t *testing.T) {
 	}
 }
 
+// --- engine: Axis 4, the account-wide push burst -------------------------
+
+// burstInput builds a scan input that either scores on Axis 1 (two agent
+// hooks → Watch) or is clean (a weight-0 surface), so the tests can watch
+// what the burst does to each.
+func burstInput(scored bool, hit bool, newest, now time.Time) scanInput {
+	rule := ignitionRule{Class: classPackage, Weight: 0}
+	if scored {
+		rule = ignitionRule{Class: classAgentHook, Weight: wIgnitionAgentHook}
+	}
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 1,
+		Branches: []scanBranch{{
+			Prov: provBranch("main", true),
+			Matches: []ignitionMatch{
+				{Path: ".claude/settings.json", Size: 400, BlobSHA: "c", Rule: rule},
+				{Path: ".gemini/settings.json", Size: 300, BlobSHA: "g", Rule: rule},
+			},
+		}},
+		Blobs: map[string]blobAnalysis{
+			"c": {Size: 400, Fetched: true, IsText: true},
+			"g": {Size: 300, Fetched: true, IsText: true},
+		},
+		Now: now,
+	}
+	if !newest.IsZero() {
+		in.Burst = PushBurst{Count: 5, Span: 49 * time.Second, Newest: newest, Repos: []string{"r", "a", "b", "c", "d"}}
+		in.BurstHit = hit
+	}
+	return in
+}
+
+func burstFinding(s *RepoScan) (Finding, bool) {
+	for _, f := range s.Findings {
+		if f.Axis == AxisPushBurst {
+			return f, true
+		}
+	}
+	return Finding{}, false
+}
+
+func TestEvaluateScanPushBurst(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		in          scanInput
+		wantFinding bool
+		wantWeight  int
+		wantVerdict ScanVerdict
+	}{
+		{
+			// The corroboration case: Axis 1 already scored 2 (Watch),
+			// the burst adds 3 → 5, which is exactly tSuspicious.
+			name:        "recent burst corroborates a scored repo",
+			in:          burstInput(true, true, now.Add(-5*time.Minute), now),
+			wantFinding: true,
+			wantWeight:  wPushBurstCorroboration,
+			wantVerdict: VerdictSuspicious,
+		},
+		{
+			// The rule that matters: a burst must never create a verdict
+			// on its own. Reported for transparency at weight 0.
+			name:        "recent burst alone scores nothing",
+			in:          burstInput(false, true, now.Add(-5*time.Minute), now),
+			wantFinding: true,
+			wantWeight:  0,
+			wantVerdict: VerdictClean,
+		},
+		{
+			// Without the recency gate this is the bug that got the
+			// original banner pulled: a months-old batch push re-alarming
+			// on every run.
+			name:        "stale burst is ignored entirely",
+			in:          burstInput(true, true, now.Add(-72*time.Hour), now),
+			wantFinding: false,
+			wantVerdict: VerdictWatch,
+		},
+		{
+			name:        "burst this repo is not part of is ignored",
+			in:          burstInput(true, false, now.Add(-5*time.Minute), now),
+			wantFinding: false,
+			wantVerdict: VerdictWatch,
+		},
+		{
+			// A caller with no repo list (accountRepos nil) must degrade
+			// to Axis 1-3 rather than mis-score.
+			name:        "no burst context at all",
+			in:          burstInput(true, false, time.Time{}, now),
+			wantFinding: false,
+			wantVerdict: VerdictWatch,
+		},
+		{
+			// A zero Now would otherwise make every burst look ancient
+			// *or* current depending on sign; assert it is simply skipped.
+			name:        "zero clock is skipped",
+			in:          burstInput(true, true, now.Add(-5*time.Minute), time.Time{}),
+			wantFinding: false,
+			wantVerdict: VerdictWatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateScan(tt.in)
+			f, ok := burstFinding(got)
+			if ok != tt.wantFinding {
+				t.Fatalf("push-burst finding present = %v, want %v (findings %+v)", ok, tt.wantFinding, got.Findings)
+			}
+			if ok && f.Weight != tt.wantWeight {
+				t.Errorf("push-burst weight = %d, want %d", f.Weight, tt.wantWeight)
+			}
+			if got.Verdict != tt.wantVerdict {
+				t.Errorf("verdict = %v, want %v (score %d)", got.Verdict, tt.wantVerdict, got.Score)
+			}
+		})
+	}
+}
+
+// The weight-0 burst finding must stay out of ScoredFindings so the
+// report's scored-evidence section doesn't imply it moved the needle.
+func TestPushBurstAloneIsNotScoredEvidence(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	got := evaluateScan(burstInput(false, true, now.Add(-time.Minute), now))
+	if _, ok := burstFinding(got); !ok {
+		t.Fatal("expected the burst to be reported for transparency")
+	}
+	for _, f := range got.ScoredFindings() {
+		if f.Axis == AxisPushBurst {
+			t.Error("a weight-0 burst must not appear among scored findings")
+		}
+	}
+}
+
 func TestEvaluateScanCompromised(t *testing.T) {
 	prov := provBranch("main", true)
 	prov.Signed = false

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -231,6 +231,52 @@ func TestEvaluateScanWatch(t *testing.T) {
 	}
 }
 
+// --- burst membership: identity, not bare name ---------------------------
+
+func TestRepoInBurst(t *testing.T) {
+	// The viewer's own repos, two of which are in the burst.
+	own := []Repo{
+		{Name: "octoscope", URL: "https://github.com/gfazioli/octoscope"},
+		{Name: "findergit", URL: "https://github.com/gfazioli/findergit"},
+		{Name: "netfox", URL: "https://github.com/gfazioli/netfox"},
+	}
+	burst := PushBurst{Count: 3, Repos: []string{"octoscope", "findergit", "netfox"}}
+
+	tests := []struct {
+		name        string
+		repos       []Repo
+		owner, repo string
+		want        bool
+	}{
+		{"own repo genuinely in the burst", own, "gfazioli", "octoscope", true},
+		{"owner casing is irrelevant", own, "GFAZIOLI", "OctoScope", true},
+		{
+			// The defect this function exists for: a watched repo from
+			// another owner that happens to share a bare name must not
+			// inherit the viewer's own fan-out.
+			name:  "same bare name, different owner, must not match",
+			repos: own, owner: "someorg", repo: "octoscope", want: false,
+		},
+		{"repo absent from the account list", own, "gfazioli", "unrelated", false},
+		{
+			// Present in the account but not part of the cluster.
+			name: "account repo outside the burst",
+			repos: append(append([]Repo{}, own...),
+				Repo{Name: "quiet", URL: "https://github.com/gfazioli/quiet"}),
+			owner: "gfazioli", repo: "quiet", want: false,
+		},
+		{"empty account list", nil, "gfazioli", "octoscope", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := repoInBurst(tt.repos, burst, tt.owner, tt.repo); got != tt.want {
+				t.Errorf("repoInBurst(%q/%q) = %v, want %v", tt.owner, tt.repo, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- engine: Axis 4, the account-wide push burst -------------------------
 
 // burstInput builds a scan input that either scores on Axis 1 (two agent
@@ -329,6 +375,24 @@ func TestEvaluateScanPushBurst(t *testing.T) {
 			// *or* current depending on sign; assert it is simply skipped.
 			name:        "zero clock is skipped",
 			in:          burstInput(true, true, now.Add(-5*time.Minute), time.Time{}),
+			wantFinding: false,
+			wantVerdict: VerdictWatch,
+		},
+		{
+			// Mild clock skew must not throw away a genuine detection.
+			name:        "slightly future push still counts as recent",
+			in:          burstInput(true, true, now.Add(30*time.Second), now),
+			wantFinding: true,
+			wantWeight:  wPushBurstCorroboration,
+			wantVerdict: VerdictSuspicious,
+		},
+		{
+			// The one-sided-comparison trap: now.Sub(future) is negative
+			// and would satisfy `age <= recency` forever, so a repo with
+			// a bogus future timestamp would look freshly burst on every
+			// single scan.
+			name:        "absurd future push is not recent",
+			in:          burstInput(true, true, now.AddDate(4, 0, 0), now),
 			wantFinding: false,
 			wantVerdict: VerdictWatch,
 		},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1158,8 +1158,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repoDetail = m.repoDetail.Close()
 		m.prDetail = m.prDetail.Close()
 		m.issueDetail = m.issueDetail.Close()
-		m.scan = m.scan.Open(msg.repo)
-		return m, fetchRepoScanCmd(m.client, owner, name, msg.repo.URL)
+		// Hand the scan the repo list for its push-burst context, via
+		// effectiveStats() rather than m.stats: public-only mode is
+		// documented as screenshot-safe, and a burst derived from
+		// private repos would disclose private push activity in the
+		// report — as a count, but a disclosure either way. Running
+		// without --public-only is how you opt into full coverage.
+		var burstRepos []github.Repo
+		if eff := m.effectiveStats(); eff != nil {
+			burstRepos = eff.Repositories
+		}
+		m.scan = m.scan.Open(msg.repo, burstRepos)
+		return m, fetchRepoScanCmd(m.client, owner, name, msg.repo.URL, burstRepos)
 
 	case repoScanFetchedMsg:
 		// Stale-fetch protection by URL — same idiom as

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -30,6 +30,11 @@ type ScanModel struct {
 	err     error
 	loading bool
 
+	// accountRepos feeds the scan's account-wide push-burst context.
+	// Captured at Open so a retry re-sends it; carries no cost of its
+	// own, being the same backing array the dashboard already holds.
+	accountRepos []github.Repo
+
 	viewport viewport.Model
 }
 
@@ -40,12 +45,17 @@ func (sm ScanModel) IsOpen() bool { return sm.open }
 // Open returns a fresh scan model in the loading state, seeded with
 // the row the user picked. The caller dispatches fetchRepoScanCmd
 // alongside this so the loading state transitions.
-func (sm ScanModel) Open(repo github.Repo) ScanModel {
+//
+// accountRepos is the dashboard's repo list, retained so the push-burst
+// context survives a retry (`r`) — Update has no other route to it.
+// Nil is fine; the scan then runs without timing context.
+func (sm ScanModel) Open(repo github.Repo, accountRepos []github.Repo) ScanModel {
 	return ScanModel{
-		open:     true,
-		repo:     repo,
-		loading:  true,
-		viewport: viewport.New(0, 0),
+		open:         true,
+		repo:         repo,
+		accountRepos: accountRepos,
+		loading:      true,
+		viewport:     viewport.New(0, 0),
 	}
 }
 
@@ -76,7 +86,7 @@ func (sm ScanModel) Update(msg tea.KeyMsg, client *github.Client, width, height 
 		sm.loading = true
 		sm.err = nil
 		sm.scan = nil
-		return sm, fetchRepoScanCmd(client, owner, name, sm.repo.URL)
+		return sm, fetchRepoScanCmd(client, owner, name, sm.repo.URL, sm.accountRepos)
 	case "y":
 		if sm.scan != nil && sm.scan.Verdict >= github.VerdictSuspicious {
 			return sm, copyTextCmd(remediationScript(sm.scan), "Script")
@@ -539,11 +549,11 @@ const scanFetchTimeout = 30 * time.Second
 
 // fetchRepoScanCmd builds the BubbleTea command that runs the scan off
 // the network and returns a repoScanFetchedMsg.
-func fetchRepoScanCmd(client *github.Client, owner, name, url string) tea.Cmd {
+func fetchRepoScanCmd(client *github.Client, owner, name, url string, accountRepos []github.Repo) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), scanFetchTimeout)
 		defer cancel()
-		scan, err := client.FetchRepoScan(ctx, owner, name)
+		scan, err := client.FetchRepoScan(ctx, owner, name, accountRepos)
 		return repoScanFetchedMsg{url: url, scan: scan, err: err}
 	}
 }

--- a/internal/ui/scan_test.go
+++ b/internal/ui/scan_test.go
@@ -99,7 +99,7 @@ func TestScanVerdictStyleDistinctGlyphs(t *testing.T) {
 }
 
 func TestScanModelViewLoading(t *testing.T) {
-	sm := ScanModel{}.Open(github.Repo{URL: "https://github.com/octocat/infected"})
+	sm := ScanModel{}.Open(github.Repo{URL: "https://github.com/octocat/infected"}, nil)
 	out := sm.View(80, 24)
 	if !strings.Contains(out, "Scanning") {
 		t.Errorf("loading view missing 'Scanning': %q", out)
@@ -108,7 +108,7 @@ func TestScanModelViewLoading(t *testing.T) {
 
 func TestScanModelViewLoaded(t *testing.T) {
 	sm := ScanModel{}.
-		Open(github.Repo{URL: "https://github.com/octocat/infected"}).
+		Open(github.Repo{URL: "https://github.com/octocat/infected"}, nil).
 		applyFetched(compromisedScan(), nil)
 
 	// Large height so the whole body sits inside the viewport window.
@@ -125,7 +125,7 @@ func TestScanModelViewLoaded(t *testing.T) {
 		t.Error("compromised verdict should advertise the fix-script key")
 	}
 	clean := ScanModel{}.
-		Open(github.Repo{URL: "https://github.com/octocat/clean"}).
+		Open(github.Repo{URL: "https://github.com/octocat/clean"}, nil).
 		applyFetched(&github.RepoScan{DefaultBranch: "main", Verdict: github.VerdictClean}, nil)
 	if strings.Contains(clean.renderTitle(), "copy fix script") {
 		t.Error("clean verdict must not advertise the fix-script key")


### PR DESCRIPTION
`DetectPushBurst` has been tested but wired to nothing since v0.20.0. It first shipped as an always-on dashboard banner and was pulled for two reasons that still hold:

- **Timing alone cannot separate a worm fan-out from an ordinary batch push.** A maintainer scripting an update across seventeen repositories fires it, and that is a normal Tuesday.
- **No recency gate**, so any historical batch re-alarmed forever.

Folding the signal into the on-demand scan answers both at once, which is what #69 asked for.

## What it does now

The burst is derived inside `FetchRepoScan` from the repo list the caller already holds — arithmetic over `PushedAt`, so it still costs **zero extra API calls** — and then:

- **Gated on one hour of recency.** The reference worm hit five repos in 49 seconds, so a live fan-out sits comfortably inside the window while yesterday's scripted sweep does not. Being tight means a scan run long after the fact loses the corroboration; that is the right way to be wrong, since the axes carrying the actual evidence do not expire.
- **Scores only as corroboration.** `wPushBurstCorroboration` (3) is added **only when the repo already scored on Axes 1-3**, which escalates roughly one tier — a Watch becomes Suspicious — and can never manufacture a verdict from nothing.
- **Still reported when it scores nothing**, at weight 0. The user sees the context and judges it; the report never hides an input. Being weight 0 it stays out of `ScoredFindings()`, so the scored-evidence section doesn't imply it moved the needle.

## Two decisions worth flagging

**The repo list comes from `effectiveStats()`, not `m.stats`.** `--public-only` is documented as screenshot-safe, and a burst spanning private repos would disclose private push activity — as a count rather than by name, but a disclosure all the same. Running without the flag is how you opt into full coverage.

**It is reported under its own `push-burst` label, and is deliberately never called "Axis 4".** A `[provenance]` tag would imply a fact about this repo's commits, which this isn't. And "Axis 4" already means capability escalation in `docs/design/supply-chain-scan.md` — the next item in this cycle (#67) — so reusing the name would have collided with it.

## Verification

Six table cases on the pure `evaluateScan`, covering corroboration, burst-alone, the stale burst, a burst this repo isn't part of, a caller with no repo list, and a zero clock. Plus one asserting a weight-0 burst stays out of scored evidence. `Now` is injected through `scanInput` so the recency gate is testable without a real clock.

A throwaway build-tag smoke test also exercised the real fetch path against the live API before being deleted: a nil repo list produced no burst finding; a forced recent burst including the scanned repo produced one at weight 0 with the verdict unchanged (this repo scores 0 on Axes 1-3), confirming the burst-alone rule end-to-end; and a 72-hour-old burst was dropped by the recency gate. The weight-3 corroboration path is covered by the unit tables, not observed live — that needs a repo that actually scores.

`gofmt`, `go vet`, the hermetic suite and `govulncheck` (CI's pin) are all clean.

Closes #69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scan results now identify recent push bursts across repositories as a distinct finding.
  * Push-burst findings provide additional corroborating context when other evidence is already present.
  * Standalone push bursts are reported without changing the overall verdict.
  * Public-only scans exclude activity from private repositories.

* **Documentation**
  * Clarified push-burst detection, recency requirements, scoring behavior, and public-only handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->