### PR TITLE
chore(release): prep 0.27.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,18 @@ A cross-platform terminal dashboard for GitHub, written in Go with BubbleTea
   threads resolved with a reply pointing at the fix commit. **Enumerate
   the threads rather than assuming who reviewed** — the roster is not
   fixed, and on any given PR either bot may be absent.
+  - **Never read review state off the check line.** CodeRabbit's check
+    reports a green `pass` with the text *"Review rate limited"* while
+    its review sits on the PR with open findings — three times in the
+    0.27.0 cycle alone (#100, #101, #103), each with real defects
+    waiting behind a check that said everything was fine. `gh pr checks`
+    answers "did CI go green", never "has anyone reviewed this". Only
+    the thread list answers that:
+    ```
+    gh api graphql -f query='{repository(owner:"gfazioli",name:"octoscope")
+      {pullRequest(number:<NN>){reviewThreads(first:30)
+      {nodes{id isResolved path line}}}}}'
+    ```
   - **CodeRabbit reviews automatically — it is not requested, and in
     practice it is the one that finds things.** It posts without being
     asked, so a PR opened five minutes ago may already have findings
@@ -127,6 +139,22 @@ A cross-platform terminal dashboard for GitHub, written in Go with BubbleTea
     its findings come from reading, and still need verifying against
     the code (on #86 it graded a real defect as merely "suspected",
     while the repo's own convention proved it certain).
+    - **The prompt decides whether it is worth running at all.** Two
+      runs in the 0.27.0 cycle, same repo, same reviewer. The first
+      asked it to review a diff, hung in `verifying` for **twelve
+      hours** and produced one usable sentence. The second **named the
+      failure modes to hunt** — "find ways a malicious workflow could
+      hold a fork trigger plus secrets and NOT be detected", listing
+      candidate evasions to rule in or out — and returned **nine real
+      findings**, two of which broke a documented invariant. Write the
+      threat model into the prompt; do not ask for a review.
+    - **It can hang, and there is no partial result.** `status <job-id>`
+      keeps answering while the log stays frozen, and `result <job-id>`
+      replies *"No job found"* until the job completes — so a stalled
+      run yields nothing at all. Give it roughly fifteen minutes, then
+      `node "$S" cancel <job-id>` and move on rather than waiting.
+      Whatever it emitted before stalling is in the agent's own
+      transcript, and is worth reading even when the job never finished.
 - Never add `Co-Authored-By: Claude` trailers.
 - Assign new issues to `gfazioli`.
 - **Issues are the backlog (since 2026-07-29).** One place, public.
@@ -323,9 +351,17 @@ A cross-platform terminal dashboard for GitHub, written in Go with BubbleTea
   check payload, then the `__typename` switch — the second run is what
   proved the real rollup still decoded). Never lands in git — the unit
   suite stays hermetic.
-  - The client constructor is **`New("", Options{})`** (empty login =
-    authenticated viewer), not a `NewClient(ctx)` — getting this wrong
-    costs a compile round-trip every time.
+  - The client constructor is
+    **`c, err := New("", Options{})`** (empty login = authenticated
+    viewer), not a `NewClient(ctx)`. **It returns two values** — the
+    note used to omit that and cost the exact compile round-trip it
+    exists to prevent, twice in 0.27.0. Copy the line, don't retype it:
+    ```go
+    c, err := New("", Options{})
+    if err != nil {
+        t.Fatalf("New: %v", err)
+    }
+    ```
   - Assert something, don't just log: a smoke test that only prints is
     green even when the fetch returns nothing. `if d.CIState != "" &&
     len(d.Checks) == 0 { t.Errorf(...) }` is what actually catches a

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ direct shortcut you can press from inside the menu to skip selection.
   **octoscope never mutates the repo.**
 
   Each scan also records a fingerprint of the repo's auto-execution
-  surface, so the next one can report **what changed since last time** —
+  surface (v0.27.0+), so the next one reports **what changed since last
+  time** —
   a file that auto-executes appeared, an existing one changed, or a
   branch tip that used to be signed no longer is. That signal survives
   renames and re-obfuscation, because a variant still has to *appear*.
@@ -212,8 +213,8 @@ direct shortcut you can press from inside the menu to skip selection.
   own — `scan-baselines.json`, beside your config; deleting it just
   starts a fresh baseline.
 
-  It also reports your **capability footprint** — what a compromise of
-  the repo could reach. Workflow permissions and triggers are read from
+  It also reports your **capability footprint** (v0.27.0+) — what a
+  compromise of the repo could reach. Workflow permissions and triggers are read from
   the files it already fetched, plus self-hosted runners, write deploy
   keys and off-platform webhooks. Holding power is not itself a finding:
   a release workflow with `contents: write` on a tag push is normal and

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -30,7 +30,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.26.0</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.27.0</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1251,7 +1251,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.26.0</span>
+                <span class="version-tag" id="version-pill">0.27.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1490,6 +1490,12 @@
                     <h3>Pipe it &middot; --plain &amp; --json</h3>
                     <p>Since v0.24.0. Run <code class="inline">octoscope --plain</code> for a static text summary, or <code class="inline">octoscope --json</code> for a <strong style="color: var(--text);">stable, versioned JSON contract</strong> you can pipe into <code class="inline">jq</code>, cron jobs or a shell status-line &mdash; no TUI. Both honour <code class="inline">--public-only</code> and the usual auth cascade.</p>
                 </div>
+                <div class="feature w-m">
+                    <div class="feature-label">Integrity over time</div>
+                    <h3>Notices what changed, not just what's there</h3>
+                    <p>The supply-chain scan records a fingerprint of what auto-executes in a repo, then reports what moved since: a file that appeared, one whose contents changed, a branch tip that stopped being signed. It also maps what a compromise could reach — workflow permissions and triggers, self-hosted runners, deploy keys, off-platform webhooks — and says which checks your token couldn't run.</p>
+                </div>
+
                 <div class="feature w-m">
                     <div class="feature-label">Configurable</div>
                     <h3>Tune it to your habits</h3>
@@ -1793,6 +1799,7 @@
                 'Accessibility': 'themes.html',
                 'Polish & reliability': 'live.html',
                 'Scripting': 'scripting.html',
+                'Integrity over time': 'drill-ins.html',
                 'Configurable': 'settings.html'
             };
             function destination(card) {

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,23 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.27.0": {
+		headline: "The integrity scan stops describing, and starts noticing.",
+		items: []whatsNewItem{
+			{
+				title: "What changed since the last scan",
+				desc:  "Every scan now records a fingerprint of the repository's auto-execution surface, so the next one reports what moved: a file that auto-executes appeared, an existing one changed, or a branch tip that used to be signed no longer is. It survives renames and re-obfuscation, because a variant still has to appear. The first scan of a repo says so rather than passing for a clean comparison.",
+			},
+			{
+				title: "What a compromise could reach",
+				desc:  "Workflow permissions and triggers, self-hosted runners, write deploy keys and off-platform webhooks. Holding power is not a finding — a release workflow with contents:write on a tag push is normal. What scores is power reachable from untrusted input, such as a pull_request_target workflow holding your secrets. Checks needing admin scope fail open, and the report names the ones it could not run.",
+			},
+			{
+				title: "A cross-repo push burst now counts as evidence",
+				desc:  "The timing signal that spots a worm fanning out across your repos is wired into the scan at last: recency-gated, and only ever corroborating a repo that already scored. A push burst on its own is a Tuesday.",
+			},
+		},
+	},
 	"0.26.0": {
 		headline: "Improvements & polish — a batch of long-standing backlog items.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.26.0"
+const version = "0.27.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Release prep for 0.27.0, so `main` is taggable the moment this lands.

The cycle shipped three issues, and they compose into one story rather than three: the supply-chain scan stopped only describing a repository and started noticing things about it.

- **#69** — the cross-repo push burst is finally wired in, recency-gated and only ever corroborating a repo that already scored.
- **#68** — every scan records a fingerprint, so the next one reports what *changed*: a file that auto-executes appeared, one whose contents moved, a branch tip that stopped being signed.
- **#67** — the capability footprint: workflow permissions and triggers, self-hosted runners, deploy keys, off-platform webhooks. Power alone is not a finding; power reachable from untrusted input is.

## What's in here

- `main.go` — version to 0.27.0
- `internal/ui/whatsnew.go` — the entry for the in-app What's new tab, one item per issue
- `README.md` — version markers on the two scan paragraphs, matching the surrounding convention
- `docs/index.html` — the inline version fallback, plus an **At a glance** card for the cycle's theme, deep-linked to the guide page that documents it
- `docs/guide/docs.js` — the guide's inline version fallback

Both version pills read the Releases API at runtime, so the values changed here are only what shows when that call cannot be made.

## The guide needed no new page

The two scan sections landed with their own features in #68 and #67, which is the release-checklist step this cycle added working as intended — the guide did not drift, because documenting it was part of shipping it rather than a step at cut time.

Verified: all 28 At a glance cards still resolve to a `DOC_MAP` entry, so the new one is not a dead click. The landing renders, `gofmt`, `go vet`, the suite and `govulncheck` are clean, and the built binary reports 0.27.0.

The hero screenshot is deliberately not in here — it can only read the new version once the bump is built, so it follows as a post-merge, pre-tag commit.
