### PR TITLE
fix(scan): an issue anyone can open is untrusted input

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -137,10 +137,28 @@ and teach everyone to ignore the axis. What scores is power reachable from
 
 - **Workflow permissions and triggers** — parsed from `.github/workflows/**`,
   which the scan already fetches, so this half costs no extra API call. The
-  fork-triggered events are `pull_request_target`, `workflow_run` and
-  `issue_comment`: each runs with the base repository's token and secrets while
-  acting on input an outsider controls. `pull_request` is deliberately not one
-  of them — a fork PR there gets a read-only token and no secrets.
+  outsider-triggerable events are `pull_request_target`, `workflow_run`,
+  `issue_comment` and `issues`: each runs with the base repository's token and
+  secrets while acting on input an outsider controls. `pull_request` is
+  deliberately not one of them — a fork PR there gets a read-only token and no
+  secrets.
+
+  The test is **who can cause the run**, not whether a fork is involved, which is
+  why `issues` is on the list ([#111](https://github.com/gfazioli/octoscope/issues/111)):
+  on a public repository anyone can open one, the title and body are theirs, and
+  `issue_comment` was already listed on exactly that reasoning — opening an issue
+  cannot be less untrusted than commenting on one.
+
+  **Known limitation — configuration-dependent events** ([#114](https://github.com/gfazioli/octoscope/issues/114)).
+  `discussion`, `discussion_comment`, `fork` and `watch` are publicly triggerable
+  only where the corresponding repository feature is enabled, and the scan has no
+  repository-configuration input. Adding them unconditionally would score
+  workflows an outsider cannot actually reach, which on this axis is the expensive
+  direction: a wrong positive is what teaches everyone to ignore it. The same
+  issue carries the open question of whether `pull_request` remains a safe
+  exclusion under the fork policies available to private repositories and
+  organisations — a claim about GitHub's behaviour that contradicts the assumption
+  above and is unverified.
   - fork trigger **+** secrets or write scopes → scores `wCapEscalation`
   - elevated scopes on a trusted trigger → inventory, weight 0
   - a bare fork trigger with neither → inventory, weight 0

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -141,7 +141,9 @@ and teach everyone to ignore the axis. What scores is power reachable from
   `issue_comment` and `issues`: each runs with the base repository's token and
   secrets while acting on input an outsider controls. `pull_request` is
   deliberately not one of them — a fork PR there gets a read-only token and no
-  secrets.
+  secrets — **on a public repository**, which is the qualifier the code carries
+  too, since whether the private-repository fork policies can lift it is the open
+  question in #114 rather than a settled fact.
 
   The test is **who can cause the run**, not whether a fork is involved, which is
   why `issues` is on the list ([#111](https://github.com/gfazioli/octoscope/issues/111)):
@@ -159,9 +161,9 @@ and teach everyone to ignore the axis. What scores is power reachable from
   exclusion under the fork policies available to private repositories and
   organisations — a claim about GitHub's behaviour that contradicts the assumption
   above and is unverified.
-  - fork trigger **+** secrets or write scopes → scores `wCapEscalation`
+  - outsider trigger **+** secrets or write scopes → scores `wCapEscalation`
   - elevated scopes on a trusted trigger → inventory, weight 0
-  - a bare fork trigger with neither → inventory, weight 0
+  - a bare outsider trigger with neither → inventory, weight 0
   - `permissions: write-all` → `wCapWriteAll` on any trigger, because it hands
     over every scope rather than the one needed
   - a workflow that will not parse is reported as **not understood**, never as
@@ -204,7 +206,7 @@ and teach everyone to ignore the axis. What scores is power reachable from
 
 - **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`.
   Inventory on their own; they score only when the repository *also* has a
-  fork-triggered workflow, because that combination is outsider-supplied code
+  outsider-triggered workflow, because that combination is outsider-supplied code
   executing on hardware you own.
 - **Deploy keys and webhooks** — `GET /repos/{owner}/{repo}/keys` and `/hooks`.
   Write keys and active off-platform hook targets are reported as inventory:
@@ -226,7 +228,7 @@ workflow reads as holding no write scope. Resolving it needs repository
 permission-default context.
 
 **The invariant.** No single axis may reach a high tier alone. Bounding each finding is not
-enough — a review caught one fork-triggered secret-bearing workflow (3) plus a
+enough — a review caught one outsider-triggered secret-bearing workflow (3) plus a
 reachable self-hosted runner (3) summing to 6 with no second axis agreeing — so
 the axis carries an aggregate ceiling (`maxCapabilityScore`, one below
 `tSuspicious`). Findings past the ceiling are still reported, at weight 0: the

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1097,7 +1097,7 @@ func evaluateScan(in scanInput) *RepoScan {
 			}
 
 			switch {
-			case len(wf.ForkTriggers) > 0 && (wf.UsesSecrets || len(wf.WritePerms) > 0):
+			case len(wf.OutsiderTriggers) > 0 && (wf.UsesSecrets || len(wf.WritePerms) > 0):
 				held := "the repository's secrets"
 				if len(wf.WritePerms) > 0 {
 					held = strings.Join(wf.WritePerms, ", ")
@@ -1111,15 +1111,15 @@ func evaluateScan(in scanInput) *RepoScan {
 					Path:   m.Path,
 					Weight: wCapEscalation,
 					Reason: fmt.Sprintf("triggered by %s — %s — while holding %s",
-						strings.Join(wf.ForkTriggers, ", "), forkTriggers[wf.ForkTriggers[0]], held),
+						strings.Join(wf.OutsiderTriggers, ", "), outsiderTriggers[wf.OutsiderTriggers[0]], held),
 				})
-			case len(wf.ForkTriggers) > 0:
+			case len(wf.OutsiderTriggers) > 0:
 				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
 					Weight: 0,
-					Reason: fmt.Sprintf("triggered by %s, but holds no secrets or write scopes", strings.Join(wf.ForkTriggers, ", ")),
+					Reason: fmt.Sprintf("triggered by %s, but holds no secrets or write scopes", strings.Join(wf.OutsiderTriggers, ", ")),
 				})
 			case len(wf.WritePerms) > 0:
 				// Power on a trusted trigger: inventory, not a finding.
@@ -1143,7 +1143,7 @@ func evaluateScan(in scanInput) *RepoScan {
 					continue
 				}
 				w := 0
-				if len(wf.ForkTriggers) > 0 {
+				if len(wf.OutsiderTriggers) > 0 {
 					w = wCapWriteAll
 				}
 				addCap(Finding{
@@ -1184,7 +1184,7 @@ func evaluateScan(in scanInput) *RepoScan {
 				if !ok || ba.Workflow == nil {
 					continue
 				}
-				if len(ba.Workflow.ForkTriggers) > 0 && ba.Workflow.SelfHostedJobs {
+				if len(ba.Workflow.OutsiderTriggers) > 0 && ba.Workflow.SelfHostedJobs {
 					return true
 				}
 			}

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -278,20 +278,20 @@ func TestEvaluateScanCapability(t *testing.T) {
 		},
 		{
 			name:        "fork trigger with secrets scores",
-			wf:          &workflowFacts{ForkTriggers: []string{"pull_request_target"}, UsesSecrets: true},
+			wf:          &workflowFacts{OutsiderTriggers: []string{"pull_request_target"}, UsesSecrets: true},
 			wantWeight:  wCapEscalation,
 			wantContain: "while holding the repository's secrets",
 		},
 		{
 			name:        "fork trigger with write permissions scores",
-			wf:          &workflowFacts{ForkTriggers: []string{"workflow_run"}, WritePerms: []string{"contents: write"}},
+			wf:          &workflowFacts{OutsiderTriggers: []string{"workflow_run"}, WritePerms: []string{"contents: write"}},
 			wantWeight:  wCapEscalation,
 			wantContain: "contents: write",
 		},
 		{
 			// A fork trigger by itself is a label bot's normal life.
 			name:        "bare fork trigger is inventory only",
-			wf:          &workflowFacts{ForkTriggers: []string{"issue_comment"}},
+			wf:          &workflowFacts{OutsiderTriggers: []string{"issue_comment"}},
 			wantWeight:  0,
 			wantContain: "holds no secrets or write scopes",
 		},
@@ -306,7 +306,7 @@ func TestEvaluateScanCapability(t *testing.T) {
 		},
 		{
 			name:        "write-all a fork trigger can reach does score",
-			wf:          &workflowFacts{ForkTriggers: []string{"pull_request_target"}, WritePerms: []string{"write-all"}},
+			wf:          &workflowFacts{OutsiderTriggers: []string{"pull_request_target"}, WritePerms: []string{"write-all"}},
 			wantWeight:  wCapEscalation + wCapWriteAll,
 			wantContain: "write-all rather than the scopes it needs",
 		},
@@ -345,7 +345,7 @@ func TestEvaluateScanCapability(t *testing.T) {
 // not one per branch — otherwise a repo with ten branches scores ten
 // times for a single file.
 func TestCapabilityReportedOncePerPath(t *testing.T) {
-	wf := &workflowFacts{ForkTriggers: []string{"pull_request_target"}, UsesSecrets: true}
+	wf := &workflowFacts{OutsiderTriggers: []string{"pull_request_target"}, UsesSecrets: true}
 	in := capInput(".github/workflows/x.yml", wf)
 	extra := scanBranch{
 		Prov: provBranch("next", false),
@@ -374,10 +374,10 @@ func TestCapabilityAloneCannotReachSuspicious(t *testing.T) {
 	// workflow, so it was green while the invariant was broken. One term
 	// proves nothing about the total.
 	worst := &workflowFacts{
-		ForkTriggers:   []string{"pull_request_target", "workflow_run", "issue_comment"},
-		WritePerms:     []string{"write-all"},
-		UsesSecrets:    true,
-		SelfHostedJobs: true, // what makes an attached runner reachable
+		OutsiderTriggers: []string{"pull_request_target", "workflow_run", "issue_comment"},
+		WritePerms:       []string{"write-all"},
+		UsesSecrets:      true,
+		SelfHostedJobs:   true, // what makes an attached runner reachable
 	}
 	in := capInput(".github/workflows/x.yml", worst)
 	in.Probes = capabilityProbes{
@@ -961,10 +961,10 @@ func TestBranchCoverageDisclosure(t *testing.T) {
 // reached Suspicious with no other axis agreeing.
 func TestCapabilityAggregateIsClamped(t *testing.T) {
 	in := capInput(".github/workflows/x.yml", &workflowFacts{
-		ForkTriggers:   []string{"pull_request_target"},
-		UsesSecrets:    true,
-		WritePerms:     []string{"write-all"},
-		SelfHostedJobs: true,
+		OutsiderTriggers: []string{"pull_request_target"},
+		UsesSecrets:      true,
+		WritePerms:       []string{"write-all"},
+		SelfHostedJobs:   true,
 	})
 	in.Probes = capabilityProbes{SelfHostedRunners: []string{"box"}}
 
@@ -995,7 +995,7 @@ func TestCapabilityDedupeIsContentKeyed(t *testing.T) {
 		},
 		Blobs: map[string]blobAnalysis{
 			"safe":   {Fetched: true, IsText: true, Workflow: &workflowFacts{}},
-			"danger": {Fetched: true, IsText: true, Workflow: &workflowFacts{ForkTriggers: []string{"pull_request_target"}, UsesSecrets: true}},
+			"danger": {Fetched: true, IsText: true, Workflow: &workflowFacts{OutsiderTriggers: []string{"pull_request_target"}, UsesSecrets: true}},
 		},
 		Now: time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC),
 	}
@@ -1010,7 +1010,7 @@ func TestCapabilityDedupeIsContentKeyed(t *testing.T) {
 // outsider code could run on your hardware when it could not.
 func TestRunnerScoresOnlyWhenReachable(t *testing.T) {
 	unreachable := capInput(".github/workflows/x.yml", &workflowFacts{
-		ForkTriggers: []string{"pull_request_target"}, // but runs on ubuntu-latest
+		OutsiderTriggers: []string{"pull_request_target"}, // but runs on ubuntu-latest
 	})
 	unreachable.Probes = capabilityProbes{SelfHostedRunners: []string{"box"}}
 	if got := evaluateScan(unreachable); got.Score != 0 {
@@ -1018,7 +1018,7 @@ func TestRunnerScoresOnlyWhenReachable(t *testing.T) {
 	}
 
 	reachable := capInput(".github/workflows/x.yml", &workflowFacts{
-		ForkTriggers: []string{"pull_request_target"}, SelfHostedJobs: true,
+		OutsiderTriggers: []string{"pull_request_target"}, SelfHostedJobs: true,
 	})
 	reachable.Probes = capabilityProbes{SelfHostedRunners: []string{"box"}}
 	if got := evaluateScan(reachable); got.Score == 0 {

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -23,27 +23,30 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-// forkTriggers are the events that run with the *base* repository's
+// outsiderTriggers are the events that run with the *base* repository's
 // token and secrets while acting on input an outsider controls. They
 // are the reason capability matters.
 //
-// pull_request is deliberately absent: a fork PR on that event gets a
-// read-only token and no secrets, which is the safe design.
+// The list is about *who can cause the run*, not about forks — which is
+// why the name is not forkTriggers, and why `issues` belongs here (#111):
+// on a public repository anyone can open one, the title and body are
+// theirs, and the run gets the base repository's token and secrets.
+// `issue_comment` was already listed on exactly that reasoning, and opening
+// an issue cannot be less untrusted than commenting on one.
 //
-// The list is about *who can cause the run*, not about forks specifically,
-// which is why `issues` belongs here (#111): on a public repository anyone
-// can open one, the title and body are theirs, and the run gets the base
-// repository's token and secrets. `issue_comment` was already listed on
-// exactly that reasoning, and opening an issue cannot be less untrusted
-// than commenting on one.
+// pull_request is deliberately absent, **on a public repository**: a fork
+// PR on that event gets a read-only token and no secrets. The qualifier is
+// deliberate — whether the private-repository and organisation fork
+// policies can lift that is an open question, not a settled fact, and it is
+// tracked in #114 rather than assumed either way here.
 //
 // Events left out for now, and why they are a question rather than an
 // omission: `discussion`, `discussion_comment`, `fork` and `watch` are
 // publicly triggerable only when the corresponding repository feature is
 // enabled, which the scan has no input for — adding them blind would score
 // workflows an outsider cannot reach, and on this axis a wrong positive is
-// what teaches everyone to ignore it. Tracked separately.
-var forkTriggers = map[string]string{
+// what teaches everyone to ignore it. Also #114.
+var outsiderTriggers = map[string]string{
 	"pull_request_target": "runs with the base repo's token and secrets against a fork's pull request",
 	"workflow_run":        "runs in the base repo context after another workflow, with secrets available",
 	"issue_comment":       "fires on a comment from anyone who can comment",
@@ -52,8 +55,8 @@ var forkTriggers = map[string]string{
 
 // workflowFacts is what one workflow file tells us about capability.
 type workflowFacts struct {
-	// ForkTriggers are the untrusted-input events this workflow answers.
-	ForkTriggers []string
+	// OutsiderTriggers are the untrusted-input events this workflow answers.
+	OutsiderTriggers []string
 	// WritePerms are the elevated grants found, top-level or per-job —
 	// "write-all", "contents: write", "id-token: write", …
 	WritePerms []string
@@ -120,8 +123,8 @@ func parseWorkflow(content []byte) workflowFacts {
 		trigger = root["true"]
 	}
 	for _, ev := range eventNames(trigger) {
-		if _, ok := forkTriggers[ev]; ok {
-			f.ForkTriggers = append(f.ForkTriggers, ev)
+		if _, ok := outsiderTriggers[ev]; ok {
+			f.OutsiderTriggers = append(f.OutsiderTriggers, ev)
 		}
 	}
 

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -29,10 +29,25 @@ import (
 //
 // pull_request is deliberately absent: a fork PR on that event gets a
 // read-only token and no secrets, which is the safe design.
+//
+// The list is about *who can cause the run*, not about forks specifically,
+// which is why `issues` belongs here (#111): on a public repository anyone
+// can open one, the title and body are theirs, and the run gets the base
+// repository's token and secrets. `issue_comment` was already listed on
+// exactly that reasoning, and opening an issue cannot be less untrusted
+// than commenting on one.
+//
+// Events left out for now, and why they are a question rather than an
+// omission: `discussion`, `discussion_comment`, `fork` and `watch` are
+// publicly triggerable only when the corresponding repository feature is
+// enabled, which the scan has no input for — adding them blind would score
+// workflows an outsider cannot reach, and on this axis a wrong positive is
+// what teaches everyone to ignore it. Tracked separately.
 var forkTriggers = map[string]string{
 	"pull_request_target": "runs with the base repo's token and secrets against a fork's pull request",
 	"workflow_run":        "runs in the base repo context after another workflow, with secrets available",
 	"issue_comment":       "fires on a comment from anyone who can comment",
+	"issues":              "fires on an issue anyone can open, carrying their title and body",
 }
 
 // workflowFacts is what one workflow file tells us about capability.

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -10,7 +10,7 @@ func TestParseWorkflow(t *testing.T) {
 	tests := []struct {
 		name         string
 		yaml         string
-		wantFork     []string
+		wantOutsider []string
 		wantWrite    []string
 		wantSecrets  bool
 		wantUnparsed bool
@@ -18,8 +18,8 @@ func TestParseWorkflow(t *testing.T) {
 		{
 			// octoscope's own release.yml shape. Elevated and
 			// secret-reading, and entirely correct: only someone who can
-			// already push a tag can trigger it. Must not be a fork
-			// trigger, or the axis would flag half of GitHub.
+			// already push a tag can trigger it. Must not count as
+			// outsider-triggered, or the axis would flag half of GitHub.
 			name: "tag-triggered release workflow is powerful but trusted",
 			yaml: `
 on:
@@ -51,9 +51,9 @@ jobs:
     steps:
       - run: echo ${{ secrets.NPM_TOKEN }}
 `,
-			wantFork:    []string{"pull_request_target"},
-			wantWrite:   []string{"contents: write"},
-			wantSecrets: true,
+			wantOutsider: []string{"pull_request_target"},
+			wantWrite:    []string{"contents: write"},
+			wantSecrets:  true,
 		},
 		{
 			// A bare `on:` decodes to the string key "on" with this
@@ -65,8 +65,8 @@ jobs:
 on: [push, workflow_run]
 permissions: write-all
 `,
-			wantFork:  []string{"workflow_run"},
-			wantWrite: []string{"write-all"},
+			wantOutsider: []string{"workflow_run"},
+			wantWrite:    []string{"write-all"},
 		},
 		{
 			// Flow style is valid YAML and a trivial way to defeat a
@@ -76,8 +76,8 @@ permissions: write-all
 on: {issue_comment: {types: [created]}}
 permissions: {contents: write, id-token: write}
 `,
-			wantFork:  []string{"issue_comment"},
-			wantWrite: []string{"contents: write", "id-token: write"},
+			wantOutsider: []string{"issue_comment"},
+			wantWrite:    []string{"contents: write", "id-token: write"},
 		},
 		{
 			// Per-job permissions override the top level, so a workflow
@@ -124,13 +124,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BODY: ${{ github.event.issue.body }}
 `,
-			wantFork:    []string{"issues"},
-			wantWrite:   []string{"issues: write"},
-			wantSecrets: true,
+			wantOutsider: []string{"issues"},
+			wantWrite:    []string{"issues: write"},
+			wantSecrets:  true,
 		},
 		{
-			// The scope named `issues` is not the event named `issues`: a
-			// read-only grant on a push-triggered workflow stays inventory.
+			// The scope named `issues` is not the event named `issues`.
+			// This grant is elevated, and still inventory: nothing an
+			// outsider triggers can reach it, because the trigger is push.
 			name: "the issues scope is not the issues event",
 			yaml: `
 on: push
@@ -157,13 +158,13 @@ permissions:
 			if got.UsesSecrets != tt.wantSecrets {
 				t.Errorf("UsesSecrets = %v, want %v", got.UsesSecrets, tt.wantSecrets)
 			}
-			sort.Strings(got.ForkTriggers)
+			sort.Strings(got.OutsiderTriggers)
 			sort.Strings(got.WritePerms)
-			want := append([]string(nil), tt.wantFork...)
+			want := append([]string(nil), tt.wantOutsider...)
 			sort.Strings(want)
-			if len(got.ForkTriggers) != 0 || len(want) != 0 {
-				if !reflect.DeepEqual(got.ForkTriggers, want) {
-					t.Errorf("ForkTriggers = %v, want %v", got.ForkTriggers, want)
+			if len(got.OutsiderTriggers) != 0 || len(want) != 0 {
+				if !reflect.DeepEqual(got.OutsiderTriggers, want) {
+					t.Errorf("OutsiderTriggers = %v, want %v", got.OutsiderTriggers, want)
 				}
 			}
 			wantW := append([]string(nil), tt.wantWrite...)
@@ -232,8 +233,8 @@ func TestParseWorkflowSecretSpellings(t *testing.T) {
 			if !got.UsesSecrets {
 				t.Errorf("secrets not detected in the %s", name)
 			}
-			if len(got.ForkTriggers) != 1 {
-				t.Errorf("fork trigger not detected: %+v", got.ForkTriggers)
+			if len(got.OutsiderTriggers) != 1 {
+				t.Errorf("outsider trigger not detected: %+v", got.OutsiderTriggers)
 			}
 		})
 	}

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -104,6 +104,42 @@ permissions:
 `,
 		},
 		{
+			// #111: the triage shape. Anyone can open an issue on a public
+			// repository, the body is theirs, and the run holds the base
+			// repository's token — the same reasoning that already put
+			// issue_comment on the list. Opening cannot be less untrusted
+			// than commenting.
+			name: "an issue anyone can open is untrusted input",
+			yaml: `
+on:
+  issues:
+    types: [opened]
+permissions:
+  issues: write
+jobs:
+  triage:
+    steps:
+      - run: gh issue comment "$URL" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ github.event.issue.body }}
+`,
+			wantFork:    []string{"issues"},
+			wantWrite:   []string{"issues: write"},
+			wantSecrets: true,
+		},
+		{
+			// The scope named `issues` is not the event named `issues`: a
+			// read-only grant on a push-triggered workflow stays inventory.
+			name: "the issues scope is not the issues event",
+			yaml: `
+on: push
+permissions:
+  issues: write
+`,
+			wantWrite: []string{"issues: write"},
+		},
+		{
 			// Not understood must be distinguishable from understood and
 			// clean, or the report would imply a check that never ran.
 			name:         "unparseable content is flagged, not silently clean",


### PR DESCRIPTION
Closes #111. Follow-up question filed as #114.

The capability axis scores power *reachable from untrusted input*, and decided what
counts as untrusted from a closed list of three events. `issue_comment` was on it,
described in the code as firing "on a comment from anyone who can comment".
`issues` was not — and by that same reasoning, **opening** an issue cannot be less
untrusted than commenting on one.

## The shape this missed

An ordinary triage workflow:

```yaml
on:
  issues:
    types: [opened]
permissions:
  issues: write
jobs:
  triage:
    steps:
      - run: gh issue comment "$URL" --body "$BODY"
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          BODY: ${{ github.event.issue.body }}
```

`WritePerms` and `UsesSecrets` were both extracted correctly; `ForkTriggers` was
empty, so the report said this was reachable only from its own triggers. Anyone can
open an issue on a public repository, the body is theirs, and the run holds the
repository's token.

## Scope, and what is deliberately not here

Four events stay out — `discussion`, `discussion_comment`, `fork`, `watch` — because
they are publicly triggerable only where the corresponding repository feature is
enabled, and the scan has no configuration input to tell. Adding them blind would
score workflows an outsider cannot reach, and on this axis a wrong positive is the
expensive direction: the design rests on reachability, and an axis that cries wolf
gets ignored. `issues` has no such condition on a public repository.

That question, plus the unverified claim that `pull_request` may not be a safe
exclusion under private-repository fork policies, is **#114** — filed rather than
left as a note in the design doc, per the convention that a documented limitation
needs an issue in the same PR.

## Bounded impact worth stating

This makes more workflows score `wCapEscalation` (3), including legitimate triage
bots. That is intended — it is genuinely power reachable from outsider-supplied
input, the class behind script-injection-via-issue-body — and it stays bounded:
`maxCapabilityScore` is 4 against a `tSuspicious` threshold of 5, so this axis
still cannot reach the suspicious tier without a second independent signal
agreeing.

## Verification

Two tests. One is the triage shape above. The other guards a confusion the change
invites: the **scope** named `issues` is not the **event** named `issues`, so
`permissions: {issues: write}` on a push-triggered workflow stays inventory.

Mutation: removing `issues` from the list fails exactly the new case and nothing
else. `gofmt` clean, `go vet` clean, full suite green under `-race`.
