### PR TITLE
feat(scan): report what changed since the last scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,17 @@ direct shortcut you can press from inside the menu to skip selection.
   remediation script (`y`) and the right OAuth-grant revoke links.
   **octoscope never mutates the repo.**
 
+  Each scan also records a fingerprint of the repo's auto-execution
+  surface, so the next one can report **what changed since last time** —
+  a file that auto-executes appeared, an existing one changed, or a
+  branch tip that used to be signed no longer is. That signal survives
+  renames and re-obfuscation, because a variant still has to *appear*.
+  The first scan of a repo says so explicitly rather than passing for a
+  clean comparison, and a baseline older than 30 days reports without
+  affecting the verdict. This is the one file octoscope writes on its
+  own — `scan-baselines.json`, beside your config; deleting it just
+  starts a fresh baseline.
+
 ### Rate-limit awareness
 
 The footer surfaces your GitHub GraphQL budget live:

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -159,17 +159,51 @@ non-negotiables:
 
 ## Baseline / delta
 
-Not implemented yet — tracked as
-[#68](https://github.com/gfazioli/octoscope/issues/68).
+**Shipped in 0.27.0** ([#68](https://github.com/gfazioli/octoscope/issues/68)).
 
-Persist a per-repo fingerprint — the set of ignition-path blob OIDs plus the
-HEAD signature state — then flag **deltas** on a later scan: "a new
-`.vscode/tasks.json` appeared since the last scan", "HEAD on `main` went
-signed → unsigned".
+Every scan records a per-repo fingerprint — the blob OID of each *scoring*
+ignition path, per branch, plus whether each branch tip carried a genuine
+author signature — and diffs the next scan against it.
 
 Delta detection is the most future-proof axis of all: it is both name-agnostic
 *and* content-agnostic. It just notices that something which auto-executes
 changed.
+
+**What scores.** A scoring ignition path that appeared on a branch the baseline
+already knew (`wDeltaNewIgnition`), a known one whose content changed
+(`wDeltaChangedIgnition`), and a branch tip that used to be signed and no longer
+is (`wDeltaSignedRegressed`). Gaining a signature is an improvement and says
+nothing.
+
+**What does not.** Weight-0 surfaces are never fingerprinted: `package.json` and
+editor task files change constantly for ordinary reasons, and diffing them would
+bury real signal under the maintainer's own commits. Nor is a path on a branch
+the baseline never saw — that is new work, not an appearance, or every feature
+branch would alarm.
+
+**The three questions the issue left open, and how they were answered:**
+
+- **Where it lives.** A sibling JSON file, `scan-baselines.json`, next to
+  whichever `config.toml` is in use (so `--config` keeps its state together).
+  Deliberately *not* in the TOML: that file is hand-edited and carefully
+  round-tripped, and filling it with blob OIDs would wreck it. A malformed
+  store degrades to "no baseline" rather than failing the scan — it is
+  machine-written, so refusing to scan over a corrupt cache would trade a
+  security tool for a bookkeeping problem.
+- **First run.** Reported explicitly, at weight 0: *"no previous scan of this
+  repository to compare against"*. Silence would be indistinguishable from
+  "nothing changed", which is the one reading this axis must never support.
+- **Staleness.** Past `baselineMaxAge` (30 days) the deltas are still listed,
+  with their age stated, but stop scoring. A months-old fingerprint diffs into a
+  long list of legitimate changes, and scoring that would train the user to
+  ignore the axis — worse than saying nothing.
+
+Two further consequences worth stating. The store is keyed by `owner/name`, so a
+**rename** reads as a first run: continuity is lost, but no delta is ever
+invented, which is the right way round. And the fingerprint records the
+**verdict at capture time**, so a baseline taken while the repo was already
+flagged makes the report say so — "no change" on top of a compromised baseline
+means nothing has improved, not that all is well.
 
 ## Architecture — tiers inside the complexity ceiling
 

--- a/docs/guide/drill-ins.html
+++ b/docs/guide/drill-ins.html
@@ -66,6 +66,20 @@
           <figcaption>A scan report — verdict, risk score, the scored findings behind it, the auto-execution surface, and per-branch provenance.</figcaption>
         </figure>
 
+        <h3>What changed since last time</h3>
+        <p>Each scan records a fingerprint of the repository's auto-execution surface — which scoring files exist on which branches, and whether each branch tip was signed — and the next scan reports what moved: a file that auto-executes <b>appeared</b>, an existing one <b>changed</b>, or a branch tip that used to be signed <b>no longer is</b>.</p>
+        <p>This is the most durable signal octoscope has, because it cares about neither the filename nor the contents: a variant that renames its dropper and obfuscates it differently still has to <i>appear</i>, and appearing is what gets caught.</p>
+        <ul>
+          <li>The <b>first</b> scan of a repo says so explicitly. No baseline means no comparison — never a confirmed "nothing changed".</li>
+          <li>A baseline older than <b>30 days</b> still lists what changed, but stops affecting the verdict: months of legitimate drift would otherwise train you to ignore it.</li>
+          <li>Everyday files that change constantly — <code>package.json</code>, editor task files — are deliberately not tracked, so real signal doesn't get buried under your own commits.</li>
+        </ul>
+
+        <div class="note">
+          <span class="ic">◑</span>
+          <p>This is the one thing octoscope writes on its own: <code>scan-baselines.json</code>, next to your config file. Deleting it is harmless — the next scan simply starts a new baseline.</p>
+        </div>
+
         <div class="note">
           <span class="ic">↗</span>
           <p>The full detection model — the four axes, the weighting, and the honest gaps — is written up in the <a href="https://github.com/gfazioli/octoscope/blob/main/docs/design/supply-chain-scan.md">supply-chain scan design doc</a>.</p>

--- a/internal/config/baseline.go
+++ b/internal/config/baseline.go
@@ -1,0 +1,135 @@
+package config
+
+// Scan baselines are octoscope's only piece of *machine-written* state,
+// and they deliberately do not live in config.toml. That file is
+// hand-edited and round-tripped carefully to preserve the user's own
+// formatting and lists; filling it with blob OIDs and timestamps would
+// wreck it. They get a sibling JSON file instead, which the user is
+// never expected to open.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// BaselineFingerprint is one repository's recorded auto-execution
+// surface, as captured by a previous scan. A later scan diffs against it
+// to answer the question the content axes cannot: did something that
+// auto-executes *change*?
+//
+// Keys in Ignition are "branch\x00path" — see BaselineKey. Signed maps a
+// branch name to whether its tip carried a genuine author signature.
+type BaselineFingerprint struct {
+	CapturedAt time.Time `json:"captured_at"`
+
+	// Verdict is the scan verdict at the moment of capture. Recorded so
+	// a later report can admit that the baseline was taken when the repo
+	// was *already* flagged — a "no change since last scan" on top of a
+	// compromised baseline means nothing has improved, not that all is
+	// well.
+	Verdict string `json:"verdict"`
+
+	Ignition map[string]string `json:"ignition"`
+	Signed   map[string]bool   `json:"signed"`
+}
+
+// Baselines is the whole store, keyed by "owner/name".
+//
+// A repository rename produces a new key, so the first scan after a
+// rename reads as "no baseline yet" and simply starts a fresh history.
+// That loses continuity but never invents a delta, which is the right
+// way round for a security signal.
+type Baselines struct {
+	Repos map[string]BaselineFingerprint `json:"repos"`
+}
+
+// BaselinePathFor puts the store next to whichever config file is
+// actually in use, so `--config /somewhere/else.toml` keeps its state
+// together with it instead of writing back into the default directory.
+// An empty configPath falls back to BaselinePath.
+func BaselinePathFor(configPath string) string {
+	if configPath == "" {
+		return BaselinePath()
+	}
+	return filepath.Join(filepath.Dir(configPath), "scan-baselines.json")
+}
+
+// BaselinePath returns the baseline store's location, alongside the
+// config file and honouring $XDG_CONFIG_HOME the same way. Returns ""
+// when no usable directory exists, which callers treat as "no
+// persistence available" rather than an error.
+func BaselinePath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "octoscope", "scan-baselines.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "octoscope", "scan-baselines.json")
+}
+
+// LoadBaselines reads the store. A missing file yields an empty store
+// and no error — that is the ordinary first-run state.
+//
+// A *malformed* file also yields an empty store and no error, unlike
+// config.Load which fails loudly. The asymmetry is deliberate: a broken
+// config is a user mistake worth stopping for, whereas this file is
+// machine-written and the user never touches it. Refusing to scan
+// because a cache got corrupted would trade a security tool for a
+// bookkeeping problem. The next successful scan rewrites it.
+func LoadBaselines(path string) Baselines {
+	empty := Baselines{Repos: map[string]BaselineFingerprint{}}
+	if path == "" {
+		return empty
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return empty
+	}
+	var out Baselines
+	if err := json.Unmarshal(b, &out); err != nil {
+		return empty
+	}
+	if out.Repos == nil {
+		out.Repos = map[string]BaselineFingerprint{}
+	}
+	return out
+}
+
+// SaveBaselines writes the store, creating the directory if needed. The
+// write goes to a temp file and is renamed into place so an interrupted
+// save cannot leave a half-written store behind.
+func SaveBaselines(path string, b Baselines) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".scan-baselines-*.json")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}

