### PR TITLE
docs(claude): validate an assertion by mutating what it protects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -781,7 +781,11 @@ complexity ceiling before adding fields".
   nothing about the total.
   - **Writing that lesson down was not the same as applying it.** The
     test kept its single workflow afterwards, and that shape scores
-    exactly 4 — which is also the value of the ceiling, so it could not
+    exactly 4 — which is also `maxCapabilityScore`, the axis ceiling,
+    sitting at one below the `tSuspicious` threshold of 5. Ceiling and
+    threshold are two different numbers and both matter here: the sum
+    that broke the invariant was 6 against the *threshold*, while the
+    single-workflow shape lands on the *ceiling*, so the test could not
     tell a clamped sum from one that was naturally small. Removing the
     clamp left it green. Fixed in PR #109, two releases later, and only
     because someone re-read it rather than trusting that a lesson in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -779,6 +779,35 @@ complexity ceiling before adding fields".
   When the property is "these together stay under N", enumerate every
   contributor and construct the worst combination; one term proves
   nothing about the total.
+  - **Writing that lesson down was not the same as applying it.** The
+    test kept its single workflow afterwards, and that shape scores
+    exactly 4 — which is also the value of the ceiling, so it could not
+    tell a clamped sum from one that was naturally small. Removing the
+    clamp left it green. Fixed in PR #109, two releases later, and only
+    because someone re-read it rather than trusting that a lesson in
+    this file had already been acted on.
+- **Validate an assertion by mutating what it protects.** An assertion
+  can be satisfied by something other than the thing it names, and
+  reading it will not tell you — both defects above looked correct on
+  the page. Break the guard deliberately, run the test, and require it
+  to fail; restore, and require it to pass. On a 40-line test-only diff
+  this found two inert assertions, one of them freshly written and one
+  already through a bot review:
+  - the maximal-case gap above — clamp disabled, old shape still passed
+    (score 4, `watch`), the enumerated shape correctly failed (score 7,
+    `suspicious`);
+  - a disclosure assertion that counted zero-weight findings, when
+    deploy keys and webhooks are weight 0 **by construction** — so it
+    stayed satisfied even with overflow findings dropped outright
+    instead of disclosed. It now names the specific finding the ceiling
+    clamps. Caught by Copilot on #109, in a review thread and not in
+    the review body, which is the reason threads get enumerated rather
+    than assumed.
+
+  The mutation is throwaway: patch, measure, `git checkout --` the
+  source, delete any scratch test. What belongs in the commit message
+  is the measurement, so the next reader knows the assertion was proven
+  to bite rather than merely believed to.
 - **`-race` proves nothing about code no test reaches.** The suite was
   green under the race detector while `fetchCapabilityProbes` — three
   goroutines sharing a struct — had no test at all, because it is


### PR DESCRIPTION
Documentation only — no code, no test changes.

PR #109 produced two findings that neither reading nor a green suite would have
surfaced, and both were instances of the same thing: **an assertion satisfied by
something other than what it claims to check.**

1. The maximal-case gap. This file already carried the lesson ("a test that pins a
   ceiling on a *sum* has to build the maximal case") — and the test kept its
   single workflow anyway, for two releases. That shape scores 4, which is also the
   ceiling, so it could not distinguish a clamped sum from a naturally small one.
   With the clamp removed it still passed.
2. A disclosure assertion counting zero-weight findings, while deploy keys and
   webhooks are weight 0 *by construction* — so it held even with overflow findings
   dropped outright rather than disclosed. Caught by Copilot, in a review thread
   rather than the review body.

Neither was provable by reading. Both were provable in under a minute by breaking
the guard and requiring the test to fail.

## What this adds

- A sub-bullet under the existing ceiling lesson recording that **writing it down
  did not get it applied** — worth stating plainly, because the failure mode of a
  conventions file is a reader assuming a documented lesson is already live.
- A new bullet, **"validate an assertion by mutating what it protects"**, with both
  measurements and the note that the mutation is throwaway while the measurement
  belongs in the commit message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded testing guidance for aggregate limits and protected conditions.
  * Added examples for capability-score limits and zero-weight disclosure checks.
  * Included recommendations for cleanup and test measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->