### PR TITLE
feat(scan): capability escalation — what a compromise could reach

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,17 @@ direct shortcut you can press from inside the menu to skip selection.
   own — `scan-baselines.json`, beside your config; deleting it just
   starts a fresh baseline.
 
+  It also reports your **capability footprint** — what a compromise of
+  the repo could reach. Workflow permissions and triggers are read from
+  the files it already fetched, plus self-hosted runners, write deploy
+  keys and off-platform webhooks. Holding power is not itself a finding:
+  a release workflow with `contents: write` on a tag push is normal and
+  stays inventory. What scores is power reachable from *untrusted
+  input* — a `pull_request_target` workflow holding the repo's secrets,
+  or a self-hosted runner an outsider's pull request can reach. The
+  probes that need admin scope **fail open** on a minimal token, and the
+  report says which ones it could not check.
+
 ### Rate-limit awareness
 
 The footer surfaces your GitHub GraphQL budget live:

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -123,16 +123,51 @@ feature branch is normal and must not score.
 
 ## Axis 4 — capability escalation
 
-Not implemented yet — tracked as
-[#67](https://github.com/gfazioli/octoscope/issues/67).
+**Shipped in 0.27.0** ([#67](https://github.com/gfazioli/octoscope/issues/67)).
 
-- **Workflow permissions and triggers** — `.github/workflows/**` requesting
-  `contents: write` or `id-token: write`, using `pull_request_target`, or
-  exposing secrets in a fork-triggered context
-- **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`
-  (needs admin scope)
-- **New deploy keys and webhooks** — `GET /repos/{owner}/{repo}/keys` and
-  `/hooks`, especially write keys or hooks pointing off-platform
+The persistence and exfiltration footprint: what a compromise of this
+repository would be able to reach.
+
+**Capability alone is never scored, and that is the design.** octoscope's own
+`release.yml` requests `contents: write` and reads two secrets, and it is
+entirely correct — it fires on a tag push, so only someone who can already push
+tags can reach it. Scoring power by itself would flag a large share of GitHub
+and teach everyone to ignore the axis. What scores is power reachable from
+**untrusted input**.
+
+- **Workflow permissions and triggers** — parsed from `.github/workflows/**`,
+  which the scan already fetches, so this half costs no extra API call. The
+  fork-triggered events are `pull_request_target`, `workflow_run` and
+  `issue_comment`: each runs with the base repository's token and secrets while
+  acting on input an outsider controls. `pull_request` is deliberately not one
+  of them — a fork PR there gets a read-only token and no secrets.
+  - fork trigger **+** secrets or write scopes → scores `wCapEscalation`
+  - elevated scopes on a trusted trigger → inventory, weight 0
+  - a bare fork trigger with neither → inventory, weight 0
+  - `permissions: write-all` → `wCapWriteAll` on any trigger, because it hands
+    over every scope rather than the one needed
+  - a workflow that will not parse is reported as **not understood**, never as
+    checked-and-clean
+
+  Parsing uses a real YAML parser rather than line matching: flow style
+  (`permissions: {contents: write}`) and anchors are valid YAML and trivially
+  defeat a scanner that reads lines. Note the YAML 1.1 trap — a bare `on:` key
+  decodes as the boolean `true`, so both spellings are looked up.
+
+- **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`.
+  Inventory on their own; they score only when the repository *also* has a
+  fork-triggered workflow, because that combination is outsider-supplied code
+  executing on hardware you own.
+- **Deploy keys and webhooks** — `GET /repos/{owner}/{repo}/keys` and `/hooks`.
+  Write keys and active off-platform hook targets are reported as inventory:
+  both are ordinary in healthy repositories, and what would make one suspicious
+  is its *appearance*, which the delta axis is the right place to catch.
+
+**The invariant.** No single axis may reach a high tier alone. Capability's
+worst shape — a fork trigger holding secrets *and* `write-all` — sums to 4,
+below `tSuspicious`, so it lands on Watch and needs a second axis to agree
+before the verdict escalates. `TestCapabilityAloneCannotReachSuspicious` pins
+this, and it caught the first weighting, which reached Suspicious on its own.
 
 These calls need elevated scope, so a 403 must not fail the scan. But *not
 failing* is different from *not saying*: *a security report that hides its own

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -151,8 +151,11 @@ and teach everyone to ignore the axis. What scores is power reachable from
 
   Parsing uses a real YAML parser rather than line matching: flow style
   (`permissions: {contents: write}`) and anchors are valid YAML and trivially
-  defeat a scanner that reads lines. Note the YAML 1.1 trap — a bare `on:` key
-  decodes as the boolean `true`, so both spellings are looked up.
+  defeat a scanner that reads lines. On the YAML 1.1 `on`-as-boolean trap:
+  measured against `yaml.v3`, decoding into `map[string]any` keeps the key as
+  the string `"on"`, and only a typed target such as `map[bool]any` resolves it
+  to `true`. The parser looks up both spellings as cheap insurance against a
+  change of decode target, not because the boolean form occurs today.
 
 - **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`.
   Inventory on their own; they score only when the repository *also* has a

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -163,11 +163,26 @@ and teach everyone to ignore the axis. What scores is power reachable from
   both are ordinary in healthy repositories, and what would make one suspicious
   is its *appearance*, which the delta axis is the right place to catch.
 
-**The invariant.** No single axis may reach a high tier alone. Capability's
-worst shape — a fork trigger holding secrets *and* `write-all` — sums to 4,
-below `tSuspicious`, so it lands on Watch and needs a second axis to agree
-before the verdict escalates. `TestCapabilityAloneCannotReachSuspicious` pins
-this, and it caught the first weighting, which reached Suspicious on its own.
+**Known limitation — reusable workflows.** Each workflow file is assessed on
+its own, so a chain is not composed: a `pull_request_target` caller that invokes
+`./.github/workflows/reusable.yml` with `secrets: inherit` is caught (the
+caller's `secrets: inherit` counts as reaching secrets), but a callee that reads
+a secret the caller passed *by name* is scored independently, and on its own
+`workflow_call` is not untrusted input. Joining caller and callee needs a
+cross-file pass this axis does not yet do.
+
+**Known limitation — implicit default permissions.** A workflow with no
+`permissions:` block inherits the repository's default, which an organisation
+can set to write. The parser reads only what the file declares, so such a
+workflow reads as holding no write scope. Resolving it needs repository
+permission-default context.
+
+**The invariant.** No single axis may reach a high tier alone. Bounding each finding is not
+enough — a review caught one fork-triggered secret-bearing workflow (3) plus a
+reachable self-hosted runner (3) summing to 6 with no second axis agreeing — so
+the axis carries an aggregate ceiling (`maxCapabilityScore`, one below
+`tSuspicious`). Findings past the ceiling are still reported, at weight 0: the
+arithmetic is clamped, not the disclosure.
 
 These calls need elevated scope, so a 403 must not fail the scan. But *not
 failing* is different from *not saying*: *a security report that hides its own

--- a/docs/guide/drill-ins.html
+++ b/docs/guide/drill-ins.html
@@ -80,6 +80,15 @@
           <p>This is the one thing octoscope writes on its own: <code>scan-baselines.json</code>, next to your config file. Deleting it is harmless — the next scan simply starts a new baseline.</p>
         </div>
 
+        <h3>What a compromise could reach</h3>
+        <p>The scan also reads your <b>capability footprint</b>: what permissions and triggers your workflows declare, plus self-hosted runners, write-access deploy keys and webhooks delivering off GitHub.</p>
+        <p>Holding power is not itself a finding. A release workflow asking for <code>contents: write</code> and reading secrets is completely normal — only someone who can already push a tag can trigger it, so it stays inventory. What scores is power reachable from <b>untrusted input</b>: a <code>pull_request_target</code> workflow holding the repository's secrets, or a self-hosted runner that an outsider's pull request can reach.</p>
+
+        <div class="note">
+          <span class="ic">◑</span>
+          <p>Runners, deploy keys and webhooks need a token scope a minimal token won't have. Those checks <b>fail open</b> — the scan still runs — and the report names whichever ones it couldn't check, so a clean result is never mistaken for a complete one.</p>
+        </div>
+
         <div class="note">
           <span class="ic">↗</span>
           <p>The full detection model — the four axes, the weighting, and the honest gaps — is written up in the <a href="https://github.com/gfazioli/octoscope/blob/main/docs/design/supply-chain-scan.md">supply-chain scan design doc</a>.</p>

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
 	golang.org/x/oauth2 v0.36.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,7 @@ golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
 golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/github/capability.go
+++ b/internal/github/capability.go
@@ -1,0 +1,175 @@
+package github
+
+// Axis 4 — capability escalation, the elevated-scope half.
+//
+// Self-hosted runners, deploy keys and webhooks describe what a
+// compromise of this repository could reach: someone else's hardware,
+// a persistent write credential, an off-platform delivery path.
+//
+// Every probe here needs a token scope a minimal token will not have,
+// so all three **fail open**: a 403 is not an error worth interrupting
+// anyone for. Failing open is not the same as staying quiet, though.
+// Whatever could not be checked is recorded and surfaced, because a
+// security report that hides its own blind spots is worse than one that
+// admits them (#85, and the same rule the partial-branch disclosure
+// follows).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// UncheckedProbe names a capability probe that did not run, and why, so
+// the report can say so rather than let a clean verdict read as
+// complete.
+type UncheckedProbe struct {
+	Name   string
+	Reason string
+}
+
+// capabilityProbes is the gathered result of the elevated-scope half.
+type capabilityProbes struct {
+	SelfHostedRunners []string // runner labels/names
+	WriteDeployKeys   []string // titles of keys that are not read-only
+	OffPlatformHooks  []string // hook targets outside github.com
+	Unchecked         []UncheckedProbe
+}
+
+// restList performs one authenticated GET and decodes into out. It
+// reports checked=false with a human reason for the statuses that mean
+// "your token cannot see this", rather than returning an error: those
+// are expected on a minimal token and must not fail the scan.
+func (c *Client) restList(ctx context.Context, path string, out any) (checked bool, reason string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com"+path, nil)
+	if err != nil {
+		return false, "request could not be built"
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.rest.Do(req)
+	if err != nil {
+		return false, "the request did not complete"
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusForbidden, resp.StatusCode == http.StatusUnauthorized:
+		return false, "the token lacks the scope this needs"
+	case resp.StatusCode == http.StatusNotFound:
+		// GitHub returns 404 rather than 403 for some resources a token
+		// may not see, so this is indistinguishable from "none exist".
+		// Saying so is more honest than assuming either.
+		return false, "not visible to this token"
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return false, fmt.Sprintf("GitHub answered %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return false, "the response could not be read"
+	}
+	return true, ""
+}
+
+// fetchCapabilityProbes runs the three elevated-scope probes
+// concurrently. It never returns an error: everything that goes wrong
+// becomes an entry in Unchecked.
+func (c *Client) fetchCapabilityProbes(ctx context.Context, owner, name string) capabilityProbes {
+	base := fmt.Sprintf("/repos/%s/%s", url.PathEscape(owner), url.PathEscape(name))
+
+	var (
+		mu  sync.Mutex
+		out capabilityProbes
+		wg  sync.WaitGroup
+	)
+	skip := func(n, why string) {
+		mu.Lock()
+		out.Unchecked = append(out.Unchecked, UncheckedProbe{Name: n, Reason: why})
+		mu.Unlock()
+	}
+
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		var payload struct {
+			Runners []struct {
+				Name   string `json:"name"`
+				Status string `json:"status"`
+			} `json:"runners"`
+		}
+		ok, why := c.restList(ctx, base+"/actions/runners", &payload)
+		if !ok {
+			skip("self-hosted runners", why)
+			return
+		}
+		mu.Lock()
+		for _, r := range payload.Runners {
+			out.SelfHostedRunners = append(out.SelfHostedRunners, Sanitize(r.Name))
+		}
+		mu.Unlock()
+	}()
+
+	go func() {
+		defer wg.Done()
+		var keys []struct {
+			Title    string `json:"title"`
+			ReadOnly bool   `json:"read_only"`
+		}
+		ok, why := c.restList(ctx, base+"/keys", &keys)
+		if !ok {
+			skip("deploy keys", why)
+			return
+		}
+		mu.Lock()
+		for _, k := range keys {
+			if !k.ReadOnly {
+				out.WriteDeployKeys = append(out.WriteDeployKeys, Sanitize(k.Title))
+			}
+		}
+		mu.Unlock()
+	}()
+
+	go func() {
+		defer wg.Done()
+		var hooks []struct {
+			Active bool `json:"active"`
+			Config struct {
+				URL string `json:"url"`
+			} `json:"config"`
+		}
+		ok, why := c.restList(ctx, base+"/hooks", &hooks)
+		if !ok {
+			skip("webhooks", why)
+			return
+		}
+		mu.Lock()
+		for _, h := range hooks {
+			if !h.Active || h.Config.URL == "" {
+				continue
+			}
+			if host := hookHost(h.Config.URL); host != "" && !strings.HasSuffix(host, "github.com") {
+				out.OffPlatformHooks = append(out.OffPlatformHooks, Sanitize(host))
+			}
+		}
+		mu.Unlock()
+	}()
+
+	wg.Wait()
+	return out
+}
+
+// hookHost extracts a webhook target's host. A URL that will not parse
+// yields "", which the caller treats as nothing to report rather than
+// guessing — the same reasoning as querying URL fields as strings.
+func hookHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}

--- a/internal/github/capability.go
+++ b/internal/github/capability.go
@@ -45,7 +45,17 @@ type capabilityProbes struct {
 // "your token cannot see this", rather than returning an error: those
 // are expected on a minimal token and must not fail the scan.
 func (c *Client) restList(ctx context.Context, path string, out any) (checked bool, reason string) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com"+path, nil)
+	// Ask for the largest page GitHub allows. Without this the default
+	// is 30, and a repository's only write-capable deploy key could sit
+	// on page two — omitted from the report while the probe still
+	// claimed to have checked. More than 100 is declared rather than
+	// silently walked: paging is unbounded work inside a scan that is
+	// deliberately bounded everywhere else.
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com"+path+sep+"per_page=100", nil)
 	if err != nil {
 		return false, "request could not be built"
 	}
@@ -72,7 +82,16 @@ func (c *Client) restList(ctx context.Context, path string, out any) (checked bo
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return false, "the response could not be read"
 	}
+	if hasNextPage(resp.Header.Get("Link")) {
+		return true, "more than 100 entries — only the first page was read"
+	}
 	return true, ""
+}
+
+// hasNextPage reports whether GitHub's Link header advertises another
+// page, which is how a truncated list announces itself.
+func hasNextPage(link string) bool {
+	return strings.Contains(link, `rel="next"`)
 }
 
 // fetchCapabilityProbes runs the three elevated-scope probes
@@ -107,6 +126,10 @@ func (c *Client) fetchCapabilityProbes(ctx context.Context, owner, name string) 
 			skip("self-hosted runners", why)
 			return
 		}
+		if why != "" {
+			// Checked, but not exhaustively — still a coverage gap.
+			skip("self-hosted runners", why)
+		}
 		mu.Lock()
 		for _, r := range payload.Runners {
 			out.SelfHostedRunners = append(out.SelfHostedRunners, Sanitize(r.Name))
@@ -124,6 +147,10 @@ func (c *Client) fetchCapabilityProbes(ctx context.Context, owner, name string) 
 		if !ok {
 			skip("deploy keys", why)
 			return
+		}
+		if why != "" {
+			// Checked, but not exhaustively — still a coverage gap.
+			skip("deploy keys", why)
 		}
 		mu.Lock()
 		for _, k := range keys {
@@ -147,12 +174,16 @@ func (c *Client) fetchCapabilityProbes(ctx context.Context, owner, name string) 
 			skip("webhooks", why)
 			return
 		}
+		if why != "" {
+			// Checked, but not exhaustively — still a coverage gap.
+			skip("webhooks", why)
+		}
 		mu.Lock()
 		for _, h := range hooks {
 			if !h.Active || h.Config.URL == "" {
 				continue
 			}
-			if host := hookHost(h.Config.URL); host != "" && !strings.HasSuffix(host, "github.com") {
+			if host := hookHost(h.Config.URL); host != "" && !isGitHubHost(host) {
 				out.OffPlatformHooks = append(out.OffPlatformHooks, Sanitize(host))
 			}
 		}
@@ -161,6 +192,14 @@ func (c *Client) fetchCapabilityProbes(ctx context.Context, owner, name string) 
 
 	wg.Wait()
 	return out
+}
+
+// isGitHubHost matches github.com and its subdomains only. A plain
+// HasSuffix check would read "evilgithub.com" as GitHub infrastructure
+// and drop it from the report — the classic suffix-without-a-boundary
+// bug, and here it hides exactly the exfiltration target that matters.
+func isGitHubHost(host string) bool {
+	return host == "github.com" || strings.HasSuffix(host, ".github.com")
 }
 
 // hookHost extracts a webhook target's host. A URL that will not parse

--- a/internal/github/capability_test.go
+++ b/internal/github/capability_test.go
@@ -1,0 +1,141 @@
+package github
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestRESTClient points a Client's REST transport at a local server
+// that dispatches on request path, so the capability probes can be
+// exercised without the network. Reuses rewriteHost, the same harness
+// the GraphQL fetch tests use.
+func newTestRESTClient(t *testing.T, routes map[string]func(w http.ResponseWriter)) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for suffix, h := range routes {
+			if strings.HasSuffix(r.URL.Path, suffix) {
+				w.Header().Set("Content-Type", "application/json")
+				h(w)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"message":"not found"}`)
+	}))
+	t.Cleanup(srv.Close)
+	httpClient := &http.Client{Transport: &rewriteHost{host: srv.URL}}
+	return &Client{rest: httpClient, authenticated: true}
+}
+
+func json200(body string) func(http.ResponseWriter) {
+	return func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}
+}
+
+func status(code int) func(http.ResponseWriter) {
+	return func(w http.ResponseWriter) {
+		w.WriteHeader(code)
+		_, _ = io.WriteString(w, `{"message":"nope"}`)
+	}
+}
+
+// The mixed case a real minimal token produces: some probes answer,
+// others are refused. Run under -race this also exercises the three
+// concurrent goroutines, which no other test reaches.
+func TestFetchCapabilityProbesMixed(t *testing.T) {
+	c := newTestRESTClient(t, map[string]func(http.ResponseWriter){
+		"/actions/runners": json200(`{"runners":[{"name":"build-box","status":"online"}]}`),
+		"/keys":            status(http.StatusForbidden),
+		"/hooks": json200(`[
+			{"active":true,"config":{"url":"https://hooks.example.net/x"}},
+			{"active":true,"config":{"url":"https://api.github.com/internal"}},
+			{"active":false,"config":{"url":"https://disabled.example.org/y"}}
+		]`),
+	})
+
+	p := c.fetchCapabilityProbes(context.Background(), "o", "r")
+
+	if len(p.SelfHostedRunners) != 1 || p.SelfHostedRunners[0] != "build-box" {
+		t.Errorf("runners = %v, want [build-box]", p.SelfHostedRunners)
+	}
+	// Only the active, off-platform hook counts: github.com is not
+	// off-platform, and an inactive hook delivers nothing.
+	if len(p.OffPlatformHooks) != 1 || p.OffPlatformHooks[0] != "hooks.example.net" {
+		t.Errorf("off-platform hooks = %v, want [hooks.example.net]", p.OffPlatformHooks)
+	}
+	if len(p.Unchecked) != 1 {
+		t.Fatalf("unchecked = %+v, want exactly the refused probe", p.Unchecked)
+	}
+	if p.Unchecked[0].Name != "deploy keys" || !strings.Contains(p.Unchecked[0].Reason, "scope") {
+		t.Errorf("unchecked entry = %+v, want deploy keys / a scope reason", p.Unchecked[0])
+	}
+}
+
+// The load-bearing property: a token with no extra scopes gets every
+// probe refused, and that must be reported rather than raised.
+func TestFetchCapabilityProbesFailOpen(t *testing.T) {
+	c := newTestRESTClient(t, map[string]func(http.ResponseWriter){
+		"/actions/runners": status(http.StatusForbidden),
+		"/keys":            status(http.StatusForbidden),
+		"/hooks":           status(http.StatusUnauthorized),
+	})
+
+	p := c.fetchCapabilityProbes(context.Background(), "o", "r")
+	if len(p.Unchecked) != 3 {
+		t.Errorf("unchecked = %d, want all 3 declared: %+v", len(p.Unchecked), p.Unchecked)
+	}
+	if len(p.SelfHostedRunners)+len(p.WriteDeployKeys)+len(p.OffPlatformHooks) != 0 {
+		t.Error("refused probes must contribute no findings")
+	}
+}
+
+// Malformed JSON must be reported as unreadable rather than decoded
+// into a silent zero value that reads as "checked, found nothing".
+func TestFetchCapabilityProbesGarbageIsDeclared(t *testing.T) {
+	c := newTestRESTClient(t, map[string]func(http.ResponseWriter){
+		"/actions/runners": json200(`{"runners": [ this is not json`),
+		"/keys":            json200(`[]`),
+		"/hooks":           json200(`[]`),
+	})
+
+	p := c.fetchCapabilityProbes(context.Background(), "o", "r")
+	if len(p.Unchecked) != 1 || p.Unchecked[0].Name != "self-hosted runners" {
+		t.Errorf("unchecked = %+v, want the runners probe declared unreadable", p.Unchecked)
+	}
+}
+
+// A cancelled context must not turn into a scan failure either.
+func TestFetchCapabilityProbesCancelledContext(t *testing.T) {
+	c := newTestRESTClient(t, map[string]func(http.ResponseWriter){
+		"/actions/runners": json200(`{"runners":[]}`),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	p := c.fetchCapabilityProbes(ctx, "o", "r")
+	if len(p.Unchecked) != 3 {
+		t.Errorf("unchecked = %d, want 3 — a dead context must be declared, not raised: %+v", len(p.Unchecked), p.Unchecked)
+	}
+}
+
+func TestHookHost(t *testing.T) {
+	tests := map[string]string{
+		"https://hooks.slack.com/services/x": "hooks.slack.com",
+		"https://API.GitHub.com/thing":       "api.github.com",
+		"http://192.168.1.5:9000/hook":       "192.168.1.5",
+		"":                                   "",
+		"not a url at all":                   "",
+		"://broken":                          "",
+	}
+	for in, want := range tests {
+		if got := hookHost(in); got != want {
+			t.Errorf("hookHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/github/capability_test.go
+++ b/internal/github/capability_test.go
@@ -139,3 +139,52 @@ func TestHookHost(t *testing.T) {
 		}
 	}
 }
+
+// "evilgithub.com" ends with "github.com" but is not GitHub. The
+// suffix-without-a-boundary bug hid exactly the exfiltration target
+// that matters.
+func TestIsGitHubHostBoundary(t *testing.T) {
+	for host, want := range map[string]bool{
+		"github.com":         true,
+		"api.github.com":     true,
+		"evilgithub.com":     false,
+		"github.com.evil.io": false,
+		"hooks.slack.com":    false,
+	} {
+		if got := isGitHubHost(host); got != want {
+			t.Errorf("isGitHubHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+// A list longer than one page is checked but not exhaustively, and that
+// difference has to reach the report.
+func TestProbeDeclaresTruncatedPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/keys") {
+			w.Header().Set("Link", `<https://api.github.com/repositories/1/keys?page=2>; rel="next"`)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `[{"title":"deploy","read_only":false}]`)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	t.Cleanup(srv.Close)
+	c := &Client{rest: &http.Client{Transport: &rewriteHost{host: srv.URL}}, authenticated: true}
+
+	p := c.fetchCapabilityProbes(context.Background(), "o", "r")
+	if len(p.WriteDeployKeys) != 1 {
+		t.Errorf("first page should still be read: %+v", p.WriteDeployKeys)
+	}
+	var declared bool
+	for _, u := range p.Unchecked {
+		if u.Name == "deploy keys" && strings.Contains(u.Reason, "first page") {
+			declared = true
+		}
+	}
+	if !declared {
+		t.Errorf("a truncated list must be declared: %+v", p.Unchecked)
+	}
+}

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -383,6 +383,27 @@ const (
 	// provenance anomaly all on the same branch.
 	wCombinedSmokingGun = 4
 
+	// Axis 4 — capability escalation.
+	//
+	// Capability on its own is not scored, and that is the whole design.
+	// octoscope's own release.yml asks for contents:write and reads two
+	// secrets; it fires on a tag push, so only someone who can already
+	// push tags can reach it, and it is completely ordinary. Scoring
+	// power alone would flag a large share of GitHub and train everyone
+	// to ignore the axis. What scores is power reachable from *untrusted
+	// input* — a fork-triggered event holding the base repo's secrets or
+	// write scopes.
+	// The values are bounded by an invariant the axis must not break:
+	// capability alone can never reach Suspicious. Its worst shape — a
+	// fork trigger holding secrets *and* write-all — must stay under
+	// tSuspicious, so 3+1 lands on Watch. That ceiling is deliberate:
+	// this axis describes a configuration risk, not evidence that
+	// anything has happened, so it belongs below wIgnitionNamedIOC and
+	// needs a second axis to agree before the verdict escalates.
+	// TestCapabilityAloneCannotReachSuspicious pins it.
+	wCapEscalation = 3 // fork-triggered event + secrets or write permissions
+	wCapWriteAll   = 1 // permissions: write-all — sloppy on any trigger, and rare enough to say so
+
 	// Delta weights. Comparing against a recorded fingerprint is the
 	// most future-proof signal in the design because it is both
 	// name-agnostic and content-agnostic: a variant that renames its
@@ -473,7 +494,10 @@ const (
 	AxisProvenance FindingAxis = "provenance"
 	// AxisDelta reports what changed since the last recorded scan of
 	// this repo, rather than what is present now.
-	AxisDelta FindingAxis = "delta"
+	// AxisCapability is the persistence / exfiltration footprint: what a
+	// compromise of this repo would be able to reach.
+	AxisCapability FindingAxis = "capability"
+	AxisDelta      FindingAxis = "delta"
 	// AxisPushBurst is account-wide rather than per-repo: it reports
 	// that this repo was pushed as part of a tight cross-repo cluster.
 	// It is reported even when it scores nothing, so the user sees the
@@ -538,6 +562,12 @@ type RepoScan struct {
 	Score   int
 	Verdict ScanVerdict
 
+	// Unchecked lists the capability probes that could not run, with the
+	// reason. Surfaced so a clean verdict is never mistaken for a
+	// complete one — the same disclosure rule as partial branch
+	// coverage.
+	Unchecked []UncheckedProbe
+
 	// Fingerprint is this scan's own record of the repo's
 	// auto-execution surface, for the caller to persist as the baseline
 	// the *next* scan diffs against. Verdict is filled in with the
@@ -592,7 +622,7 @@ func (s *RepoScan) ContextFindings() []Finding {
 		if f.Weight > 0 {
 			continue // already shown as scored evidence
 		}
-		if f.Axis == AxisDelta || f.Axis == AxisPushBurst {
+		if f.Axis == AxisDelta || f.Axis == AxisPushBurst || f.Axis == AxisCapability {
 			out = append(out, f)
 		}
 	}
@@ -633,6 +663,12 @@ type blobAnalysis struct {
 	IsText  bool
 	Entropy float64
 	Markers []string // human-readable obfuscation markers, already plain ASCII
+
+	// Workflow holds the Axis-4 capability facts, set only for CI
+	// workflow files and only when their content was actually pulled.
+	// Nil everywhere else, so the engine can tell "not a workflow" from
+	// "a workflow we could not read".
+	Workflow *workflowFacts
 }
 
 // maxBlobScanBytes caps how large a matched ignition blob we'll pull
@@ -802,6 +838,11 @@ type scanInput struct {
 	// rather than silently skipped: "we have nothing to compare against"
 	// must never be allowed to read as "nothing changed".
 	Baseline *ScanFingerprint
+
+	// Probes is the elevated-scope half of Axis 4. Its zero value means
+	// the probes did not run at all, which is different from running and
+	// finding nothing — Unchecked carries that distinction.
+	Probes capabilityProbes
 }
 
 // evaluateScan is the pure heart of the detector: it turns gathered
@@ -985,6 +1026,139 @@ func evaluateScan(in scanInput) *RepoScan {
 				Reason: fmt.Sprintf("an anomalous payload and an anomalous commit tip coincide on branch %q", b.Prov.Name),
 			})
 		}
+	}
+
+	// --- Axis 4: capability escalation, workflow half -------------------
+	//
+	// Reported once per distinct workflow path: the same file on five
+	// branches is one fact about the repo, not five.
+	seenWorkflow := map[string]bool{}
+	for _, b := range in.Branches {
+		for _, m := range b.Matches {
+			if m.Rule.Class != classCI || seenWorkflow[m.Path] {
+				continue
+			}
+			ba, ok := in.Blobs[m.BlobSHA]
+			if !ok || ba.Workflow == nil {
+				continue // not fetched, or not readable as a workflow
+			}
+			seenWorkflow[m.Path] = true
+			wf := ba.Workflow
+
+			if wf.Unparsed {
+				// Say it was not understood rather than let it pass for
+				// checked-and-clean.
+				add(Finding{
+					Axis:   AxisCapability,
+					Branch: b.Prov.Name,
+					Path:   m.Path,
+					Weight: 0,
+					Reason: fmt.Sprintf("%s could not be parsed as a workflow, so its permissions and triggers were not checked", m.Path),
+				})
+				continue
+			}
+
+			switch {
+			case len(wf.ForkTriggers) > 0 && (wf.UsesSecrets || len(wf.WritePerms) > 0):
+				held := "the repository's secrets"
+				if len(wf.WritePerms) > 0 {
+					held = strings.Join(wf.WritePerms, ", ")
+					if wf.UsesSecrets {
+						held += " and the repository's secrets"
+					}
+				}
+				add(Finding{
+					Axis:   AxisCapability,
+					Branch: b.Prov.Name,
+					Path:   m.Path,
+					Weight: wCapEscalation,
+					Reason: fmt.Sprintf("triggered by %s — %s — while holding %s",
+						strings.Join(wf.ForkTriggers, ", "), forkTriggers[wf.ForkTriggers[0]], held),
+				})
+			case len(wf.ForkTriggers) > 0:
+				add(Finding{
+					Axis:   AxisCapability,
+					Branch: b.Prov.Name,
+					Path:   m.Path,
+					Weight: 0,
+					Reason: fmt.Sprintf("triggered by %s, but holds no secrets or write scopes", strings.Join(wf.ForkTriggers, ", ")),
+				})
+			case len(wf.WritePerms) > 0:
+				// Power on a trusted trigger: inventory, not a finding.
+				add(Finding{
+					Axis:   AxisCapability,
+					Branch: b.Prov.Name,
+					Path:   m.Path,
+					Weight: 0,
+					Reason: fmt.Sprintf("grants %s, reachable only from its own triggers", strings.Join(wf.WritePerms, ", ")),
+				})
+			}
+
+			// write-all is worth its own small weight on any trigger:
+			// it hands over every scope rather than the one needed.
+			for _, p := range wf.WritePerms {
+				if p == "write-all" {
+					add(Finding{
+						Axis:   AxisCapability,
+						Branch: b.Prov.Name,
+						Path:   m.Path,
+						Weight: wCapWriteAll,
+						Reason: fmt.Sprintf("%s grants write-all rather than the scopes it needs", m.Path),
+					})
+				}
+			}
+		}
+	}
+
+	// --- Axis 4: capability escalation, elevated-scope half -------------
+	//
+	// Runners, keys and hooks are capability, so by the same rule as the
+	// workflow half they are inventory unless something makes them
+	// reachable from untrusted input.
+	s.Unchecked = in.Probes.Unchecked
+
+	forkTriggered := len(seenWorkflow) > 0 && func() bool {
+		for _, b := range in.Branches {
+			for _, m := range b.Matches {
+				if ba, ok := in.Blobs[m.BlobSHA]; ok && ba.Workflow != nil && len(ba.Workflow.ForkTriggers) > 0 {
+					return true
+				}
+			}
+		}
+		return false
+	}()
+
+	if n := len(in.Probes.SelfHostedRunners); n > 0 {
+		// The one combination worth scoring here: a workflow an outsider
+		// can trigger, on hardware you own. That is untrusted code
+		// executing on your machine, with whatever else lives on it.
+		if forkTriggered {
+			add(Finding{
+				Axis:   AxisCapability,
+				Weight: wCapEscalation,
+				Reason: fmt.Sprintf("%d self-hosted runner(s) attached to a repository that also has a fork-triggered workflow — outsider-supplied code could run on your own hardware", n),
+			})
+		} else {
+			add(Finding{
+				Axis:   AxisCapability,
+				Weight: 0,
+				Reason: fmt.Sprintf("%d self-hosted runner(s) attached; no fork-triggered workflow reaches them", n),
+			})
+		}
+	}
+	if keys := in.Probes.WriteDeployKeys; len(keys) > 0 {
+		add(Finding{
+			Axis:   AxisCapability,
+			Weight: 0,
+			Reason: fmt.Sprintf("%d deploy key(s) with write access: %s — each is a standing credential that can push", len(keys), strings.Join(keys, ", ")),
+		})
+	}
+	if hooks := dedupeStrings(in.Probes.OffPlatformHooks); len(hooks) > 0 {
+		add(Finding{
+			Axis:   AxisCapability,
+			Weight: 0,
+			Reason: fmt.Sprintf("active webhook(s) delivering off-platform to %s", strings.Join(hooks, ", ")),
+		})
 	}
 
 	// --- fingerprint + delta -------------------------------------------
@@ -1497,6 +1671,13 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 					ba.IsText = isTextContent(content)
 					ba.Entropy = shannonEntropy(content)
 					ba.Markers = looksObfuscated(content)
+					if m.Rule.Class == classCI {
+						// Content is already bounded by maxBlobScanBytes
+						// above, which is what makes handing it to a
+						// YAML parser acceptable.
+						wf := parseWorkflow(content)
+						ba.Workflow = &wf
+					}
 				}
 				// A blob fetch failure is non-fatal: we still have the
 				// size signal from the tree entry.
@@ -1517,6 +1698,10 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 		Now:           time.Now(),
 		Baseline:      opts.Baseline,
 	}
+	// Elevated-scope probes, best-effort by construction: they never
+	// return an error, so a minimal token simply gets a scan with those
+	// gaps declared.
+	in.Probes = c.fetchCapabilityProbes(ctx, owner, name)
 	// The push burst costs no API call: it is arithmetic over PushedAt
 	// timestamps the caller already holds from the dashboard fetch. An
 	// empty accountRepos simply means no timing context — the scan still

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -402,7 +402,15 @@ const (
 	// needs a second axis to agree before the verdict escalates.
 	// TestCapabilityAloneCannotReachSuspicious pins it.
 	wCapEscalation = 3 // fork-triggered event + secrets or write permissions
-	wCapWriteAll   = 1 // permissions: write-all — sloppy on any trigger, and rare enough to say so
+	wCapWriteAll   = 1 // permissions: write-all, where a fork trigger can reach it
+
+	// maxCapabilityScore is the ceiling on what the whole axis may
+	// contribute, and it is the part that actually enforces the
+	// invariant. Bounding each finding is not enough: two of them summed
+	// past tSuspicious with nothing else agreeing. Findings beyond the
+	// ceiling are still reported, at weight 0 — the arithmetic is
+	// clamped, not the disclosure.
+	maxCapabilityScore = tSuspicious - 1
 
 	// Delta weights. Comparing against a recorded fingerprint is the
 	// most future-proof signal in the design because it is both
@@ -1030,25 +1038,55 @@ func evaluateScan(in scanInput) *RepoScan {
 
 	// --- Axis 4: capability escalation, workflow half -------------------
 	//
-	// Reported once per distinct workflow path: the same file on five
+	// Reported once per distinct workflow content: the same file on five
 	// branches is one fact about the repo, not five.
+	var uncheckedWorkflows []string
+
+	// Axis 4 is clamped as a whole, not just per finding. Individual
+	// weights below tSuspicious are not enough on their own: one
+	// fork-triggered secret-bearing workflow (3) plus a reachable
+	// self-hosted runner (3) summed to 6 and reached Suspicious with no
+	// second axis agreeing — the exact invariant this axis promised to
+	// keep. Findings past the ceiling are still reported, at weight 0,
+	// so nothing is hidden; only the arithmetic is bounded.
+	capBudget := maxCapabilityScore
+	addCap := func(f Finding) {
+		if f.Weight > capBudget {
+			f.Weight = capBudget
+		}
+		capBudget -= f.Weight
+		add(f)
+	}
+	// Keyed by path AND content: the same path can hold different
+	// content on two branches, and deduping on the path alone let a safe
+	// default-branch copy mask a dangerous side-branch variant — which
+	// is precisely the side-branch divergence this scan exists to catch.
 	seenWorkflow := map[string]bool{}
 	for _, b := range in.Branches {
 		for _, m := range b.Matches {
-			if m.Rule.Class != classCI || seenWorkflow[m.Path] {
+			wfKey := fingerprintKey(m.BlobSHA, m.Path)
+			if m.Rule.Class != classCI || seenWorkflow[wfKey] {
 				continue
 			}
 			ba, ok := in.Blobs[m.BlobSHA]
 			if !ok || ba.Workflow == nil {
-				continue // not fetched, or not readable as a workflow
+				// The content never arrived — over maxBlobScanBytes, or
+				// past the maxBlobFetches budget. Skipping quietly would
+				// let an unexamined workflow pass for an examined one, so
+				// declare it the same way a refused probe is declared.
+				if !seenWorkflow[wfKey] {
+					seenWorkflow[wfKey] = true
+					uncheckedWorkflows = append(uncheckedWorkflows, m.Path)
+				}
+				continue
 			}
-			seenWorkflow[m.Path] = true
+			seenWorkflow[wfKey] = true
 			wf := ba.Workflow
 
 			if wf.Unparsed {
 				// Say it was not understood rather than let it pass for
 				// checked-and-clean.
-				add(Finding{
+				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
@@ -1067,7 +1105,7 @@ func evaluateScan(in scanInput) *RepoScan {
 						held += " and the repository's secrets"
 					}
 				}
-				add(Finding{
+				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
@@ -1076,7 +1114,7 @@ func evaluateScan(in scanInput) *RepoScan {
 						strings.Join(wf.ForkTriggers, ", "), forkTriggers[wf.ForkTriggers[0]], held),
 				})
 			case len(wf.ForkTriggers) > 0:
-				add(Finding{
+				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
@@ -1085,7 +1123,7 @@ func evaluateScan(in scanInput) *RepoScan {
 				})
 			case len(wf.WritePerms) > 0:
 				// Power on a trusted trigger: inventory, not a finding.
-				add(Finding{
+				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
@@ -1094,18 +1132,27 @@ func evaluateScan(in scanInput) *RepoScan {
 				})
 			}
 
-			// write-all is worth its own small weight on any trigger:
-			// it hands over every scope rather than the one needed.
+			// write-all hands over every scope rather than the one
+			// needed. It scores only where a fork trigger can reach it:
+			// on a trusted trigger it is untidy, not dangerous, and
+			// scoring it there would break the rule that capability
+			// alone never moves the verdict — five such workflows would
+			// have reached Suspicious between them.
 			for _, p := range wf.WritePerms {
-				if p == "write-all" {
-					add(Finding{
-						Axis:   AxisCapability,
-						Branch: b.Prov.Name,
-						Path:   m.Path,
-						Weight: wCapWriteAll,
-						Reason: fmt.Sprintf("%s grants write-all rather than the scopes it needs", m.Path),
-					})
+				if p != "write-all" {
+					continue
 				}
+				w := 0
+				if len(wf.ForkTriggers) > 0 {
+					w = wCapWriteAll
+				}
+				addCap(Finding{
+					Axis:   AxisCapability,
+					Branch: b.Prov.Name,
+					Path:   m.Path,
+					Weight: w,
+					Reason: fmt.Sprintf("%s grants write-all rather than the scopes it needs", m.Path),
+				})
 			}
 		}
 	}
@@ -1116,11 +1163,28 @@ func evaluateScan(in scanInput) *RepoScan {
 	// workflow half they are inventory unless something makes them
 	// reachable from untrusted input.
 	s.Unchecked = in.Probes.Unchecked
+	for _, p := range dedupeStrings(uncheckedWorkflows) {
+		s.Unchecked = append(s.Unchecked, UncheckedProbe{
+			Name:   p,
+			Reason: "content not retrieved, so its permissions and triggers were not read",
+		})
+	}
 
-	forkTriggered := len(seenWorkflow) > 0 && func() bool {
+	// A runner is only *reachable* from untrusted input if some
+	// fork-triggered workflow actually targets a self-hosted runner.
+	// Scoring on the mere coexistence of a fork trigger and a runner
+	// would flag a repo whose pull_request_target job runs on
+	// ubuntu-latest while the runner serves a tag-release workflow —
+	// two unrelated facts, and the claim "outsider code could run on
+	// your hardware" would simply be false.
+	forkReachesRunner := func() bool {
 		for _, b := range in.Branches {
 			for _, m := range b.Matches {
-				if ba, ok := in.Blobs[m.BlobSHA]; ok && ba.Workflow != nil && len(ba.Workflow.ForkTriggers) > 0 {
+				ba, ok := in.Blobs[m.BlobSHA]
+				if !ok || ba.Workflow == nil {
+					continue
+				}
+				if len(ba.Workflow.ForkTriggers) > 0 && ba.Workflow.SelfHostedJobs {
 					return true
 				}
 			}
@@ -1132,29 +1196,29 @@ func evaluateScan(in scanInput) *RepoScan {
 		// The one combination worth scoring here: a workflow an outsider
 		// can trigger, on hardware you own. That is untrusted code
 		// executing on your machine, with whatever else lives on it.
-		if forkTriggered {
-			add(Finding{
+		if forkReachesRunner {
+			addCap(Finding{
 				Axis:   AxisCapability,
 				Weight: wCapEscalation,
-				Reason: fmt.Sprintf("%d self-hosted runner(s) attached to a repository that also has a fork-triggered workflow — outsider-supplied code could run on your own hardware", n),
+				Reason: fmt.Sprintf("%d self-hosted runner(s) attached, and a fork-triggered workflow targets self-hosted — outsider-supplied code can run on your own hardware", n),
 			})
 		} else {
-			add(Finding{
+			addCap(Finding{
 				Axis:   AxisCapability,
 				Weight: 0,
-				Reason: fmt.Sprintf("%d self-hosted runner(s) attached; no fork-triggered workflow reaches them", n),
+				Reason: fmt.Sprintf("%d self-hosted runner(s) attached; no fork-triggered workflow targets them", n),
 			})
 		}
 	}
 	if keys := in.Probes.WriteDeployKeys; len(keys) > 0 {
-		add(Finding{
+		addCap(Finding{
 			Axis:   AxisCapability,
 			Weight: 0,
 			Reason: fmt.Sprintf("%d deploy key(s) with write access: %s — each is a standing credential that can push", len(keys), strings.Join(keys, ", ")),
 		})
 	}
 	if hooks := dedupeStrings(in.Probes.OffPlatformHooks); len(hooks) > 0 {
-		add(Finding{
+		addCap(Finding{
 			Axis:   AxisCapability,
 			Weight: 0,
 			Reason: fmt.Sprintf("active webhook(s) delivering off-platform to %s", strings.Join(hooks, ", ")),

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1192,7 +1192,11 @@ func evaluateScan(in scanInput) *RepoScan {
 		return false
 	}()
 
-	if n := len(in.Probes.SelfHostedRunners); n > 0 {
+	// Deduped like the hook list: two runners registered under the same
+	// name, or two keys sharing a title, would otherwise inflate a count
+	// the report states as fact.
+	runners := dedupeStrings(in.Probes.SelfHostedRunners)
+	if n := len(runners); n > 0 {
 		// The one combination worth scoring here: a workflow an outsider
 		// can trigger, on hardware you own. That is untrusted code
 		// executing on your machine, with whatever else lives on it.
@@ -1210,7 +1214,7 @@ func evaluateScan(in scanInput) *RepoScan {
 			})
 		}
 	}
-	if keys := in.Probes.WriteDeployKeys; len(keys) > 0 {
+	if keys := dedupeStrings(in.Probes.WriteDeployKeys); len(keys) > 0 {
 		addCap(Finding{
 			Axis:   AxisCapability,
 			Weight: 0,

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -296,9 +296,18 @@ func TestEvaluateScanCapability(t *testing.T) {
 			wantContain: "holds no secrets or write scopes",
 		},
 		{
-			name:        "write-all is called out on any trigger",
+			// write-all on a trusted trigger is untidy, not dangerous.
+			// Scoring it broke the capability-alone rule: five such
+			// workflows reached Suspicious between them.
+			name:        "write-all on a trusted trigger is inventory",
 			wf:          &workflowFacts{WritePerms: []string{"write-all"}},
-			wantWeight:  wCapWriteAll,
+			wantWeight:  0,
+			wantContain: "write-all rather than the scopes it needs",
+		},
+		{
+			name:        "write-all a fork trigger can reach does score",
+			wf:          &workflowFacts{ForkTriggers: []string{"pull_request_target"}, WritePerms: []string{"write-all"}},
+			wantWeight:  wCapEscalation + wCapWriteAll,
 			wantContain: "write-all rather than the scopes it needs",
 		},
 		{
@@ -887,5 +896,94 @@ func TestBranchCoverageDisclosure(t *testing.T) {
 				t.Errorf("PartialCoverage() = %v, want %v", got, tt.wantPartial)
 			}
 		})
+	}
+}
+
+// --- regressions found by the Codex review of #103 -----------------------
+
+// Bounding each finding is not enough. One fork-triggered secret-bearing
+// workflow (3) plus a reachable self-hosted runner (3) summed to 6 and
+// reached Suspicious with no other axis agreeing.
+func TestCapabilityAggregateIsClamped(t *testing.T) {
+	in := capInput(".github/workflows/x.yml", &workflowFacts{
+		ForkTriggers:   []string{"pull_request_target"},
+		UsesSecrets:    true,
+		WritePerms:     []string{"write-all"},
+		SelfHostedJobs: true,
+	})
+	in.Probes = capabilityProbes{SelfHostedRunners: []string{"box"}}
+
+	got := evaluateScan(in)
+	if got.Verdict >= VerdictSuspicious {
+		t.Errorf("axis 4 aggregate reached %v (score %d) with no other axis", got.Verdict, got.Score)
+	}
+	if got.Score > maxCapabilityScore {
+		t.Errorf("capability contributed %d, above the %d ceiling", got.Score, maxCapabilityScore)
+	}
+	// Clamping the arithmetic must not hide the evidence.
+	if len(capFindings(got)) < 3 {
+		t.Errorf("clamping dropped findings: %+v", capFindings(got))
+	}
+}
+
+// Deduping by path alone let a safe copy on the default branch mask a
+// dangerous variant at the same path on a side branch — the exact
+// divergence pattern the scan exists to catch.
+func TestCapabilityDedupeIsContentKeyed(t *testing.T) {
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 2,
+		Branches: []scanBranch{
+			{Prov: provBranch("main", true), Matches: []ignitionMatch{
+				{Path: ".github/workflows/ci.yml", BlobSHA: "safe", Rule: ignitionRule{Class: classCI}}}},
+			{Prov: provBranch("next", false), Matches: []ignitionMatch{
+				{Path: ".github/workflows/ci.yml", BlobSHA: "danger", Rule: ignitionRule{Class: classCI}}}},
+		},
+		Blobs: map[string]blobAnalysis{
+			"safe":   {Fetched: true, IsText: true, Workflow: &workflowFacts{}},
+			"danger": {Fetched: true, IsText: true, Workflow: &workflowFacts{ForkTriggers: []string{"pull_request_target"}, UsesSecrets: true}},
+		},
+		Now: time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC),
+	}
+	got := evaluateScan(in)
+	if got.Score == 0 {
+		t.Errorf("the dangerous side-branch variant was skipped: %+v", capFindings(got))
+	}
+}
+
+// A runner is reachable only if a fork-triggered workflow actually
+// targets self-hosted. Coexistence alone made the report claim
+// outsider code could run on your hardware when it could not.
+func TestRunnerScoresOnlyWhenReachable(t *testing.T) {
+	unreachable := capInput(".github/workflows/x.yml", &workflowFacts{
+		ForkTriggers: []string{"pull_request_target"}, // but runs on ubuntu-latest
+	})
+	unreachable.Probes = capabilityProbes{SelfHostedRunners: []string{"box"}}
+	if got := evaluateScan(unreachable); got.Score != 0 {
+		t.Errorf("runner scored without a self-hosted fork job: %d %+v", got.Score, capFindings(got))
+	}
+
+	reachable := capInput(".github/workflows/x.yml", &workflowFacts{
+		ForkTriggers: []string{"pull_request_target"}, SelfHostedJobs: true,
+	})
+	reachable.Probes = capabilityProbes{SelfHostedRunners: []string{"box"}}
+	if got := evaluateScan(reachable); got.Score == 0 {
+		t.Error("a fork-triggered self-hosted job with a runner attached must score")
+	}
+}
+
+// A workflow whose content never arrived (over the size cap, or past
+// the fetch budget) must be declared, not silently treated as examined.
+func TestUnretrievedWorkflowIsDeclared(t *testing.T) {
+	in := capInput(".github/workflows/x.yml", nil) // Workflow facts absent
+	in.Blobs["w"] = blobAnalysis{Size: 900}        // never fetched
+	got := evaluateScan(in)
+	found := false
+	for _, u := range got.Unchecked {
+		if strings.Contains(u.Name, "x.yml") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("an unretrieved workflow was not declared: %+v", got.Unchecked)
 	}
 }

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -231,6 +231,149 @@ func TestEvaluateScanWatch(t *testing.T) {
 	}
 }
 
+// --- Axis 4: capability escalation ---------------------------------------
+
+// capInput builds a scan of one CI workflow with the given facts.
+func capInput(path string, wf *workflowFacts) scanInput {
+	return scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 1,
+		Branches: []scanBranch{{
+			Prov: provBranch("main", true),
+			Matches: []ignitionMatch{
+				{Path: path, Size: 900, BlobSHA: "w", Rule: ignitionRule{Class: classCI, Weight: 0}},
+			},
+		}},
+		Blobs: map[string]blobAnalysis{
+			"w": {Size: 900, Fetched: true, IsText: true, Workflow: wf},
+		},
+		Now: time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func capFindings(s *RepoScan) []Finding {
+	var out []Finding
+	for _, f := range s.Findings {
+		if f.Axis == AxisCapability {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func TestEvaluateScanCapability(t *testing.T) {
+	tests := []struct {
+		name        string
+		wf          *workflowFacts
+		wantWeight  int
+		wantContain string
+	}{
+		{
+			// The false positive this axis must not produce: octoscope's
+			// own release workflow. Powerful, secret-reading, correct.
+			name:        "power on a trusted trigger is inventory only",
+			wf:          &workflowFacts{WritePerms: []string{"contents: write"}, UsesSecrets: true},
+			wantWeight:  0,
+			wantContain: "reachable only from its own triggers",
+		},
+		{
+			name:        "fork trigger with secrets scores",
+			wf:          &workflowFacts{ForkTriggers: []string{"pull_request_target"}, UsesSecrets: true},
+			wantWeight:  wCapEscalation,
+			wantContain: "while holding the repository's secrets",
+		},
+		{
+			name:        "fork trigger with write permissions scores",
+			wf:          &workflowFacts{ForkTriggers: []string{"workflow_run"}, WritePerms: []string{"contents: write"}},
+			wantWeight:  wCapEscalation,
+			wantContain: "contents: write",
+		},
+		{
+			// A fork trigger by itself is a label bot's normal life.
+			name:        "bare fork trigger is inventory only",
+			wf:          &workflowFacts{ForkTriggers: []string{"issue_comment"}},
+			wantWeight:  0,
+			wantContain: "holds no secrets or write scopes",
+		},
+		{
+			name:        "write-all is called out on any trigger",
+			wf:          &workflowFacts{WritePerms: []string{"write-all"}},
+			wantWeight:  wCapWriteAll,
+			wantContain: "write-all rather than the scopes it needs",
+		},
+		{
+			// Not understood must never pass for checked-and-clean.
+			name:        "unparseable workflow says it was not checked",
+			wf:          &workflowFacts{Unparsed: true},
+			wantWeight:  0,
+			wantContain: "could not be parsed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateScan(capInput(".github/workflows/x.yml", tt.wf))
+			fs := capFindings(got)
+			if len(fs) == 0 {
+				t.Fatalf("no capability finding produced")
+			}
+			total, joined := 0, ""
+			for _, f := range fs {
+				total += f.Weight
+				joined += f.Reason + "\n"
+			}
+			if total != tt.wantWeight {
+				t.Errorf("capability weight = %d, want %d (%s)", total, tt.wantWeight, joined)
+			}
+			if !strings.Contains(joined, tt.wantContain) {
+				t.Errorf("reason %q does not mention %q", joined, tt.wantContain)
+			}
+		})
+	}
+}
+
+// The same workflow on many branches is one fact about the repository,
+// not one per branch — otherwise a repo with ten branches scores ten
+// times for a single file.
+func TestCapabilityReportedOncePerPath(t *testing.T) {
+	wf := &workflowFacts{ForkTriggers: []string{"pull_request_target"}, UsesSecrets: true}
+	in := capInput(".github/workflows/x.yml", wf)
+	extra := scanBranch{
+		Prov: provBranch("next", false),
+		Matches: []ignitionMatch{
+			{Path: ".github/workflows/x.yml", Size: 900, BlobSHA: "w", Rule: ignitionRule{Class: classCI, Weight: 0}},
+		},
+	}
+	in.Branches = append(in.Branches, extra)
+	in.BranchesTotal = 2
+
+	got := evaluateScan(in)
+	if n := len(capFindings(got)); n != 1 {
+		t.Errorf("capability findings = %d, want 1: %+v", n, capFindings(got))
+	}
+}
+
+// The invariant #67 asks to preserve: no single axis can reach a high
+// tier alone. Capability is the newest and therefore the one at risk of
+// having thresholds loosened to make it visible.
+func TestCapabilityAloneCannotReachSuspicious(t *testing.T) {
+	// The worst a workflow can do on this axis: a fork trigger holding
+	// secrets AND write-all.
+	worst := &workflowFacts{
+		ForkTriggers: []string{"pull_request_target", "workflow_run"},
+		WritePerms:   []string{"write-all"},
+		UsesSecrets:  true,
+	}
+	got := evaluateScan(capInput(".github/workflows/x.yml", worst))
+	if got.Verdict >= VerdictSuspicious {
+		t.Errorf("capability alone reached %v with score %d — no single axis may do that", got.Verdict, got.Score)
+	}
+	if got.Score == 0 {
+		t.Error("the worst capability shape should still score something")
+	}
+	t.Logf("worst capability-only shape: score %d, verdict %v", got.Score, got.Verdict)
+}
+
 // --- delta: what changed since the recorded baseline ---------------------
 
 // deltaInput builds a scan of one branch carrying one *scoring* ignition

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -1,0 +1,160 @@
+package github
+
+// Axis 4 — capability escalation, the workflow half.
+//
+// This file only *extracts facts* from a workflow file; the scoring
+// lives in evaluateScan with the other axes, so the same pure-function
+// discipline applies.
+//
+// The distinction that makes this axis useful is not "does the workflow
+// hold power" but "is that power reachable from untrusted input".
+// octoscope's own release.yml requests contents:write and reads two
+// secrets, and it is entirely correct: it triggers on a tag push, which
+// only someone who can already push tags can cause. The same file
+// triggered by pull_request_target would be a privilege-escalation
+// gadget. Scoring capability alone would light up a large share of
+// GitHub, teaching everyone to ignore the axis.
+
+import (
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// forkTriggers are the events that run with the *base* repository's
+// token and secrets while acting on input an outsider controls. They
+// are the reason capability matters.
+//
+// pull_request is deliberately absent: a fork PR on that event gets a
+// read-only token and no secrets, which is the safe design.
+var forkTriggers = map[string]string{
+	"pull_request_target": "runs with the base repo's token and secrets against a fork's pull request",
+	"workflow_run":        "runs in the base repo context after another workflow, with secrets available",
+	"issue_comment":       "fires on a comment from anyone who can comment",
+}
+
+// workflowFacts is what one workflow file tells us about capability.
+type workflowFacts struct {
+	// ForkTriggers are the untrusted-input events this workflow answers.
+	ForkTriggers []string
+	// WritePerms are the elevated grants found, top-level or per-job —
+	// "write-all", "contents: write", "id-token: write", …
+	WritePerms []string
+	// UsesSecrets reports whether the file references the secrets
+	// context anywhere.
+	UsesSecrets bool
+	// Unparsed is true when the content could not be decoded as YAML, so
+	// the report can say the file was not understood rather than imply
+	// it was checked and found clean.
+	Unparsed bool
+}
+
+// parseWorkflow extracts the capability facts from one workflow file.
+//
+// Callers must cap the content length before calling — the scan already
+// does, via maxBlobScanBytes — because this hands attacker-controlled
+// bytes to a YAML parser.
+func parseWorkflow(content []byte) workflowFacts {
+	var f workflowFacts
+	// The secrets check is textual on purpose: a reference can hide in a
+	// script body, an env block or a with: input, and all of them are
+	// just strings by the time YAML is done.
+	f.UsesSecrets = strings.Contains(string(content), "secrets.")
+
+	var root map[string]any
+	if err := yaml.Unmarshal(content, &root); err != nil || root == nil {
+		f.Unparsed = true
+		return f
+	}
+
+	// YAML 1.1 reads a bare `on` as the boolean true, and GitHub's own
+	// workflow files are written with a bare `on:`. Decoding into
+	// map[string]any therefore yields the key "true", not "on". Missing
+	// this is silent: every trigger would simply never be found.
+	trigger := root["on"]
+	if trigger == nil {
+		trigger = root["true"]
+	}
+	for _, ev := range eventNames(trigger) {
+		if _, ok := forkTriggers[ev]; ok {
+			f.ForkTriggers = append(f.ForkTriggers, ev)
+		}
+	}
+
+	f.WritePerms = append(f.WritePerms, writeGrants(root["permissions"])...)
+	// Per-job permissions override the top level, so both matter.
+	if jobs, ok := root["jobs"].(map[string]any); ok {
+		for _, j := range jobs {
+			job, ok := j.(map[string]any)
+			if !ok {
+				continue
+			}
+			f.WritePerms = append(f.WritePerms, writeGrants(job["permissions"])...)
+		}
+	}
+	f.WritePerms = dedupeStrings(f.WritePerms)
+	return f
+}
+
+// eventNames normalises the three shapes `on:` can take — a bare string,
+// a list, or a mapping of event to filters.
+func eventNames(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return []string{t}
+	case []any:
+		var out []string
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case map[string]any:
+		var out []string
+		for k := range t {
+			out = append(out, k)
+		}
+		return out
+	}
+	return nil
+}
+
+// writeGrants normalises a `permissions:` value into the elevated grants
+// it confers. Read-only scopes are not returned: they are the safe
+// default and listing them would drown the signal.
+func writeGrants(v any) []string {
+	switch t := v.(type) {
+	case string:
+		if t == "write-all" {
+			return []string{"write-all"}
+		}
+	case map[string]any:
+		var out []string
+		for scope, val := range t {
+			s, ok := val.(string)
+			if !ok || s != "write" {
+				continue
+			}
+			out = append(out, scope+": write")
+		}
+		return out
+	}
+	return nil
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -40,9 +40,12 @@ type workflowFacts struct {
 	// WritePerms are the elevated grants found, top-level or per-job —
 	// "write-all", "contents: write", "id-token: write", …
 	WritePerms []string
-	// UsesSecrets reports whether the file references the secrets
-	// context anywhere.
+	// UsesSecrets reports whether the file can reach the secrets
+	// context — by reference, or by handing them to a called workflow.
 	UsesSecrets bool
+	// SelfHostedJobs is true when any job targets a self-hosted runner,
+	// which is what makes an attached runner actually *reachable*.
+	SelfHostedJobs bool
 	// Unparsed is true when the content could not be decoded as YAML, so
 	// the report can say the file was not understood rather than imply
 	// it was checked and found clean.
@@ -59,7 +62,15 @@ func parseWorkflow(content []byte) workflowFacts {
 	// The secrets check is textual on purpose: a reference can hide in a
 	// script body, an env block or a with: input, and all of them are
 	// just strings by the time YAML is done.
-	f.UsesSecrets = strings.Contains(string(content), "secrets.")
+	//
+	// Three spellings, not one. `secrets.NAME` is the common form, but
+	// GitHub also supports index syntax — `secrets['NAME']` — which a
+	// dot-only check misses entirely, and `secrets: inherit` hands the
+	// whole set to a called workflow without naming any of them.
+	text := string(content)
+	f.UsesSecrets = strings.Contains(text, "secrets.") ||
+		strings.Contains(text, "secrets[") ||
+		strings.Contains(text, "secrets: inherit")
 
 	var root map[string]any
 	if err := yaml.Unmarshal(content, &root); err != nil || root == nil {
@@ -90,6 +101,9 @@ func parseWorkflow(content []byte) workflowFacts {
 				continue
 			}
 			f.WritePerms = append(f.WritePerms, writeGrants(job["permissions"])...)
+			if runsOnSelfHosted(job["runs-on"]) {
+				f.SelfHostedJobs = true
+			}
 		}
 	}
 	f.WritePerms = dedupeStrings(f.WritePerms)
@@ -141,6 +155,29 @@ func writeGrants(v any) []string {
 		return out
 	}
 	return nil
+}
+
+// runsOnSelfHosted reports whether a job's runs-on targets a
+// self-hosted runner. The value may be a string, a list of labels, or a
+// group/labels mapping; "self-hosted" is the conventional label, and a
+// group assignment is self-hosted by definition.
+func runsOnSelfHosted(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return strings.Contains(t, "self-hosted")
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok && strings.Contains(s, "self-hosted") {
+				return true
+			}
+		}
+	case map[string]any:
+		if _, ok := t["group"]; ok {
+			return true
+		}
+		return runsOnSelfHosted(t["labels"])
+	}
+	return false
 }
 
 func dedupeStrings(in []string) []string {

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -16,6 +16,7 @@ package github
 // GitHub, teaching everyone to ignore the axis.
 
 import (
+	"sort"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"
@@ -78,10 +79,13 @@ func parseWorkflow(content []byte) workflowFacts {
 		return f
 	}
 
-	// YAML 1.1 reads a bare `on` as the boolean true, and GitHub's own
-	// workflow files are written with a bare `on:`. Decoding into
-	// map[string]any therefore yields the key "true", not "on". Missing
-	// this is silent: every trigger would simply never be found.
+	// YAML 1.1 treats a bare `on` as a boolean, which is a real trap in
+	// GitHub Actions files — but *not* with this decoder target.
+	// Measured against yaml.v3: unmarshalling "on: push" into
+	// map[string]any yields the key "on", and only a typed target such
+	// as map[bool]any produces map[true:push]. The "true" lookup is
+	// kept as cheap insurance in case the decode target or the library
+	// ever changes, not because it fires today.
 	trigger := root["on"]
 	if trigger == nil {
 		trigger = root["true"]
@@ -129,6 +133,11 @@ func eventNames(v any) []string {
 		for k := range t {
 			out = append(out, k)
 		}
+		// Go randomises map iteration, and these names are joined into
+		// report text: unsorted, two scans of the same repository would
+		// render different sentences. The delta section already sorts
+		// for this reason.
+		sort.Strings(out)
 		return out
 	}
 	return nil
@@ -152,6 +161,7 @@ func writeGrants(v any) []string {
 			}
 			out = append(out, scope+": write")
 		}
+		sort.Strings(out) // deterministic report text; see eventNames
 		return out
 	}
 	return nil

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -1,0 +1,160 @@
+package github
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestParseWorkflow(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		wantFork     []string
+		wantWrite    []string
+		wantSecrets  bool
+		wantUnparsed bool
+	}{
+		{
+			// octoscope's own release.yml shape. Elevated and
+			// secret-reading, and entirely correct: only someone who can
+			// already push a tag can trigger it. Must not be a fork
+			// trigger, or the axis would flag half of GitHub.
+			name: "tag-triggered release workflow is powerful but trusted",
+			yaml: `
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+jobs:
+  release:
+    steps:
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+`,
+			wantWrite:   []string{"contents: write"},
+			wantSecrets: true,
+		},
+		{
+			// The escalation shape: untrusted input, base-repo secrets.
+			name: "pull_request_target with secrets",
+			yaml: `
+on:
+  pull_request_target:
+    types: [opened]
+permissions:
+  contents: write
+jobs:
+  build:
+    steps:
+      - run: echo ${{ secrets.NPM_TOKEN }}
+`,
+			wantFork:    []string{"pull_request_target"},
+			wantWrite:   []string{"contents: write"},
+			wantSecrets: true,
+		},
+		{
+			// A bare `on:` is read as the boolean true by YAML 1.1, so
+			// the key is "true" rather than "on". Missing this would
+			// silently find no triggers at all, ever.
+			name: "list-form trigger under the YAML-boolean on key",
+			yaml: `
+on: [push, workflow_run]
+permissions: write-all
+`,
+			wantFork:  []string{"workflow_run"},
+			wantWrite: []string{"write-all"},
+		},
+		{
+			// Flow style is valid YAML and a trivial way to defeat a
+			// line-based scanner — the reason this uses a real parser.
+			name: "flow-style mapping is still understood",
+			yaml: `
+on: {issue_comment: {types: [created]}}
+permissions: {contents: write, id-token: write}
+`,
+			wantFork:  []string{"issue_comment"},
+			wantWrite: []string{"contents: write", "id-token: write"},
+		},
+		{
+			// Per-job permissions override the top level, so a workflow
+			// that looks read-only at the top can still be elevated.
+			name: "per-job permissions are picked up",
+			yaml: `
+on: push
+permissions:
+  contents: read
+jobs:
+  publish:
+    permissions:
+      id-token: write
+`,
+			wantWrite: []string{"id-token: write"},
+		},
+		{
+			name: "read-only permissions are not grants",
+			yaml: `
+on: push
+permissions:
+  contents: read
+  issues: read
+`,
+		},
+		{
+			// Not understood must be distinguishable from understood and
+			// clean, or the report would imply a check that never ran.
+			name:         "unparseable content is flagged, not silently clean",
+			yaml:         "\x00\x01 this: [is not: valid: yaml",
+			wantUnparsed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWorkflow([]byte(tt.yaml))
+			if got.Unparsed != tt.wantUnparsed {
+				t.Fatalf("Unparsed = %v, want %v", got.Unparsed, tt.wantUnparsed)
+			}
+			if got.UsesSecrets != tt.wantSecrets {
+				t.Errorf("UsesSecrets = %v, want %v", got.UsesSecrets, tt.wantSecrets)
+			}
+			sort.Strings(got.ForkTriggers)
+			sort.Strings(got.WritePerms)
+			want := append([]string(nil), tt.wantFork...)
+			sort.Strings(want)
+			if len(got.ForkTriggers) != 0 || len(want) != 0 {
+				if !reflect.DeepEqual(got.ForkTriggers, want) {
+					t.Errorf("ForkTriggers = %v, want %v", got.ForkTriggers, want)
+				}
+			}
+			wantW := append([]string(nil), tt.wantWrite...)
+			sort.Strings(wantW)
+			if len(got.WritePerms) != 0 || len(wantW) != 0 {
+				if !reflect.DeepEqual(got.WritePerms, wantW) {
+					t.Errorf("WritePerms = %v, want %v", got.WritePerms, wantW)
+				}
+			}
+		})
+	}
+}
+
+// The parser is handed bytes from a repository that may be hostile, so
+// it must return rather than panic on anything.
+func TestParseWorkflowNeverPanics(t *testing.T) {
+	for _, in := range []string{
+		"", "\n", "---\n", "[]", "null", "on:", "on: null",
+		"on:\n  pull_request_target:\njobs: not-a-map",
+		"permissions: 42", "jobs:\n  a: 1\n  b: [x]",
+	} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("parseWorkflow(%q) panicked: %v", in, r)
+				}
+			}()
+			_ = parseWorkflow([]byte(in))
+		}()
+	}
+}

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -158,3 +158,40 @@ func TestParseWorkflowNeverPanics(t *testing.T) {
 		}()
 	}
 }
+
+// Regressions from the Codex review of #103: three ways a secret can be
+// reachable that a `secrets.` substring check alone would miss.
+func TestParseWorkflowSecretSpellings(t *testing.T) {
+	tests := map[string]string{
+		"dot form":     "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ secrets.TOKEN }}\n",
+		"index form":   "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ secrets['DEPLOY_TOKEN'] }}\n",
+		"inherit form": "on: pull_request_target\njobs:\n  a:\n    uses: ./.github/workflows/reusable.yml\n    secrets: inherit\n",
+	}
+	for name, y := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := parseWorkflow([]byte(y))
+			if !got.UsesSecrets {
+				t.Errorf("secrets not detected in the %s", name)
+			}
+			if len(got.ForkTriggers) != 1 {
+				t.Errorf("fork trigger not detected: %+v", got.ForkTriggers)
+			}
+		})
+	}
+}
+
+// A runner only matters if a job actually targets it.
+func TestParseWorkflowSelfHostedJobs(t *testing.T) {
+	tests := map[string]bool{
+		"jobs:\n  a:\n    runs-on: ubuntu-latest\n":                false,
+		"jobs:\n  a:\n    runs-on: self-hosted\n":                  true,
+		"jobs:\n  a:\n    runs-on: [self-hosted, linux]\n":         true,
+		"jobs:\n  a:\n    runs-on:\n      group: my-org-runners\n": true,
+		"jobs:\n  a:\n    runs-on:\n      labels: [self-hosted]\n": true,
+	}
+	for y, want := range tests {
+		if got := parseWorkflow([]byte("on: push\n" + y)).SelfHostedJobs; got != want {
+			t.Errorf("SelfHostedJobs = %v, want %v for:\n%s", got, want, y)
+		}
+	}
+}

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -56,10 +56,11 @@ jobs:
 			wantSecrets: true,
 		},
 		{
-			// A bare `on:` is read as the boolean true by YAML 1.1, so
-			// the key is "true" rather than "on". Missing this would
-			// silently find no triggers at all, ever.
-			name: "list-form trigger under the YAML-boolean on key",
+			// A bare `on:` decodes to the string key "on" with this
+			// target — measured, not assumed: only a typed map[bool]any
+			// turns it into true. The parser also looks up "true" as
+			// cheap insurance, which this case does not depend on.
+			name: "list-form trigger under a bare on key",
 			yaml: `
 on: [push, workflow_run]
 permissions: write-all

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -249,7 +249,7 @@ func (sm ScanModel) computeBody(width int) string {
 		if s.Verdict == github.VerdictClean {
 			note += " — a clean result covers only what was checked"
 		}
-		b.WriteString(warnStyle.Render(note))
+		b.WriteString(lipgloss.NewStyle().Width(max(width, 20)).Render(warnStyle.Render(note)))
 		b.WriteString("\n\n")
 	}
 

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -234,6 +234,25 @@ func (sm ScanModel) computeBody(width int) string {
 		b.WriteString("\n\n")
 	}
 
+	// ---- What could not be checked
+	//
+	// The capability probes need scopes a minimal token will not have,
+	// and they fail open so the scan still runs. Failing open without
+	// saying so would be the false-negative trap all over again: the
+	// reader has to know a clean verdict covers only what was reachable.
+	if len(s.Unchecked) > 0 {
+		var parts []string
+		for _, u := range s.Unchecked {
+			parts = append(parts, fmt.Sprintf("%s (%s)", u.Name, u.Reason))
+		}
+		note := "Not checked: " + strings.Join(parts, " · ")
+		if s.Verdict == github.VerdictClean {
+			note += " — a clean result covers only what was checked"
+		}
+		b.WriteString(warnStyle.Render(note))
+		b.WriteString("\n\n")
+	}
+
 	// ---- Context: recorded but not scored (delta / push-burst)
 	//
 	// These carry weight 0, so neither the scored-findings section nor

--- a/internal/ui/scan_test.go
+++ b/internal/ui/scan_test.go
@@ -181,3 +181,28 @@ func TestContextRowsCarryNoWeightColumn(t *testing.T) {
 		t.Errorf("scored finding lost its weight column:\n%s", out)
 	}
 }
+
+// Probes that could not run must be named in the report. Failing open
+// keeps the scan working on a minimal token; staying quiet about it
+// would let a clean verdict read as a complete one.
+func TestScanViewDeclaresUncheckedProbes(t *testing.T) {
+	scan := &github.RepoScan{
+		DefaultBranch: "main",
+		Verdict:       github.VerdictClean,
+		Unchecked: []github.UncheckedProbe{
+			{Name: "deploy keys", Reason: "the token lacks the scope this needs"},
+			{Name: "self-hosted runners", Reason: "the token lacks the scope this needs"},
+		},
+	}
+	out := ansi.Strip(ScanModel{scan: scan}.computeBody(140))
+	for _, want := range []string{
+		"Not checked",
+		"deploy keys",
+		"self-hosted runners",
+		"covers only what was checked",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report does not disclose %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
The fourth axis from the design — the persistence and exfiltration footprint, or what a compromise of this repository would be able to reach. It closes the last of the three supply-chain items in this cycle.

## Capability alone is never scored

This is the design, not a compromise made to reduce noise. octoscope's own `release.yml` requests `contents: write` and reads two secrets, and it is entirely correct: it fires on a tag push, so only someone who can already push tags can reach it. Scoring power by itself would flag a large share of GitHub and train everyone to ignore the axis.

What scores is **power reachable from untrusted input**:

| Shape | Result |
|---|---|
| fork-triggered event **+** secrets or write scopes | scores |
| elevated scopes on a trusted trigger | inventory, weight 0 |
| bare fork trigger, nothing held | inventory, weight 0 |
| `permissions: write-all` | small weight on any trigger |
| workflow that will not parse | reported as **not understood** |

The fork-triggered events are `pull_request_target`, `workflow_run` and `issue_comment`. `pull_request` is deliberately absent: a fork PR there gets a read-only token and no secrets, which is the safe design.

Verified live against this repository: `release.yml` produces *"grants contents: write, reachable only from its own triggers"* at **weight 0**, and the verdict stays clean. That was the false positive worth designing around.

## Two halves, two costs

**The workflow half costs no extra API call.** The scan already fetches `.github/workflows` to inventory it; it now reads permissions and triggers from the same bytes.

**The elevated-scope half** probes self-hosted runners, deploy keys and webhooks over REST. Runners are inventory on their own and score only when the repository *also* has a fork-triggered workflow — outsider-supplied code executing on hardware you own. Write deploy keys and off-platform webhooks stay inventory: both are ordinary in healthy repositories, and what would make one suspicious is its *appearance*, which the delta axis added in #68 is the right place to catch.

## Failing open, but not staying quiet

The probes need scopes a minimal token will not have, so a 403 is swallowed — it is not an error worth interrupting anyone for. But whatever could not be checked is carried on `RepoScan` and named in the report, qualifying a clean verdict exactly as partial branch coverage already does:

```
Not checked: deploy keys (the token lacks the scope this needs) — a clean result covers only what was checked
```

Note that GitHub answers 404 rather than 403 for some resources a token cannot see, which is indistinguishable from "none exist" — the report says "not visible to this token" rather than picking one.

## A real YAML parser, deliberately

This promotes `gopkg.in/yaml.v3` from a test-only transitive dependency to a direct one, which in a supply-chain tool deserves stating rather than slipping through. The trade: flow style (`permissions: {contents: write}`) and anchors are valid YAML and defeat line matching trivially, so a regex scanner would be evadable by anyone who cared — and a false negative is the expensive direction here. Input is capped by `maxBlobScanBytes` before it reaches the parser, and `govulncheck` covers the dependency in CI.

The tests pin the YAML 1.1 trap that would otherwise have broken this silently: a bare `on:` decodes as the boolean `true`, so the key is `"true"` and not `"on"`. Missing it means finding no triggers at all, ever.

## The invariant earned its test immediately

The issue asks that no single axis reach a high tier alone. That is now `TestCapabilityAloneCannotReachSuspicious`, and it failed on the first weighting: the worst capability-only shape scored 6 against a `tSuspicious` of 5. The weights came down rather than the threshold going up, so it now lands on Watch and needs a second axis to agree.

## Verification

Six table cases on the scoring matrix, one on per-path deduplication (the same workflow on five branches is one fact, not five), the invariant test, seven parser cases including flow style, the YAML-boolean `on`, per-job permissions and unparseable input, plus a fuzz-ish case asserting the parser never panics on hostile bytes. A render test asserts the unchecked-probe disclosure reaches the screen.

A throwaway smoke test ran the probes against the live API before being deleted: all three ran on this token, found nothing, and the scan survived — which is the load-bearing property.

`gofmt`, `go vet`, the hermetic suite and `govulncheck` are clean. README, guide and design doc updated.

Closes #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability-footprint checks for workflows, self-hosted runners, deploy keys, and external webhooks.
  * Detects risky combinations involving untrusted workflow triggers, secrets, write permissions, and self-hosted runners.
  * Reports unavailable or incomplete checks with their names and reasons.
  * Clean scan results clarify when they cover only successfully checked capabilities.
  * Findings remain visible even when they do not affect the overall score.

* **Documentation**
  * Updated security-scan documentation with capability checks, scoring behavior, and coverage limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->