--- a/internal/config/baseline.go
+++ b/internal/config/baseline.go
@@ -118,17 +118,20 @@ func SaveBaselines(path string, b Baselines) error {
 		return err
 	}
 	tmpName := tmp.Name()
+	// The cleanup calls below run when an error is already in hand and
+	// nothing useful could be done with a second one, so their returns
+	// are discarded explicitly rather than silently.
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return err
 	}
 	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return err
 	}
 	return nil

--- a/internal/config/baseline_test.go
+++ b/internal/config/baseline_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBaselineRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "scan-baselines.json")
+
+	// Missing file is the ordinary first-run state, not an error.
+	if got := LoadBaselines(path); len(got.Repos) != 0 {
+		t.Fatalf("missing file yielded %d repos, want 0", len(got.Repos))
+	}
+
+	when := time.Date(2026, 8, 1, 9, 30, 0, 0, time.UTC)
+	in := Baselines{Repos: map[string]BaselineFingerprint{
+		"gfazioli/octoscope": {
+			CapturedAt: when,
+			Verdict:    "clean",
+			Ignition:   map[string]string{"main\x00.claude/settings.json": "abc123"},
+			Signed:     map[string]bool{"main": true},
+		},
+	}}
+	if err := SaveBaselines(path, in); err != nil {
+		t.Fatalf("SaveBaselines: %v", err)
+	}
+
+	got := LoadBaselines(path)
+	fp, ok := got.Repos["gfazioli/octoscope"]
+	if !ok {
+		t.Fatal("saved repo missing after reload")
+	}
+	if !fp.CapturedAt.Equal(when) {
+		t.Errorf("CapturedAt = %v, want %v", fp.CapturedAt, when)
+	}
+	if fp.Verdict != "clean" {
+		t.Errorf("Verdict = %q, want clean", fp.Verdict)
+	}
+	if fp.Ignition["main\x00.claude/settings.json"] != "abc123" {
+		t.Errorf("ignition OID not preserved: %+v", fp.Ignition)
+	}
+	if !fp.Signed["main"] {
+		t.Error("signed state not preserved")
+	}
+}
+
+// A corrupted store must degrade to "no baseline", never block a scan:
+// it is machine-written state, not a user config worth stopping for.
+func TestLoadBaselinesToleratesGarbage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan-baselines.json")
+	if err := os.WriteFile(path, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got := LoadBaselines(path)
+	if got.Repos == nil {
+		t.Fatal("Repos must be non-nil so callers can index it safely")
+	}
+	if len(got.Repos) != 0 {
+		t.Errorf("garbage yielded %d repos, want 0", len(got.Repos))
+	}
+}
+
+// An empty path means "no persistence available" (no HOME, no XDG) and
+// must be a silent no-op at both ends rather than an error.
+func TestBaselinesEmptyPathIsANoOp(t *testing.T) {
+	if got := LoadBaselines(""); len(got.Repos) != 0 {
+		t.Errorf("empty path yielded %d repos, want 0", len(got.Repos))
+	}
+	if err := SaveBaselines("", Baselines{}); err != nil {
+		t.Errorf("SaveBaselines(\"\") = %v, want nil", err)
+	}
+}
+
+// The save is atomic, so a reader never sees a partial file and no
+// stray temp files are left behind.
+func TestSaveBaselinesLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scan-baselines.json")
+	if err := SaveBaselines(path, Baselines{Repos: map[string]BaselineFingerprint{
+		"o/r": {CapturedAt: time.Now(), Verdict: "watch"},
+	}}); err != nil {
+		t.Fatalf("SaveBaselines: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "scan-baselines.json" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("directory holds %v, want only scan-baselines.json", names)
+	}
+}
+
+func TestBaselinePathHonoursXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-example")
+	want := filepath.Join("/tmp/xdg-example", "octoscope", "scan-baselines.json")
+	if got := BaselinePath(); got != want {
+		t.Errorf("BaselinePath() = %q, want %q", got, want)
+	}
+}

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1022,11 +1022,20 @@ func evaluateScan(in scanInput) *RepoScan {
 		if age < 0 {
 			age = -age
 		}
-		// Past baselineMaxAge the diff is mostly legitimate drift, so it
-		// is reported without weight rather than allowed to score.
-		scoring := age <= baselineMaxAge && !in.Baseline.CapturedAt.IsZero() && !in.Now.IsZero()
+		// Two separate reasons not to score, and they need separate
+		// wording. An unmeasurable age is not an old baseline: a store
+		// entry written before this field existed, or hand-edited,
+		// decodes with a zero CapturedAt, and subtracting from the zero
+		// time yields an age of ~739969 days. Printing that as "the
+		// baseline is 739969 days old" would read as a bug, because it
+		// is one.
+		measurable := !in.Baseline.CapturedAt.IsZero() && !in.Now.IsZero()
+		scoring := measurable && age <= baselineMaxAge
 		stale := ""
-		if !scoring {
+		switch {
+		case !measurable:
+			stale = " (the recorded baseline has no capture time, so its age is unknown and this is reported without affecting the verdict)"
+		case !scoring:
 			stale = fmt.Sprintf(" (baseline is %d days old, so this is reported without affecting the verdict)", int(age.Hours()/24))
 		}
 		weigh := func(w int) int {

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -158,6 +158,65 @@ func DetectPushBurst(repos []Repo, minRepos int, window time.Duration) (PushBurs
 	return best, true
 }
 
+// baselineMaxAge is how long a recorded fingerprint stays useful for
+// *scoring*. Past it the deltas are still reported — with the age
+// stated, so the user can read them — but they no longer move the
+// verdict. A three-month-old baseline diffs into a long list of
+// perfectly legitimate changes, and scoring that would train the user
+// to ignore the axis, which is worse than saying nothing.
+const baselineMaxAge = 30 * 24 * time.Hour
+
+// ScanOptions carries the optional context a scan can use. It exists as
+// a struct rather than more parameters because the list only grows —
+// the burst context arrived with #69, the baseline with #68, and the
+// capability-escalation axis will want its own inputs.
+type ScanOptions struct {
+	// AccountRepos is the caller's already-fetched repo list, used only
+	// to derive the account-wide push-burst context — pure arithmetic
+	// over PushedAt, so it costs no extra API call. Nil means no timing
+	// context.
+	AccountRepos []Repo
+
+	// Baseline is the fingerprint recorded by the previous scan of this
+	// repository, or nil if there is none yet.
+	Baseline *ScanFingerprint
+}
+
+// ScanFingerprint is a repository's auto-execution surface as recorded
+// by one scan: which scoring ignition paths existed on which branches,
+// with the blob OID of each, plus whether each branch tip carried a
+// genuine author signature. A later scan diffs against it to answer the
+// question no content axis can — did something that auto-executes
+// *change*?
+//
+// This is the in-memory, domain-side shape. The on-disk shape lives in
+// internal/config (BaselineFingerprint); the UI layer converts, because
+// it is the only layer that imports both packages. Keep the two in step.
+type ScanFingerprint struct {
+	CapturedAt time.Time
+	Verdict    string
+
+	// Ignition maps fingerprintKey(branch, path) to the path's blob OID.
+	Ignition map[string]string
+	// Signed maps a branch name to whether its tip carried a genuine
+	// author signature. Its key set doubles as "the branches this scan
+	// actually saw", which the delta uses to avoid reporting every path
+	// on a brand-new branch as an appearance.
+	Signed map[string]bool
+}
+
+// fingerprintKey joins a branch and path into a single map key. NUL
+// cannot occur in either, so the join is unambiguous.
+func fingerprintKey(branch, path string) string { return branch + "\x00" + path }
+
+// splitFingerprintKey is fingerprintKey's inverse, for rendering.
+func splitFingerprintKey(k string) (branch, path string) {
+	if i := strings.IndexByte(k, 0); i >= 0 {
+		return k[:i], k[i+1:]
+	}
+	return "", k
+}
+
 // repoInBurst reports whether the repo identified by owner/name is one
 // of the repos the burst was actually computed from.
 //
@@ -324,6 +383,20 @@ const (
 	// provenance anomaly all on the same branch.
 	wCombinedSmokingGun = 4
 
+	// Delta weights. Comparing against a recorded fingerprint is the
+	// most future-proof signal in the design because it is both
+	// name-agnostic and content-agnostic: a variant that renames its
+	// dropper and obfuscates it differently still has to *appear*, and
+	// appearing is what this catches.
+	//
+	// Only paths whose ignition rule scores (weight > 0) are diffed. The
+	// ubiquitous weight-0 surfaces — package.json, an editor task file —
+	// change constantly for entirely ordinary reasons, and diffing them
+	// would bury a real signal under a maintainer's own commits.
+	wDeltaNewIgnition     = 4 // a scoring auto-execution surface that was not there before
+	wDeltaChangedIgnition = 2 // a known one whose content changed
+	wDeltaSignedRegressed = 3 // a branch that used to carry a genuine signature no longer does
+
 	// wPushBurstCorroboration is the account-wide timing signal's
 	// contribution, and it is applied **only to a repo that already
 	// scored on Axis 1-3**. That gate is the whole point: timing alone
@@ -398,6 +471,9 @@ const (
 	AxisIgnition   FindingAxis = "ignition"
 	AxisBlob       FindingAxis = "blob"
 	AxisProvenance FindingAxis = "provenance"
+	// AxisDelta reports what changed since the last recorded scan of
+	// this repo, rather than what is present now.
+	AxisDelta FindingAxis = "delta"
 	// AxisPushBurst is account-wide rather than per-repo: it reports
 	// that this repo was pushed as part of a tight cross-repo cluster.
 	// It is reported even when it scores nothing, so the user sees the
@@ -461,6 +537,13 @@ type RepoScan struct {
 
 	Score   int
 	Verdict ScanVerdict
+
+	// Fingerprint is this scan's own record of the repo's
+	// auto-execution surface, for the caller to persist as the baseline
+	// the *next* scan diffs against. Verdict is filled in with the
+	// verdict this scan reached, so a later report can admit when the
+	// baseline was taken on an already-flagged repo.
+	Fingerprint ScanFingerprint
 }
 
 // IgnitionInventory returns the auto-execution surface (Axis 1),
@@ -488,6 +571,28 @@ func (s *RepoScan) ScoredFindings() []Finding {
 	var out []Finding
 	for _, f := range s.Findings {
 		if f.Weight > 0 {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ContextFindings returns the evidence that was *recorded but not
+// scored* — the weight-0 delta and push-burst entries.
+//
+// This accessor exists because ScoredFindings (weight > 0) and
+// IgnitionInventory (Axis 1) between them do not cover these, so
+// without it the report would silently drop them. That matters most for
+// exactly the ones the design depends on being visible: "no previous
+// scan to compare against" is the guard against a first run reading as
+// a confirmed clean, and it carries weight 0 by definition.
+func (s *RepoScan) ContextFindings() []Finding {
+	var out []Finding
+	for _, f := range s.Findings {
+		if f.Weight > 0 {
+			continue // already shown as scored evidence
+		}
+		if f.Axis == AxisDelta || f.Axis == AxisPushBurst {
 			out = append(out, f)
 		}
 	}
@@ -691,6 +796,12 @@ type scanInput struct {
 	Burst    PushBurst
 	BurstHit bool
 	Now      time.Time
+
+	// Baseline is the fingerprint recorded by the previous scan of this
+	// repo, or nil on the first ever scan. Nil is reported explicitly
+	// rather than silently skipped: "we have nothing to compare against"
+	// must never be allowed to read as "nothing changed".
+	Baseline *ScanFingerprint
 }
 
 // evaluateScan is the pure heart of the detector: it turns gathered
@@ -876,6 +987,125 @@ func evaluateScan(in scanInput) *RepoScan {
 		}
 	}
 
+	// --- fingerprint + delta -------------------------------------------
+	//
+	// Record this scan's surface first, unconditionally: the caller
+	// persists it whatever the verdict, so the next scan always has
+	// something to diff against.
+	s.Fingerprint = ScanFingerprint{
+		CapturedAt: in.Now,
+		Ignition:   map[string]string{},
+		Signed:     map[string]bool{},
+	}
+	for _, b := range in.Branches {
+		s.Fingerprint.Signed[b.Prov.Name] = b.Prov.Signed && !b.Prov.SignedByGitHub
+		for _, m := range b.Matches {
+			if m.Rule.Weight <= 0 {
+				continue // ubiquitous surface; see the delta weights
+			}
+			s.Fingerprint.Ignition[fingerprintKey(b.Prov.Name, m.Path)] = m.BlobSHA
+		}
+	}
+
+	switch {
+	case in.Baseline == nil:
+		// Say so out loud. A first scan has nothing to compare against,
+		// and silence here would be indistinguishable from "nothing
+		// changed" — the one reading this axis must never support.
+		add(Finding{
+			Axis:   AxisDelta,
+			Weight: 0,
+			Reason: "no previous scan of this repository to compare against — this scan records the baseline for the next one",
+		})
+	default:
+		age := in.Now.Sub(in.Baseline.CapturedAt)
+		if age < 0 {
+			age = -age
+		}
+		// Past baselineMaxAge the diff is mostly legitimate drift, so it
+		// is reported without weight rather than allowed to score.
+		scoring := age <= baselineMaxAge && !in.Baseline.CapturedAt.IsZero() && !in.Now.IsZero()
+		stale := ""
+		if !scoring {
+			stale = fmt.Sprintf(" (baseline is %d days old, so this is reported without affecting the verdict)", int(age.Hours()/24))
+		}
+		weigh := func(w int) int {
+			if scoring {
+				return w
+			}
+			return 0
+		}
+
+		// Only diff branches the baseline actually saw. A branch created
+		// since then is new work, and every ignition file on it would
+		// otherwise read as an appearance.
+		//
+		// Iterate in sorted key order: Go randomises map iteration, and
+		// a report whose findings shuffle between two runs of the same
+		// scan is impossible to diff by eye and impossible to test.
+		ignKeys := make([]string, 0, len(s.Fingerprint.Ignition))
+		for k := range s.Fingerprint.Ignition {
+			ignKeys = append(ignKeys, k)
+		}
+		sort.Strings(ignKeys)
+		for _, key := range ignKeys {
+			oid := s.Fingerprint.Ignition[key]
+			branch, path := splitFingerprintKey(key)
+			if _, known := in.Baseline.Signed[branch]; !known {
+				continue
+			}
+			prev, existed := in.Baseline.Ignition[key]
+			switch {
+			case !existed:
+				add(Finding{
+					Axis:   AxisDelta,
+					Branch: branch,
+					Path:   path,
+					Weight: weigh(wDeltaNewIgnition),
+					Reason: fmt.Sprintf("%s appeared on %q since the last scan — it auto-executes and was not there before%s", path, branch, stale),
+				})
+			case prev != oid:
+				add(Finding{
+					Axis:   AxisDelta,
+					Branch: branch,
+					Path:   path,
+					Weight: weigh(wDeltaChangedIgnition),
+					Reason: fmt.Sprintf("%s changed on %q since the last scan (%s → %s)%s", path, branch, shortOID(prev), shortOID(oid), stale),
+				})
+			}
+		}
+
+		// A branch that used to carry a genuine author signature and no
+		// longer does. The reverse — unsigned becoming signed — is an
+		// improvement and says nothing.
+		sigBranches := make([]string, 0, len(s.Fingerprint.Signed))
+		for b := range s.Fingerprint.Signed {
+			sigBranches = append(sigBranches, b)
+		}
+		sort.Strings(sigBranches)
+		for _, branch := range sigBranches {
+			nowSigned := s.Fingerprint.Signed[branch]
+			if was, known := in.Baseline.Signed[branch]; known && was && !nowSigned {
+				add(Finding{
+					Axis:   AxisDelta,
+					Branch: branch,
+					Weight: weigh(wDeltaSignedRegressed),
+					Reason: fmt.Sprintf("the tip of %q was signed at the last scan and no longer is%s", branch, stale),
+				})
+			}
+		}
+
+		// If the baseline was captured while the repo was already
+		// flagged, "nothing changed" means nothing has improved.
+		if in.Baseline.Verdict != "" && in.Baseline.Verdict != VerdictClean.String() {
+			add(Finding{
+				Axis:   AxisDelta,
+				Weight: 0,
+				Reason: fmt.Sprintf("the baseline itself was recorded while this repository was already %q — an absence of changes is not a clean bill of health", in.Baseline.Verdict),
+			})
+		}
+	}
+
 	// The account-wide push burst, evaluated last because whether it
 	// scores depends on what Axis 1-3 already found. Deliberately not
 	// numbered as an axis: "Axis 4" is capability escalation.
@@ -912,6 +1142,9 @@ func evaluateScan(in scanInput) *RepoScan {
 	}
 
 	s.Verdict = verdictFor(s.Score)
+	// Stamp the verdict onto the fingerprint the caller will persist, so
+	// the next scan can tell whether its baseline was a healthy one.
+	s.Fingerprint.Verdict = s.Verdict.String()
 	return s
 }
 
@@ -1083,11 +1316,11 @@ type scanRefsQuery struct {
 // Then the pure evaluateScan reduces the gathered facts to findings +
 // verdict.
 //
-// accountRepos is the caller's already-fetched repo list, used only to
-// derive the account-wide push-burst context — pure arithmetic over
-// PushedAt, so it costs no extra API call. Pass nil when there is none:
-// the scan degrades cleanly to Axis 1-3.
-func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, accountRepos []Repo) (*RepoScan, error) {
+// Everything the scan needs beyond the repo itself arrives in
+// ScanOptions; both of its fields are optional and the scan degrades
+// cleanly without them.
+func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts ScanOptions) (*RepoScan, error) {
+	accountRepos := opts.AccountRepos
 	var q scanRefsQuery
 	vars := map[string]interface{}{
 		"owner": githubv4.String(owner),
@@ -1273,6 +1506,7 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, accountR
 		Branches:      branches,
 		Blobs:         blobs,
 		Now:           time.Now(),
+		Baseline:      opts.Baseline,
 	}
 	// The push burst costs no API call: it is arithmetic over PushedAt
 	// timestamps the caller already holds from the dashboard fetch. An

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -231,6 +231,194 @@ func TestEvaluateScanWatch(t *testing.T) {
 	}
 }
 
+// --- delta: what changed since the recorded baseline ---------------------
+
+// deltaInput builds a scan of one branch carrying one *scoring* ignition
+// path, so the delta axis has something it will actually diff.
+func deltaInput(branch, path, blobSHA string, signed bool, baseline *ScanFingerprint, now time.Time) scanInput {
+	prov := provBranch(branch, true)
+	prov.Signed = signed
+	prov.SignedByGitHub = false
+	return scanInput{
+		Owner: "o", Name: "r", DefaultBranch: branch,
+		BranchesTotal: 1,
+		Branches: []scanBranch{{
+			Prov: prov,
+			Matches: []ignitionMatch{
+				{Path: path, Size: 400, BlobSHA: blobSHA, Rule: ignitionRule{Class: classAgentHook, Weight: wIgnitionAgentHook}},
+			},
+		}},
+		Blobs:    map[string]blobAnalysis{blobSHA: {Size: 400, Fetched: true, IsText: true}},
+		Now:      now,
+		Baseline: baseline,
+	}
+}
+
+func deltaFindings(s *RepoScan) []Finding {
+	var out []Finding
+	for _, f := range s.Findings {
+		if f.Axis == AxisDelta {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func TestEvaluateScanDelta(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	fresh := now.Add(-48 * time.Hour)
+	ancient := now.Add(-120 * 24 * time.Hour)
+	const branch, path = "main", ".claude/settings.json"
+	key := fingerprintKey(branch, path)
+
+	base := func(capturedAt time.Time, ign map[string]string, signed map[string]bool, verdict string) *ScanFingerprint {
+		return &ScanFingerprint{CapturedAt: capturedAt, Verdict: verdict, Ignition: ign, Signed: signed}
+	}
+
+	tests := []struct {
+		name        string
+		in          scanInput
+		wantCount   int
+		wantWeight  int // total weight contributed by delta findings
+		wantContain string
+	}{
+		{
+			// First ever scan: must SAY it has nothing to compare
+			// against, so silence can never read as "nothing changed".
+			name:        "no baseline announces itself",
+			in:          deltaInput(branch, path, "aaa", true, nil, now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "no previous scan",
+		},
+		{
+			name: "unchanged surface produces no delta",
+			in: deltaInput(branch, path, "aaa", true,
+				base(fresh, map[string]string{key: "aaa"}, map[string]bool{branch: true}, "clean"), now),
+			wantCount:  0,
+			wantWeight: 0,
+		},
+		{
+			// The headline signal: something that auto-executes appeared.
+			name: "new ignition path scores",
+			in: deltaInput(branch, path, "aaa", true,
+				base(fresh, map[string]string{}, map[string]bool{branch: true}, "clean"), now),
+			wantCount:   1,
+			wantWeight:  wDeltaNewIgnition,
+			wantContain: "appeared",
+		},
+		{
+			name: "changed content on a known path scores",
+			in: deltaInput(branch, path, "bbb", true,
+				base(fresh, map[string]string{key: "aaa"}, map[string]bool{branch: true}, "clean"), now),
+			wantCount:   1,
+			wantWeight:  wDeltaChangedIgnition,
+			wantContain: "changed",
+		},
+		{
+			name: "signature regression scores",
+			in: deltaInput(branch, path, "aaa", false,
+				base(fresh, map[string]string{key: "aaa"}, map[string]bool{branch: true}, "clean"), now),
+			wantCount:   1,
+			wantWeight:  wDeltaSignedRegressed,
+			wantContain: "no longer is",
+		},
+		{
+			// Gaining a signature is an improvement, not a signal.
+			name: "signature improvement is silent",
+			in: deltaInput(branch, path, "aaa", true,
+				base(fresh, map[string]string{key: "aaa"}, map[string]bool{branch: false}, "clean"), now),
+			wantCount:  0,
+			wantWeight: 0,
+		},
+		{
+			// A branch the baseline never saw is new work, not an
+			// appearance — otherwise every new feature branch alarms.
+			name: "path on a branch the baseline never saw is ignored",
+			in: deltaInput(branch, path, "aaa", true,
+				base(fresh, map[string]string{}, map[string]bool{"other": true}, "clean"), now),
+			wantCount:  0,
+			wantWeight: 0,
+		},
+		{
+			// Stale baselines still report, but must not score: a
+			// months-old diff is mostly legitimate drift.
+			name: "stale baseline reports without scoring",
+			in: deltaInput(branch, path, "aaa", true,
+				base(ancient, map[string]string{}, map[string]bool{branch: true}, "clean"), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "without affecting the verdict",
+		},
+		{
+			// "Nothing changed" on top of an already-bad baseline is not
+			// a clean bill of health, and the report has to say so.
+			name: "baseline taken while already flagged is disclosed",
+			in: deltaInput(branch, path, "aaa", true,
+				base(fresh, map[string]string{key: "aaa"}, map[string]bool{branch: true}, "likely compromised"), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "already",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateScan(tt.in)
+			ds := deltaFindings(got)
+			if len(ds) != tt.wantCount {
+				t.Fatalf("delta findings = %d, want %d: %+v", len(ds), tt.wantCount, ds)
+			}
+			total := 0
+			joined := ""
+			for _, d := range ds {
+				total += d.Weight
+				joined += d.Reason + "\n"
+			}
+			if total != tt.wantWeight {
+				t.Errorf("delta weight = %d, want %d (%s)", total, tt.wantWeight, joined)
+			}
+			if tt.wantContain != "" && !strings.Contains(joined, tt.wantContain) {
+				t.Errorf("delta reason %q does not mention %q", joined, tt.wantContain)
+			}
+		})
+	}
+}
+
+// The fingerprint the caller persists must describe this scan: scoring
+// ignition paths with their blob OIDs, the per-branch signature state,
+// and the verdict reached — the last so a later scan can tell it was
+// baselined against an already-flagged repo.
+func TestScanFingerprintIsRecorded(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	in := deltaInput("main", ".claude/settings.json", "abc123", true, nil, now)
+	// A ubiquitous, weight-0 surface must stay out: diffing package.json
+	// would bury real signal under ordinary commits.
+	in.Branches[0].Matches = append(in.Branches[0].Matches, ignitionMatch{
+		Path: "package.json", Size: 900, BlobSHA: "noise",
+		Rule: ignitionRule{Class: classPackage, Weight: 0},
+	})
+	in.Blobs["noise"] = blobAnalysis{Size: 900, Fetched: true, IsText: true}
+
+	got := evaluateScan(in)
+	fp := got.Fingerprint
+	if !fp.CapturedAt.Equal(now) {
+		t.Errorf("CapturedAt = %v, want %v", fp.CapturedAt, now)
+	}
+	if fp.Verdict != got.Verdict.String() {
+		t.Errorf("Verdict = %q, want %q", fp.Verdict, got.Verdict.String())
+	}
+	if oid := fp.Ignition[fingerprintKey("main", ".claude/settings.json")]; oid != "abc123" {
+		t.Errorf("scoring path OID = %q, want abc123", oid)
+	}
+	if _, ok := fp.Ignition[fingerprintKey("main", "package.json")]; ok {
+		t.Error("weight-0 surface must not be fingerprinted")
+	}
+	if !fp.Signed["main"] {
+		t.Error("branch signature state not recorded")
+	}
+}
+
 // --- burst membership: identity, not bare name ---------------------------
 
 func TestRepoInBurst(t *testing.T) {

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -351,6 +351,18 @@ func TestEvaluateScanDelta(t *testing.T) {
 			wantContain: "without affecting the verdict",
 		},
 		{
+			// A store entry with no captured_at decodes to the zero
+			// time, and measuring an age from it yields ~739969 days.
+			// That must not be dressed up as a very old baseline: it is
+			// an unknown age, and saying so is the honest reading.
+			name: "baseline with no capture time says the age is unknown",
+			in: deltaInput(branch, path, "aaa", true,
+				base(time.Time{}, map[string]string{}, map[string]bool{branch: true}, "clean"), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "age is unknown",
+		},
+		{
 			// "Nothing changed" on top of an already-bad baseline is not
 			// a clean bill of health, and the report has to say so.
 			name: "baseline taken while already flagged is disclosed",

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1168,8 +1168,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if eff := m.effectiveStats(); eff != nil {
 			burstRepos = eff.Repositories
 		}
-		m.scan = m.scan.Open(msg.repo, burstRepos)
-		return m, fetchRepoScanCmd(m.client, owner, name, msg.repo.URL, burstRepos)
+		// The baseline store sits beside whichever config file is in
+		// use, so --config keeps its state together with it.
+		blPath := config.BaselinePathFor(m.configPath)
+		m.scan = m.scan.Open(msg.repo, burstRepos, blPath)
+		return m, fetchRepoScanCmd(m.client, owner, name, msg.repo.URL, burstRepos, blPath)
 
 	case repoScanFetchedMsg:
 		// Stale-fetch protection by URL — same idiom as

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/gfazioli/octoscope/internal/config"
 	"github.com/gfazioli/octoscope/internal/github"
 )
 
@@ -34,6 +35,9 @@ type ScanModel struct {
 	// Captured at Open so a retry re-sends it; carries no cost of its
 	// own, being the same backing array the dashboard already holds.
 	accountRepos []github.Repo
+	// baselinePath is retained for the same reason as accountRepos:
+	// Update has no route to it when the user retries with `r`.
+	baselinePath string
 
 	viewport viewport.Model
 }
@@ -49,11 +53,12 @@ func (sm ScanModel) IsOpen() bool { return sm.open }
 // accountRepos is the dashboard's repo list, retained so the push-burst
 // context survives a retry (`r`) — Update has no other route to it.
 // Nil is fine; the scan then runs without timing context.
-func (sm ScanModel) Open(repo github.Repo, accountRepos []github.Repo) ScanModel {
+func (sm ScanModel) Open(repo github.Repo, accountRepos []github.Repo, baselinePath string) ScanModel {
 	return ScanModel{
 		open:         true,
 		repo:         repo,
 		accountRepos: accountRepos,
+		baselinePath: baselinePath,
 		loading:      true,
 		viewport:     viewport.New(0, 0),
 	}
@@ -86,7 +91,7 @@ func (sm ScanModel) Update(msg tea.KeyMsg, client *github.Client, width, height 
 		sm.loading = true
 		sm.err = nil
 		sm.scan = nil
-		return sm, fetchRepoScanCmd(client, owner, name, sm.repo.URL, sm.accountRepos)
+		return sm, fetchRepoScanCmd(client, owner, name, sm.repo.URL, sm.accountRepos, sm.baselinePath)
 	case "y":
 		if sm.scan != nil && sm.scan.Verdict >= github.VerdictSuspicious {
 			return sm, copyTextCmd(remediationScript(sm.scan), "Script")
@@ -226,6 +231,20 @@ func (sm ScanModel) computeBody(width int) string {
 	} else {
 		b.WriteString(okStyle.Render("No anomalies scored.") +
 			mutedStyle.Render(" The auto-execution surface below is informational."))
+		b.WriteString("\n\n")
+	}
+
+	// ---- Context: recorded but not scored (delta / push-burst)
+	//
+	// These carry weight 0, so neither the scored-findings section nor
+	// the ignition inventory would show them, and they would vanish. The
+	// first-run notice in particular has to be visible: a scan with no
+	// baseline must not be readable as a confirmed "nothing changed".
+	if ctx := s.ContextFindings(); len(ctx) > 0 {
+		b.WriteString(subSectionTitleStyle.Render("Context"))
+		b.WriteString("  " + mutedStyle.Render("noted, does not affect the verdict"))
+		b.WriteString("\n")
+		b.WriteString(renderFindings(ctx, width))
 		b.WriteString("\n\n")
 	}
 
@@ -549,11 +568,48 @@ const scanFetchTimeout = 30 * time.Second
 
 // fetchRepoScanCmd builds the BubbleTea command that runs the scan off
 // the network and returns a repoScanFetchedMsg.
-func fetchRepoScanCmd(client *github.Client, owner, name, url string, accountRepos []github.Repo) tea.Cmd {
+// Both the baseline read and the write happen in here rather than in
+// Update: they touch the disk, and Update must return promptly.
+func fetchRepoScanCmd(client *github.Client, owner, name, url string, accountRepos []github.Repo, baselinePath string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), scanFetchTimeout)
 		defer cancel()
-		scan, err := client.FetchRepoScan(ctx, owner, name, accountRepos)
+
+		key := owner + "/" + name
+		store := config.LoadBaselines(baselinePath)
+		var prev *github.ScanFingerprint
+		if fp, ok := store.Repos[key]; ok {
+			prev = &github.ScanFingerprint{
+				CapturedAt: fp.CapturedAt,
+				Verdict:    fp.Verdict,
+				Ignition:   fp.Ignition,
+				Signed:     fp.Signed,
+			}
+		}
+
+		scan, err := client.FetchRepoScan(ctx, owner, name, github.ScanOptions{
+			AccountRepos: accountRepos,
+			Baseline:     prev,
+		})
+
+		// Record this scan as the baseline for the next one — whatever
+		// the verdict, so a compromised repo still gets a history. A
+		// failed write is swallowed on purpose: losing the baseline
+		// costs the delta axis on the next run, and that is not worth
+		// failing a completed scan over.
+		if err == nil && scan != nil && baselinePath != "" {
+			if store.Repos == nil {
+				store.Repos = map[string]config.BaselineFingerprint{}
+			}
+			store.Repos[key] = config.BaselineFingerprint{
+				CapturedAt: scan.Fingerprint.CapturedAt,
+				Verdict:    scan.Fingerprint.Verdict,
+				Ignition:   scan.Fingerprint.Ignition,
+				Signed:     scan.Fingerprint.Signed,
+			}
+			_ = config.SaveBaselines(baselinePath, store)
+		}
+
 		return repoScanFetchedMsg{url: url, scan: scan, err: err}
 	}
 }

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -298,7 +298,14 @@ func renderFindings(findings []github.Finding, width int) string {
 	var lines []string
 	for _, f := range findings {
 		tag := mutedStyle.Render("[" + string(f.Axis) + "]")
-		weight := warnStyle.Render(fmt.Sprintf("+%d", f.Weight))
+		// A weight-0 entry (the Context section) gets no "+0" column: a
+		// warn-coloured zero contradicts the header telling the reader
+		// these do not affect the verdict. Blank keeps the rows aligned
+		// with the scored ones above.
+		weight := mutedStyle.Render("  ")
+		if f.Weight > 0 {
+			weight = warnStyle.Render(fmt.Sprintf("+%d", f.Weight))
+		}
 		reason := f.Reason
 		if f.Branch != "" {
 			reason = fmt.Sprintf("%s  %s", reason, mutedStyle.Render("· "+f.Branch))

--- a/internal/ui/scan_test.go
+++ b/internal/ui/scan_test.go
@@ -99,7 +99,7 @@ func TestScanVerdictStyleDistinctGlyphs(t *testing.T) {
 }
 
 func TestScanModelViewLoading(t *testing.T) {
-	sm := ScanModel{}.Open(github.Repo{URL: "https://github.com/octocat/infected"}, nil)
+	sm := ScanModel{}.Open(github.Repo{URL: "https://github.com/octocat/infected"}, nil, "")
 	out := sm.View(80, 24)
 	if !strings.Contains(out, "Scanning") {
 		t.Errorf("loading view missing 'Scanning': %q", out)
@@ -108,7 +108,7 @@ func TestScanModelViewLoading(t *testing.T) {
 
 func TestScanModelViewLoaded(t *testing.T) {
 	sm := ScanModel{}.
-		Open(github.Repo{URL: "https://github.com/octocat/infected"}, nil).
+		Open(github.Repo{URL: "https://github.com/octocat/infected"}, nil, "").
 		applyFetched(compromisedScan(), nil)
 
 	// Large height so the whole body sits inside the viewport window.
@@ -125,9 +125,36 @@ func TestScanModelViewLoaded(t *testing.T) {
 		t.Error("compromised verdict should advertise the fix-script key")
 	}
 	clean := ScanModel{}.
-		Open(github.Repo{URL: "https://github.com/octocat/clean"}, nil).
+		Open(github.Repo{URL: "https://github.com/octocat/clean"}, nil, "").
 		applyFetched(&github.RepoScan{DefaultBranch: "main", Verdict: github.VerdictClean}, nil)
 	if strings.Contains(clean.renderTitle(), "copy fix script") {
 		t.Error("clean verdict must not advertise the fix-script key")
+	}
+}
+
+// A weight-0 finding is invisible to both ScoredFindings and the
+// ignition inventory, so without the Context section the first-run
+// notice would never reach the screen — and a scan with no baseline
+// would read as a confirmed "nothing changed". Assert on the rendered
+// output, not on the data.
+func TestScanViewShowsContextFindings(t *testing.T) {
+	scan := &github.RepoScan{
+		DefaultBranch: "main",
+		Verdict:       github.VerdictClean,
+		Findings: []github.Finding{{
+			Axis:   github.AxisDelta,
+			Weight: 0,
+			Reason: "no previous scan of this repository to compare against — this scan records the baseline for the next one",
+		}},
+	}
+	sm := ScanModel{}.
+		Open(github.Repo{URL: "https://github.com/octocat/fresh"}, nil, "").
+		applyFetched(scan, nil)
+
+	out := sm.View(120, 200)
+	for _, want := range []string{"Context", "no previous scan"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered report is missing %q:\n%s", want, out)
+		}
 	}
 }

--- a/internal/ui/scan_test.go
+++ b/internal/ui/scan_test.go
@@ -158,3 +158,26 @@ func TestScanViewShowsContextFindings(t *testing.T) {
 		}
 	}
 }
+
+// Context rows must not carry a "+0" weight column: a warn-coloured
+// zero contradicts the header that calls them verdict-neutral, and the
+// scored rows above are the only place a weight belongs.
+func TestContextRowsCarryNoWeightColumn(t *testing.T) {
+	scan := &github.RepoScan{
+		DefaultBranch: "main",
+		Verdict:       github.VerdictWatch,
+		Score:         2,
+		Findings: []github.Finding{
+			{Axis: github.AxisIgnition, Branch: "main", Path: ".claude/settings.json", Weight: 2, Reason: "agent hook present"},
+			{Axis: github.AxisDelta, Weight: 0, Reason: "no previous scan of this repository to compare against"},
+		},
+	}
+	out := ansi.Strip(ScanModel{scan: scan}.computeBody(120))
+	if strings.Contains(out, "+0") {
+		t.Errorf("a weight-0 context row rendered a +0 column:\n%s", out)
+	}
+	// The scored row must still show its weight.
+	if !strings.Contains(out, "+2") {
+		t.Errorf("scored finding lost its weight column:\n%s", out)
+	}
+}


### PR DESCRIPTION
The scan could only ever describe a repository in absolutes: what auto-executes right now, whether a tip looks forged. It could not answer what the design calls its most future-proof question — did something that auto-executes *change*? A variant that renames its dropper and obfuscates it differently defeats every content axis, but it still has to appear, and appearing is what a delta catches.

## What it does

Every scan now records a fingerprint — the blob OID of each *scoring* ignition path, per branch, plus whether each branch tip carried a genuine author signature — and the next scan diffs against it:

- a scoring auto-execution surface **appeared** on a branch the baseline already knew
- a known one's **content changed**
- a branch tip that used to be signed **no longer is**

Gaining a signature is an improvement and stays silent.

## The three open questions, answered

**Where it lives.** A sibling `scan-baselines.json` next to whichever `config.toml` is in use, so `--config` keeps its state together. Deliberately *not* inside the TOML: that file is hand-edited and carefully round-tripped, and filling it with blob OIDs would wreck it. A corrupt store degrades to "no baseline" rather than failing the scan — it is machine-written state, and refusing to scan over a bad cache would trade a security tool for a bookkeeping problem.

**First run.** Announced explicitly, at weight 0: *"no previous scan of this repository to compare against"*. Silence would be indistinguishable from "nothing changed", which is the one reading this axis must never support.

**Staleness.** Past 30 days the deltas are still listed, with their age stated, but stop scoring. A months-old fingerprint diffs into a long list of legitimate changes, and scoring that would train the user to ignore the axis — worse than saying nothing.

Two further calls: weight-0 surfaces are never fingerprinted (`package.json` and editor task files change constantly, and diffing them would bury real signal under the maintainer's own commits), and a path on a branch the baseline never saw is skipped, because that is new work rather than an appearance — otherwise every feature branch alarms. A rename reads as a first run: continuity is lost, but no delta is ever invented.

## A defect this would have inherited

The report renderer only ever showed `ScoredFindings()` and the ignition inventory, so **every weight-0 finding was invisible** — including the push-burst notice added in #69, and, far worse, the first-run notice this change depends on being seen. A scan with no baseline would have looked like a confirmed clean.

There is now a `Context` section for recorded-but-unscored evidence, labelled *"noted, does not affect the verdict"*, and a render-level test that asserts the first-run notice actually reaches the screen rather than merely existing in the data.

## Verification

Nine table cases on the pure `evaluateScan` covering the whole delta matrix, one on the fingerprint's contents (including that weight-0 surfaces stay out), five on the store (round-trip, corrupt file, empty path, atomic write leaving no temp files, XDG).

A throwaway smoke test also exercised the real fetch path end to end before being deleted:

- first scan announced the missing baseline at weight 0 and produced a fingerprint stamped with its verdict
- re-scanning against that just-taken fingerprint produced **no** delta and left the score untouched
- a doctored baseline claiming `main` had been signed produced the regression at weight 3, moving the score 0 → 3 and the verdict `clean` → `watch` — a real tier escalation, live
- the same baseline aged to 200 days still reported its deltas and scored **zero**

One gap, stated plainly: the *appearance* path (`wDeltaNewIgnition`) is covered by the unit tables but was not observed live, because octoscope itself has no scoring ignition path to make vanish. The sibling scoring path was verified live instead.

`gofmt`, `go vet`, the hermetic suite and `govulncheck` (CI's pin) are clean. README, the guide's drill-in page and the design doc are all updated — including the fact that this is the one file octoscope writes on its own.

Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository security scans now compare results with previous scans.
  * Reports highlight newly appearing or changed execution surfaces and branch-signing regressions.
  * Initial scans clearly indicate when no comparison baseline exists.
  * Context-only findings are shown separately when they do not affect the score.
  * Baselines older than 30 days are reported without changing the scan verdict.
  * Comparison history can be reset by deleting the generated baseline file.
* **Documentation**
  * Added guidance on scan comparisons, baseline expiration, excluded files, and resetting history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->