### PR TITLE
test(scan): build the real maximal case for the capability ceiling

### DIFF
--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -405,25 +405,37 @@ func TestCapabilityAloneCannotReachSuspicious(t *testing.T) {
 	// If this drops below, a contributor has been dropped or reweighted
 	// and the case has quietly stopped being maximal.
 	total := 0
-	zeroWeighted := 0
 	for _, f := range capFindings(got) {
 		total += f.Weight
-		if f.Weight == 0 {
-			zeroWeighted++
-		}
 	}
 	if total != maxCapabilityScore {
 		t.Errorf("axis total %d, want the ceiling %d — the constructed case is no longer maximal", total, maxCapabilityScore)
 	}
 
-	// Clamped arithmetic must not become a clamped report: whatever falls
-	// past the ceiling is still disclosed, at weight 0.
-	if zeroWeighted == 0 {
-		t.Error("no zero-weight capability findings — what the ceiling clamps must still be reported")
+	// Clamped arithmetic must not become a clamped report. Counting
+	// zero-weight findings would not show that: deploy keys and webhooks
+	// are weight 0 by construction, so the count stays satisfied even if
+	// the overflowing finding were dropped outright. The one the ceiling
+	// actually clamps here is the runner escalation — it arrives asking
+	// for wCapEscalation and is zeroed because the workflow already spent
+	// the budget — so name it.
+	const clampedReason = "can run on your own hardware"
+	disclosed := false
+	for _, f := range capFindings(got) {
+		if !strings.Contains(f.Reason, clampedReason) {
+			continue
+		}
+		disclosed = true
+		if f.Weight != 0 {
+			t.Errorf("the clamped runner escalation carries weight %d, want 0", f.Weight)
+		}
+	}
+	if !disclosed {
+		t.Error("the runner escalation the ceiling clamped is absent from the report — the arithmetic is clamped, not the disclosure")
 	}
 
-	t.Logf("worst capability shape: score %d, verdict %v, axis total %d across %d findings (%d disclosed at weight 0)",
-		got.Score, got.Verdict, total, len(capFindings(got)), zeroWeighted)
+	t.Logf("worst capability shape: score %d, verdict %v, axis total %d across %d findings",
+		got.Score, got.Verdict, total, len(capFindings(got)))
 }
 
 // --- delta: what changed since the recorded baseline ---------------------

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -390,8 +390,12 @@ func TestCapabilityAloneCannotReachSuspicious(t *testing.T) {
 	if got.Verdict >= VerdictSuspicious {
 		t.Errorf("capability alone reached %v with score %d — no single axis may do that", got.Verdict, got.Score)
 	}
-	if got.Score == 0 {
-		t.Error("the worst capability shape should still score something")
+	// Exactly the ceiling, not merely non-zero: this axis is the only
+	// scoring contributor in the fixture, so anything less means weight
+	// went missing between the findings and the verdict — which a
+	// non-zero check would wave through.
+	if got.Score != maxCapabilityScore {
+		t.Errorf("score %d, want the ceiling %d — the axis is the only scoring contributor here", got.Score, maxCapabilityScore)
 	}
 
 	// The ceiling must be what holds, not the weights happening to sum

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -366,21 +366,60 @@ func TestCapabilityReportedOncePerPath(t *testing.T) {
 // tier alone. Capability is the newest and therefore the one at risk of
 // having thresholds loosened to make it visible.
 func TestCapabilityAloneCannotReachSuspicious(t *testing.T) {
-	// The worst a workflow can do on this axis: a fork trigger holding
-	// secrets AND write-all.
+	// Every contributor this axis has, in its worst state, in one scan.
+	// The defect this test exists to catch was a *sum* — one
+	// fork-triggered secret-bearing workflow (3) plus a reachable
+	// self-hosted runner (3) reaching Suspicious with no second axis
+	// agreeing — and the first version of this test built a single
+	// workflow, so it was green while the invariant was broken. One term
+	// proves nothing about the total.
 	worst := &workflowFacts{
-		ForkTriggers: []string{"pull_request_target", "workflow_run"},
-		WritePerms:   []string{"write-all"},
-		UsesSecrets:  true,
+		ForkTriggers:   []string{"pull_request_target", "workflow_run", "issue_comment"},
+		WritePerms:     []string{"write-all"},
+		UsesSecrets:    true,
+		SelfHostedJobs: true, // what makes an attached runner reachable
 	}
-	got := evaluateScan(capInput(".github/workflows/x.yml", worst))
+	in := capInput(".github/workflows/x.yml", worst)
+	in.Probes = capabilityProbes{
+		SelfHostedRunners: []string{"builder-1"},
+		WriteDeployKeys:   []string{"ci deploy key"},
+		OffPlatformHooks:  []string{"hooks.example.com"},
+	}
+
+	got := evaluateScan(in)
 	if got.Verdict >= VerdictSuspicious {
 		t.Errorf("capability alone reached %v with score %d — no single axis may do that", got.Verdict, got.Score)
 	}
 	if got.Score == 0 {
 		t.Error("the worst capability shape should still score something")
 	}
-	t.Logf("worst capability-only shape: score %d, verdict %v", got.Score, got.Verdict)
+
+	// The ceiling must be what holds, not the weights happening to sum
+	// low: with one workflow the total lands on 4, which is also the
+	// ceiling, so that case cannot tell a clamped sum from an
+	// uncoincidentally small one. Saturating the ceiling is the proof.
+	// If this drops below, a contributor has been dropped or reweighted
+	// and the case has quietly stopped being maximal.
+	total := 0
+	zeroWeighted := 0
+	for _, f := range capFindings(got) {
+		total += f.Weight
+		if f.Weight == 0 {
+			zeroWeighted++
+		}
+	}
+	if total != maxCapabilityScore {
+		t.Errorf("axis total %d, want the ceiling %d — the constructed case is no longer maximal", total, maxCapabilityScore)
+	}
+
+	// Clamped arithmetic must not become a clamped report: whatever falls
+	// past the ceiling is still disclosed, at weight 0.
+	if zeroWeighted == 0 {
+		t.Error("no zero-weight capability findings — what the ceiling clamps must still be reported")
+	}
+
+	t.Logf("worst capability shape: score %d, verdict %v, axis total %d across %d findings (%d disclosed at weight 0)",
+		got.Score, got.Verdict, total, len(capFindings(got)), zeroWeighted)
 }
 
 // --- delta: what changed since the recorded baseline ---------------------


### PR DESCRIPTION
`TestCapabilityAloneCannotReachSuspicious` guards the invariant that no single
axis may push the verdict to `suspicious` on its own. On Axis 4 that is enforced
by an aggregate ceiling (`maxCapabilityScore = tSuspicious - 1`), added after a
review found one fork-triggered secret-bearing workflow (3) plus a reachable
self-hosted runner (3) summing to 6 against a threshold of 5.

The test built **one workflow**. Its worst shape scores 4 — which is also the
value of the ceiling, so the assertion could not distinguish "the clamp held" from
"the weights happened to sum below the threshold anyway".

That makes it inert against the very regression it exists to catch. Measured, by
disabling the clamp in `addCap` and running both shapes:

| Shape | Ceiling disabled | |
|---|---|---|
| previous (one workflow, no probes) | score 4, `watch` | **passes** — misses the regression |
| this PR (every contributor) | score 7, `suspicious` | **fails**, as it should |

## What changed

Only `scan_test.go`. No production code is touched — the ceiling was already
correct; the test was not proving it.

- **Enumerate every contributor of the axis** in one scan: fork triggers,
  `write-all`, secrets, a self-hosted runner made *reachable* by
  `SelfHostedJobs` (existing alone is inventory, per the reachability rule), plus
  write deploy keys and off-platform webhooks.
- **Assert the ceiling is saturated**, not merely respected. If the axis total
  ever drops below the ceiling, a contributor has been dropped or reweighted and
  the case has quietly stopped being maximal — the failure message says so
  instead of the test silently going green again.
- **Assert the clamped findings are still disclosed** at weight 0. "The
  arithmetic is clamped, not the disclosure" is a documented property of this
  axis and had no test.

## Result

```
worst capability shape: score 4, verdict watch, axis total 4 across 5 findings (3 disclosed at weight 0)
```

`gofmt` clean, `go vet` clean, full suite green under `-race`.

Follows the convention this repo already learned once: a test that pins a ceiling
on a *sum* has to build the maximal case, because one term proves nothing about
the total.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded security-risk scoring coverage for workflows with multiple high-risk capabilities.
  * Added validation to ensure scores are correctly capped at the maximum and that all contributing findings are accounted for.
  * Confirmed these scenarios remain below the “Suspicious” verdict while still producing a nonzero risk score.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->