### PR TITLE
feat(scan): resolve the repository's default workflow permissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,39 +158,65 @@ find.
     gh pr view <NN> --json reviews \
       --jq '.reviews[] | select(.author.login|test("copilot";"i")) | .body'
     ```
-  - **Codex is an optional third reviewer** (the `codex:codex-rescue`
-    agent), worth reaching for when a diff touches a security boundary
-    or a fetch path. Two operational facts, both learned the hard way:
-    the agent is a **one-shot forwarder** — it returns a job id and
-    will not poll, fetch or summarise, so asking it again for the
-    findings just restates the id; and the `/codex:*` slash commands
-    are `disable-model-invocation: true`, so the result has to be
-    pulled by running the companion script directly:
+  - **Codex is an optional third reviewer**, worth reaching for when a
+    diff touches a security boundary or a fetch path. **Call the CLI
+    directly** (measured on `codex-cli` 0.146.0) — it is synchronous and
+    hands back the whole review in one invocation:
+    ```bash
+    # prompt in a file: it is long, and shell-quoting a threat model is a trap
+    codex exec -C . -s read-only --color never - < codex-prompt.md > codex-out.txt 2>&1
+    tail -200 codex-out.txt   # the verdict is at the tail; the rest is tool trace
     ```
-    S=$(echo ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs)
-    node "$S" status <job-id> --wait --timeout-ms 900000
-    node "$S" result <job-id>
-    ```
-    Codex runs read-only, so it cannot execute `go test` / `go vet` —
-    its findings come from reading, and still need verifying against
-    the code (on #86 it graded a real defect as merely "suspected",
-    while the repo's own convention proved it certain).
-    - **The prompt decides whether it is worth running at all.** Two
-      runs in the 0.27.0 cycle, same repo, same reviewer. The first
-      asked it to review a diff, hung in `verifying` for **twelve
-      hours** and produced one usable sentence. The second **named the
-      failure modes to hunt** — "find ways a malicious workflow could
-      hold a fork trigger plus secrets and NOT be detected", listing
-      candidate evasions to rule in or out — and returned **nine real
-      findings**, two of which broke a documented invariant. Write the
-      threat model into the prompt; do not ask for a review.
-    - **It can hang, and there is no partial result.** `status <job-id>`
-      keeps answering while the log stays frozen, and `result <job-id>`
-      replies *"No job found"* until the job completes — so a stalled
-      run yields nothing at all. Give it roughly fifteen minutes, then
-      `node "$S" cancel <job-id>` and move on rather than waiting.
-      Whatever it emitted before stalling is in the agent's own
-      transcript, and is worth reading even when the job never finished.
+    `-s read-only` is the right sandbox for a review and is why it cannot
+    run `go test` / `go vet`: its findings come from reading, and every one
+    of them needs verifying against the code and the primary docs. Redirect
+    to a file — a single run emitted **6339 lines**, nearly all of it
+    trace, with the findings repeated once mid-stream and once at the end.
+    - **The prompt decides whether it is worth running at all.** Three
+      runs now say the same thing. In 0.27.0, asking it to review a diff
+      hung for **twelve hours** and produced one usable sentence; naming
+      the failure modes to hunt returned **nine real findings**, two of
+      them breaking a documented invariant. On #116 the prompt carried
+      the axis-4 invariant, the ceiling, the fail-open rule and six
+      numbered attack surfaces, with "if a section yields nothing, say
+      nothing" — and it answered per section, clean verdicts included.
+      Write the threat model into the prompt; do not ask for a review.
+    - **Its confidence is uncorrelated with its correctness, and that
+      cuts both ways.** On #116 one of three findings survived — but
+      that one was an invariant breach shipped in v0.27.0 that had
+      **passed CodeRabbit twice**, on the PR that introduced it (#101)
+      and again on #116: the push-burst gate read the whole score
+      including Axis 4, so capability plus timing reached Suspicious,
+      contradicting two code comments and `docs/design/` at once.
+
+      The one it graded **High** was wrong, and wrong in the most
+      expensive way available: it quoted a **real sentence** from
+      GitHub's reference (`pull_request_target` "is granted read/write
+      repository permission") while missing the ordered permission
+      calculation on the same page, where the repository default is step
+      one and the fork downgrade is the last step and can only *remove*
+      write. Applying it would have shipped a false positive on the axis
+      whose entire premise is not producing them. This is the repo's own
+      *verified over plausible* rule arriving from outside — a citation
+      is not a verification, and a finding graded High deserves the
+      primary source read further than the sentence quoted.
+    - **The `codex:codex-rescue` agent is the fallback, not the default.**
+      It is a **one-shot forwarder** — returns a job id and will not
+      poll, fetch or summarise, so asking again just restates the id —
+      and the `/codex:*` slash commands are
+      `disable-model-invocation: true`, so its result has to be pulled
+      by hand:
+      ```
+      S=$(echo ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs)
+      node "$S" status <job-id> --wait --timeout-ms 900000
+      node "$S" result <job-id>
+      ```
+      That path can hang with **no partial result**: `status` keeps
+      answering while the log stays frozen and `result` replies *"No job
+      found"* until completion. Give it fifteen minutes, then
+      `node "$S" cancel <job-id>`. Whatever it emitted before stalling is
+      in the agent's own transcript and is worth reading anyway. The
+      direct `codex exec` call above avoids the whole failure mode.
 - Never add `Co-Authored-By: Claude` trailers.
 - Assign new issues to `gfazioli`.
 - **Issues are the backlog (since 2026-07-29).** One place, public.

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -221,6 +221,20 @@ a secret the caller passed *by name* is scored independently, and on its own
 `workflow_call` is not untrusted input. Joining caller and callee needs a
 cross-file pass this axis does not yet do.
 
+The same gap now reaches the inherited-permission fact below, and the direction
+of the error is worth stating because it is not obvious. GitHub's reference:
+*"If `jobs.<job_id>.permissions` is not specified in the calling job, the called
+workflow will have the default permissions for the `GITHUB_TOKEN`"*, and what it
+receives *"can be only downgraded (not elevated)"*. So for a file whose **only**
+trigger is `workflow_call`, whether it really runs on the repository default is
+the **caller's** decision: right whenever the caller declares nothing, wrong the
+moment the caller declares anything — including `permissions: {}`, which hands
+over nothing at all. Assessed per file, that is unknowable rather than merely
+unknown, so the fact is reported as it stands and the residual wrong claim is the
+*reachability* half: a callee has no triggers of its own to be "reachable only
+from". Suppressing the fact instead would trade one wrong answer for another, and
+guessing a caller is what #106 exists to stop doing.
+
 - **Default workflow permissions** — `GET /repos/{owner}/{repo}/actions/permissions/workflow`
   ([#107](https://github.com/gfazioli/octoscope/issues/107)). A workflow that
   declares no `permissions:` block runs with the repository's default, which an
@@ -342,9 +356,21 @@ scan is tiered accordingly.
   [#69](https://github.com/gfazioli/octoscope/issues/69) did:
   `DetectPushBurst` now runs inside `FetchRepoScan`, gated on
   `pushBurstRecency` (one hour), and contributes `wPushBurstCorroboration`
-  **only to a repo that already scored on Axes 1-3**. A burst on a repo with
-  no other finding is still reported — at weight 0, so the user sees the
-  context without it moving the verdict. The repo list comes from the caller's
+  **only to a repo that already scored on Axes 1-3 or on the baseline delta**.
+  A burst on a repo with no other finding is still reported — at weight 0, so
+  the user sees the context without it moving the verdict.
+
+  **Axis 4 is deliberately excluded from that gate**, and for two releases the
+  code did not honour it: the condition was the whole running score, which
+  includes capability. Capability describes *configuration*, not something that
+  happened, which is why the axis carries its own ceiling one below
+  `tSuspicious` — so a capability finding (3) plus a burst (3) reached
+  Suspicious on configuration and timing alone, handing that ceiling straight
+  back. The gate now sums non-capability findings explicitly. Found by a
+  reviewer on [#116](https://github.com/gfazioli/octoscope/pull/116), which
+  widened how many repositories score on Axis 4 and therefore how many could
+  reach it; the invariant had been stated in two code comments and in this
+  document while the code disagreed with all three. The repo list comes from the caller's
   existing dashboard fetch, so it remains free; `--public-only` narrows it, on
   the grounds that a screenshot-safe mode must not disclose private push
   activity even as a count.

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -205,7 +205,7 @@ and teach everyone to ignore the axis. What scores is power reachable from
     be called secrets — does not, and neither does `mysecrets`.
 
 - **Self-hosted runners** — `GET /repos/{owner}/{repo}/actions/runners`.
-  Inventory on their own; they score only when the repository *also* has a
+  Inventory on their own; they score only when the repository *also* has an
   outsider-triggered workflow, because that combination is outsider-supplied code
   executing on hardware you own.
 - **Deploy keys and webhooks** — `GET /repos/{owner}/{repo}/keys` and `/hooks`.
@@ -221,11 +221,33 @@ a secret the caller passed *by name* is scored independently, and on its own
 `workflow_call` is not untrusted input. Joining caller and callee needs a
 cross-file pass this axis does not yet do.
 
-**Known limitation — implicit default permissions** ([#107](https://github.com/gfazioli/octoscope/issues/107)). A workflow with no
-`permissions:` block inherits the repository's default, which an organisation
-can set to write. The parser reads only what the file declares, so such a
-workflow reads as holding no write scope. Resolving it needs repository
-permission-default context.
+- **Default workflow permissions** — `GET /repos/{owner}/{repo}/actions/permissions/workflow`
+  ([#107](https://github.com/gfazioli/octoscope/issues/107)). A workflow that
+  declares no `permissions:` block runs with the repository's default, which an
+  owner or organisation can widen to read/write — so the file can hold write
+  access it never mentions, and the parser alone cannot see it. The probe supplies
+  the missing half, and the two are joined in the scoring engine, where an
+  inherited write is then treated exactly as a declared one: the power is the
+  same, only its spelling differs.
+
+  Two details carry the weight here.
+
+  *Declaring anything overrides the default*, so what matters is whether a block
+  exists, not whether it grants anything — `permissions: {contents: read}` grants
+  nothing elevated and still overrides. That is a distinction the write-grant
+  extraction cannot make on its own, since both cases leave it empty, so the
+  parser reports it separately. Per-job blocks count the same way, and one
+  inheriting job is enough.
+
+  *An unknown default resolves to neither value.* Measured: this endpoint answers
+  403 on a repository the token does not own, so it works for the owner-affiliated
+  repositories that are the scan's default scope and fails open elsewhere. Where
+  it fails, the report says so — and stops saying the workflow "holds no secrets
+  or write scopes", because that claim is exactly what the unread setting would
+  have decided. The gap is declared **only where some workflow actually inherits
+  it**: naming an unreadable setting on a repository whose workflows all declare
+  their own permissions is noise about a fact that changes nothing, and a report
+  has to stay worth reading to be read.
 
 **The invariant.** No single axis may reach a high tier alone. Bounding each finding is not
 enough — a review caught one outsider-triggered secret-bearing workflow (3) plus a

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -360,9 +360,9 @@ scan is tiered accordingly.
   A burst on a repo with no other finding is still reported — at weight 0, so
   the user sees the context without it moving the verdict.
 
-  **Axis 4 is deliberately excluded from that gate**, and for two releases the
-  code did not honour it: the condition was the whole running score, which
-  includes capability. Capability describes *configuration*, not something that
+  **Axis 4 is deliberately excluded from that gate**, and from v0.27.0 — where
+  the burst and the capability axis shipped together — the code did not honour
+  it: the condition was the whole running score, which includes capability. Capability describes *configuration*, not something that
   happened, which is why the axis carries its own ceiling one below
   `tSuspicious` — so a capability finding (3) plus a burst (3) reached
   Suspicious on configuration and timing alone, handing that ceiling straight

--- a/internal/github/capability.go
+++ b/internal/github/capability.go
@@ -38,6 +38,20 @@ type capabilityProbes struct {
 	WriteDeployKeys   []string // titles of keys that are not read-only
 	OffPlatformHooks  []string // hook targets outside github.com
 	Unchecked         []UncheckedProbe
+
+	// DefaultWorkflowPerms is the repository's default permission for
+	// workflows that declare none — "read", "write", or "" when the probe
+	// could not run (#107). Empty must not be read as either value: a
+	// repository whose default is unknown is not assumed permissive or
+	// restrictive, it is declared unchecked.
+	//
+	// Its Unchecked entry is deliberately *not* added here. Whether the gap
+	// is worth reporting depends on the workflows found, which only the
+	// scoring engine knows: naming it on a repository where every workflow
+	// declares its own permissions would be noise about a fact that changes
+	// nothing.
+	DefaultWorkflowPerms  string
+	DefaultPermsUnchecked string // reason, when DefaultWorkflowPerms is ""
 }
 
 // restList performs one authenticated GET and decodes into out. It
@@ -111,7 +125,34 @@ func (c *Client) fetchCapabilityProbes(ctx context.Context, owner, name string) 
 		mu.Unlock()
 	}
 
-	wg.Add(3)
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		var payload struct {
+			Default string `json:"default_workflow_permissions"`
+		}
+		ok, why := c.restList(ctx, base+"/actions/permissions/workflow", &payload)
+		mu.Lock()
+		defer mu.Unlock()
+		if !ok {
+			// Measured: this answers 403 on a repository the token does not
+			// own — "you must have repository read permissions or the
+			// repository Actions policies fine-grained permission" — so it
+			// works for the owned repositories that are the scan's default
+			// scope and fails open elsewhere.
+			out.DefaultPermsUnchecked = why
+			return
+		}
+		// Only the two documented values are trusted. Anything else is
+		// treated as not answered rather than guessed at, since the whole
+		// point is not assuming a default.
+		if payload.Default == "read" || payload.Default == "write" {
+			out.DefaultWorkflowPerms = payload.Default
+			return
+		}
+		out.DefaultPermsUnchecked = "GitHub answered with an unrecognised value"
+	}()
 
 	go func() {
 		defer wg.Done()

--- a/internal/github/capability_test.go
+++ b/internal/github/capability_test.go
@@ -188,3 +188,55 @@ func TestProbeDeclaresTruncatedPage(t *testing.T) {
 		t.Errorf("a truncated list must be declared: %+v", p.Unchecked)
 	}
 }
+
+// #107: the default-workflow-permissions probe. Empty must never be read as
+// either value — a repository whose default could not be read is declared
+// unchecked rather than assumed permissive or restrictive.
+func TestFetchCapabilityProbesDefaultWorkflowPerms(t *testing.T) {
+	tests := map[string]struct {
+		handler       func(http.ResponseWriter)
+		want          string
+		wantUnchecked bool
+	}{
+		"write is read": {
+			handler: json200(`{"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}`),
+			want:    "write",
+		},
+		"read is read": {
+			handler: json200(`{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}`),
+			want:    "read",
+		},
+		// Measured against the live API: a repository the token does not own
+		// answers 403 here, which is the ordinary case for anything outside
+		// the scan's owner-affiliated default scope.
+		"a 403 fails open with a reason": {
+			handler: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = io.WriteString(w, `{"message":"You must have repository read permissions"}`)
+			},
+			want:          "",
+			wantUnchecked: true,
+		},
+		// Guessing at an unrecognised value would defeat the point of the
+		// probe, which exists so the default is not assumed.
+		"an unrecognised value is not guessed at": {
+			handler:       json200(`{"default_workflow_permissions":"everything"}`),
+			want:          "",
+			wantUnchecked: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := newTestRESTClient(t, map[string]func(http.ResponseWriter){
+				"/actions/permissions/workflow": tt.handler,
+			})
+			got := c.fetchCapabilityProbes(context.Background(), "o", "r")
+			if got.DefaultWorkflowPerms != tt.want {
+				t.Errorf("DefaultWorkflowPerms = %q, want %q", got.DefaultWorkflowPerms, tt.want)
+			}
+			if (got.DefaultPermsUnchecked != "") != tt.wantUnchecked {
+				t.Errorf("DefaultPermsUnchecked = %q, wantUnchecked %v", got.DefaultPermsUnchecked, tt.wantUnchecked)
+			}
+		})
+	}
+}

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -110,8 +110,10 @@ type PushBurst struct {
 // It is now consumed by FetchRepoScan as the account-wide signal, which
 // fixes both: the
 // result is gated on pushBurstRecency, and it only scores
-// (wPushBurstCorroboration) for a repo that already scored on Axis 1-3 —
-// so it corroborates evidence instead of manufacturing a verdict.
+// (wPushBurstCorroboration) for a repo that already scored on Axis 1-3 or
+// on the baseline delta — never on Axis 4 alone, since capability is a
+// configuration risk and nothing has happened. So it corroborates
+// evidence instead of manufacturing a verdict.
 func DetectPushBurst(repos []Repo, minRepos int, window time.Duration) (PushBurst, bool) {
 	pushed := make([]Repo, 0, len(repos))
 	for _, r := range repos {
@@ -428,7 +430,8 @@ const (
 
 	// wPushBurstCorroboration is the account-wide timing signal's
 	// contribution, and it is applied **only to a repo that already
-	// scored on Axis 1-3**. That gate is the whole point: timing alone
+	// scored on Axis 1-3 or on the baseline delta** — never to one whose
+	// only score is Axis 4. That gate is the whole point: timing alone
 	// cannot separate a worm fan-out from a maintainer scripting an
 	// update across their repos, so a burst must never produce a
 	// verdict by itself — a push burst on its own is a Tuesday. When
@@ -1427,11 +1430,37 @@ func evaluateScan(in scanInput) *RepoScan {
 		age <= pushBurstRecency {
 		// Read the score *before* this finding: corroboration means
 		// "something else already flagged", not "the burst flagged".
-		corroborates := s.Score > 0
+		//
+		// Capability is excluded, and that exclusion is the invariant
+		// rather than a detail. Axis 4 describes a *configuration* risk —
+		// nothing has happened — which is why it carries its own ceiling
+		// at one below tSuspicious. Letting it corroborate hands that
+		// ceiling straight back: a capability finding (3) plus a burst (3)
+		// is 6, so configuration plus account-wide timing would reach
+		// Suspicious with no evidence that anything ran, forged or
+		// changed. `s.Score > 0` did exactly that, against what both this
+		// weight's own comment and DetectPushBurst's promised. Delta does
+		// corroborate: a new auto-execution surface *appearing* is an
+		// event, which is precisely what the burst is timing evidence for.
+		evidence := 0
+		for _, f := range s.Findings {
+			if f.Axis != AxisCapability {
+				evidence += f.Weight
+			}
+		}
+		corroborates := evidence > 0
 		weight := 0
 		reason := fmt.Sprintf(
 			"pushed as part of a burst of %d repos within %s — no scored finding in this repo for it to corroborate, so it does not affect the verdict",
 			in.Burst.Count, in.Burst.Span.Round(time.Second))
+		if !corroborates && s.Score > 0 {
+			// Something *did* score, so "no scored finding" would be false.
+			// Naming what was found and why it does not count is the part
+			// that makes the weight-0 entry readable rather than puzzling.
+			reason = fmt.Sprintf(
+				"pushed as part of a burst of %d repos within %s — the only findings here are workflow capability, which describes configuration rather than something that happened, so the burst has nothing to corroborate and does not affect the verdict",
+				in.Burst.Count, in.Burst.Span.Round(time.Second))
+		}
 		if corroborates {
 			weight = wPushBurstCorroboration
 			reason = fmt.Sprintf(

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1041,6 +1041,10 @@ func evaluateScan(in scanInput) *RepoScan {
 	// Reported once per distinct workflow content: the same file on five
 	// branches is one fact about the repo, not five.
 	var uncheckedWorkflows []string
+	// Whether some workflow depended on the repository default while that
+	// default was unreadable. This is what decides whether the gap is worth
+	// declaring at all — see below.
+	inheritedDefaultUnknown := false
 
 	// Axis 4 is clamped as a whole, not just per finding. Individual
 	// weights below tSuspicious are not enough on their own: one
@@ -1096,11 +1100,30 @@ func evaluateScan(in scanInput) *RepoScan {
 				continue
 			}
 
+			// A workflow declaring no permissions inherits the repository's
+			// default, which is not in the file — so the file can hold write
+			// access it never mentions (#107). Resolved here, where the probe
+			// result is available, and then treated exactly as a declared
+			// grant: the power is the same, only its spelling differs.
+			//
+			// An unknown default resolves to false, not to permissive. The
+			// gap is declared instead, further down, and only when a workflow
+			// actually depends on it.
+			inheritsWrite := wf.InheritsDefaultPerms && in.Probes.DefaultWorkflowPerms == "write"
+			if wf.InheritsDefaultPerms && in.Probes.DefaultWorkflowPerms == "" {
+				inheritedDefaultUnknown = true
+			}
+			holdsWrite := len(wf.WritePerms) > 0 || inheritsWrite
+
 			switch {
-			case len(wf.OutsiderTriggers) > 0 && (wf.UsesSecrets || len(wf.WritePerms) > 0):
+			case len(wf.OutsiderTriggers) > 0 && (wf.UsesSecrets || holdsWrite):
 				held := "the repository's secrets"
-				if len(wf.WritePerms) > 0 {
-					held = strings.Join(wf.WritePerms, ", ")
+				if holdsWrite {
+					if len(wf.WritePerms) > 0 {
+						held = strings.Join(wf.WritePerms, ", ")
+					} else {
+						held = "the repository's default write permission, which it does not declare"
+					}
 					if wf.UsesSecrets {
 						held += " and the repository's secrets"
 					}
@@ -1114,21 +1137,32 @@ func evaluateScan(in scanInput) *RepoScan {
 						strings.Join(wf.OutsiderTriggers, ", "), outsiderTriggers[wf.OutsiderTriggers[0]], held),
 				})
 			case len(wf.OutsiderTriggers) > 0:
+				// "Holds nothing" is a claim, so it must not be made where
+				// the unknown default is the thing that would decide it.
+				reason := fmt.Sprintf("triggered by %s, but holds no secrets or write scopes", strings.Join(wf.OutsiderTriggers, ", "))
+				if wf.InheritsDefaultPerms && in.Probes.DefaultWorkflowPerms == "" {
+					reason = fmt.Sprintf("triggered by %s and declares no permissions, so it runs with the repository default — which could not be read",
+						strings.Join(wf.OutsiderTriggers, ", "))
+				}
 				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
 					Weight: 0,
-					Reason: fmt.Sprintf("triggered by %s, but holds no secrets or write scopes", strings.Join(wf.OutsiderTriggers, ", ")),
+					Reason: reason,
 				})
-			case len(wf.WritePerms) > 0:
+			case holdsWrite:
 				// Power on a trusted trigger: inventory, not a finding.
+				grants := strings.Join(wf.WritePerms, ", ")
+				if len(wf.WritePerms) == 0 {
+					grants = "the repository's default write permission"
+				}
 				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
 					Weight: 0,
-					Reason: fmt.Sprintf("grants %s, reachable only from its own triggers", strings.Join(wf.WritePerms, ", ")),
+					Reason: fmt.Sprintf("grants %s, reachable only from its own triggers", grants),
 				})
 			}
 
@@ -1167,6 +1201,25 @@ func evaluateScan(in scanInput) *RepoScan {
 		s.Unchecked = append(s.Unchecked, UncheckedProbe{
 			Name:   p,
 			Reason: "content not retrieved, so its permissions and triggers were not read",
+		})
+	}
+	// The default-permission gap is declared only where it changes an
+	// answer — that is, where some workflow declares no permissions and so
+	// depends on a default nobody could read. On a repository whose
+	// workflows all declare their own, saying the setting was unreadable
+	// would be noise about a fact that decides nothing, and this report has
+	// to stay worth reading to be read at all.
+	if inheritedDefaultUnknown {
+		reason := in.Probes.DefaultPermsUnchecked
+		if reason == "" {
+			reason = "not read"
+		}
+		// Kept short: the UI joins these inline with the other probes, so a
+		// full explanation here would crowd out the ones beside it. Why it
+		// matters is already in the finding for the workflow that inherits.
+		s.Unchecked = append(s.Unchecked, UncheckedProbe{
+			Name:   "default workflow permissions",
+			Reason: reason + " — some workflows inherit it",
 		})
 	}
 

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -822,6 +822,49 @@ func TestEvaluateScanPushBurst(t *testing.T) {
 	}
 }
 
+// The burst must not corroborate Axis 4. Capability describes
+// configuration, not an event, which is why the axis carries its own
+// ceiling at one below tSuspicious — and letting a burst corroborate it
+// hands that ceiling straight back: 3 + 3 = 6 reaches Suspicious with no
+// evidence that anything ran, forged or changed. The gate read
+// `s.Score > 0`, which included Axis 4, against what both
+// wPushBurstCorroboration's comment and DetectPushBurst's promised.
+// Found by Codex reviewing #116, which widened how many repos score on
+// Axis 4 and so how many could reach this.
+func TestPushBurstDoesNotCorroborateCapabilityAlone(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	in := capInput(".github/workflows/x.yml", &workflowFacts{
+		OutsiderTriggers: []string{"pull_request_target"},
+		UsesSecrets:      true,
+	})
+	in.Now = now
+	in.Burst = PushBurst{Count: 5, Span: 49 * time.Second, Newest: now.Add(-5 * time.Minute), Repos: []string{"r", "a", "b", "c", "d"}}
+	in.BurstHit = true
+
+	got := evaluateScan(in)
+	if got.Score != wCapEscalation {
+		t.Fatalf("score = %d, want %d — the capability finding alone should score (findings %+v)",
+			got.Score, wCapEscalation, got.Findings)
+	}
+	f, ok := burstFinding(got)
+	if !ok {
+		t.Fatal("no push-burst finding: the burst must still be disclosed, just not scored")
+	}
+	if f.Weight != 0 {
+		t.Errorf("push-burst weight = %d, want 0 — capability is not evidence for a burst to corroborate", f.Weight)
+	}
+	if got.Verdict == VerdictSuspicious {
+		t.Errorf("verdict = %v: capability plus account-wide timing reached Suspicious with no Axis 1-3 evidence", got.Verdict)
+	}
+	// "No scored finding" would be a false sentence here — one did score.
+	if strings.Contains(f.Reason, "no scored finding") {
+		t.Errorf("reason claims nothing scored while the capability finding did: %q", f.Reason)
+	}
+	if !strings.Contains(f.Reason, "nothing to corroborate") {
+		t.Errorf("reason does not say why the burst is unscored: %q", f.Reason)
+	}
+}
+
 // The weight-0 burst finding must stay out of ScoredFindings so the
 // report's scored-evidence section doesn't imply it moved the needle.
 func TestPushBurstAloneIsNotScoredEvidence(t *testing.T) {

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -1042,3 +1042,99 @@ func TestUnretrievedWorkflowIsDeclared(t *testing.T) {
 		t.Errorf("an unretrieved workflow was not declared: %+v", got.Unchecked)
 	}
 }
+
+// #107: a workflow declaring no permissions runs on the repository default,
+// which is not in the file. The axis has to resolve it, and — the part that
+// matters more — must not guess when it cannot.
+func TestCapabilityResolvesDefaultWorkflowPerms(t *testing.T) {
+	// The shape from the issue: a fork trigger and no permissions block at
+	// all. Whether this is dangerous is a fact about the repository, not
+	// about the file.
+	bare := &workflowFacts{
+		OutsiderTriggers:     []string{"pull_request_target"},
+		InheritsDefaultPerms: true,
+	}
+
+	tests := map[string]struct {
+		wf            *workflowFacts
+		probes        capabilityProbes
+		wantScored    bool
+		wantUnchecked bool
+		wantReason    string
+	}{
+		"default write makes it an escalation": {
+			wf:         bare,
+			probes:     capabilityProbes{DefaultWorkflowPerms: "write"},
+			wantScored: true,
+			wantReason: "default write permission",
+		},
+		"default read leaves it inventory": {
+			wf:         bare,
+			probes:     capabilityProbes{DefaultWorkflowPerms: "read"},
+			wantScored: false,
+			wantReason: "holds no secrets or write scopes",
+		},
+		// The honest case: unknown must not resolve to permissive, and must
+		// not resolve to "holds nothing" either — that would be a claim the
+		// scan cannot support.
+		"an unknown default is declared, not assumed": {
+			wf:            bare,
+			probes:        capabilityProbes{DefaultPermsUnchecked: "the token lacks the scope this needs"},
+			wantScored:    false,
+			wantUnchecked: true,
+			wantReason:    "could not be read",
+		},
+		// Declaring anything overrides the default, so a read-only block on
+		// a permissive repository is genuinely safe and must not be flagged
+		// — nor should the gap be declared, since nothing depends on it.
+		"a declared block overrides a permissive default": {
+			wf:            &workflowFacts{OutsiderTriggers: []string{"pull_request_target"}},
+			probes:        capabilityProbes{DefaultWorkflowPerms: "write"},
+			wantScored:    false,
+			wantUnchecked: false,
+			wantReason:    "holds no secrets or write scopes",
+		},
+		// And the gap is not declared where it decides nothing: unknown
+		// default, but this workflow declares its own permissions.
+		"an unknown default is not declared when nothing inherits it": {
+			wf:            &workflowFacts{OutsiderTriggers: []string{"pull_request_target"}},
+			probes:        capabilityProbes{DefaultPermsUnchecked: "the token lacks the scope this needs"},
+			wantScored:    false,
+			wantUnchecked: false,
+			wantReason:    "holds no secrets or write scopes",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			in := capInput(".github/workflows/x.yml", tt.wf)
+			in.Probes = tt.probes
+			got := evaluateScan(in)
+
+			scored := false
+			reasons := ""
+			for _, f := range capFindings(got) {
+				reasons += f.Reason + "\n"
+				if f.Weight > 0 {
+					scored = true
+				}
+			}
+			if scored != tt.wantScored {
+				t.Errorf("scored = %v, want %v (score %d)\n%s", scored, tt.wantScored, got.Score, reasons)
+			}
+			if !strings.Contains(reasons, tt.wantReason) {
+				t.Errorf("no finding mentioning %q; got:\n%s", tt.wantReason, reasons)
+			}
+
+			declared := false
+			for _, u := range got.Unchecked {
+				if strings.Contains(u.Name, "default workflow permissions") {
+					declared = true
+				}
+			}
+			if declared != tt.wantUnchecked {
+				t.Errorf("default-permission gap declared = %v, want %v", declared, tt.wantUnchecked)
+			}
+		})
+	}
+}

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -66,6 +66,15 @@ type workflowFacts struct {
 	// SelfHostedJobs is true when any job targets a self-hosted runner,
 	// which is what makes an attached runner actually *reachable*.
 	SelfHostedJobs bool
+	// InheritsDefaultPerms is true when at least one job would run with
+	// the *repository's* default permissions instead of declared ones,
+	// because neither the workflow nor that job declares a `permissions:`
+	// block. What that default is is not in the file — it is a repository
+	// setting an owner can widen to read/write — so resolving it needs the
+	// probe in capability.go (#107). A workflow that declares anything,
+	// even `contents: read`, overrides the default entirely and is not
+	// affected.
+	InheritsDefaultPerms bool
 	// Unparsed is true when the content could not be decoded as YAML, so
 	// the report can say the file was not understood rather than imply
 	// it was checked and found clean.
@@ -129,12 +138,26 @@ func parseWorkflow(content []byte) workflowFacts {
 	}
 
 	f.WritePerms = append(f.WritePerms, writeGrants(root["permissions"])...)
+	// Whether the *top level* declares a block at all, which is a
+	// different question from whether it grants anything: `permissions:
+	// {contents: read}` grants nothing elevated but does override the
+	// repository default, so it must not read as inheriting.
+	_, topDeclaresPerms := root["permissions"]
+
 	// Per-job permissions override the top level, so both matter.
 	if jobs, ok := root["jobs"].(map[string]any); ok {
 		for _, j := range jobs {
 			job, ok := j.(map[string]any)
 			if !ok {
 				continue
+			}
+			// A job inherits the repository default only when nothing
+			// above it declared one either. One such job is enough: the
+			// workflow can hold power the file does not mention.
+			if !topDeclaresPerms {
+				if _, jobDeclaresPerms := job["permissions"]; !jobDeclaresPerms {
+					f.InheritsDefaultPerms = true
+				}
 			}
 			f.WritePerms = append(f.WritePerms, writeGrants(job["permissions"])...)
 			if runsOnSelfHosted(job["runs-on"]) {

--- a/internal/github/workflow_test.go
+++ b/internal/github/workflow_test.go
@@ -178,6 +178,48 @@ permissions:
 	}
 }
 
+// #107: whether a workflow would run on the *repository's* default
+// permissions. Declaring anything overrides the default, so the question is
+// "declares a block at all", not "declares an elevated grant" — a
+// distinction the WritePerms extraction alone cannot make, since both cases
+// leave it empty.
+func TestParseWorkflowInheritsDefaultPerms(t *testing.T) {
+	tests := map[string]struct {
+		yaml string
+		want bool
+	}{
+		"declares nothing anywhere": {
+			yaml: "on: pull_request_target\njobs:\n  a:\n    steps:\n      - run: ./build.sh\n",
+			want: true,
+		},
+		"a read-only top-level block still overrides": {
+			yaml: "on: pull_request_target\npermissions:\n  contents: read\njobs:\n  a:\n    steps:\n      - run: ./build.sh\n",
+			want: false,
+		},
+		"an empty top-level block overrides too": {
+			yaml: "on: pull_request_target\npermissions: {}\njobs:\n  a:\n    steps:\n      - run: ./build.sh\n",
+			want: false,
+		},
+		"every job declares its own": {
+			yaml: "on: pull_request_target\njobs:\n  a:\n    permissions:\n      contents: read\n    steps:\n      - run: ./a.sh\n  b:\n    permissions:\n      issues: write\n    steps:\n      - run: ./b.sh\n",
+			want: false,
+		},
+		// One inheriting job is enough: the workflow can hold power the
+		// file never mentions, even though a sibling job is explicit.
+		"one job declares, another does not": {
+			yaml: "on: pull_request_target\njobs:\n  a:\n    permissions:\n      contents: read\n    steps:\n      - run: ./a.sh\n  b:\n    steps:\n      - run: ./b.sh\n",
+			want: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := parseWorkflow([]byte(tt.yaml)).InheritsDefaultPerms; got != tt.want {
+				t.Errorf("InheritsDefaultPerms = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // The parser is handed bytes from a repository that may be hostile, so
 // it must return rather than panic on anything.
 func TestParseWorkflowNeverPanics(t *testing.T) {


### PR DESCRIPTION
Closes #107.

A workflow that declares no `permissions:` block runs with the **repository's**
default, which an owner or organisation can widen to read/write. That fact is not
in the file, so this read as inventory, weight 0:

```yaml
on: pull_request_target
jobs:
  build:
    steps:
      - run: ./build.sh
```

On a repository whose default is read/write, that is a fork-triggered job holding
write access to the repo — the exact shape the axis exists to flag.

## What was added

A fourth elevated-scope probe in `capability.go`, `GET
/repos/{owner}/{repo}/actions/permissions/workflow`, joined to the parser in the
scoring engine. An inherited write is then treated exactly as a declared one: the
power is the same, only its spelling differs.

**Declaring anything overrides the default**, so the parser reports whether a block
*exists*, not whether it grants anything. `permissions: {contents: read}` grants
nothing elevated and still overrides — a distinction `WritePerms` cannot express,
since both cases leave it empty, which is why this is a separate fact
(`InheritsDefaultPerms`). Per-job blocks count the same way, and **one** inheriting
job is enough: a sibling job being explicit does not protect the one that is not.

## The unknown case, which is the one that matters

Measured against the live API before writing any Go: this endpoint answers **403 on
a repository the token does not own** (*"you must have repository read permissions
or the repository Actions policies fine-grained permission"*). So it works for the
owner-affiliated repositories the scan defaults to, and fails open elsewhere — the
same shape as the runner, deploy-key and webhook probes.

Where it fails, three things follow:

- the default resolves to **neither** value — not permissive, not restrictive;
- the report **stops claiming** the workflow "holds no secrets or write scopes",
  because the unread setting is precisely what would have decided that. It now says
  the workflow declares none and runs with a default that could not be read;
- the gap is declared **only where some workflow actually inherits it**. Naming an
  unreadable setting on a repository whose workflows all declare their own
  permissions is noise about a fact that changes nothing, and a report has to stay
  worth reading to be read at all.

An unrecognised value from GitHub is treated as not answered rather than guessed at,
for the same reason the probe exists.

## Verification

19 new subtests across the three layers:

- **parser** (5) — nothing declared, a read-only top-level block, `permissions: {}`,
  every job explicit, and one job explicit while another is not
- **probe** (4) — `write`, `read`, a 403 failing open with a reason, and an
  unrecognised value
- **scoring** (5) — default write escalates, default read stays inventory, unknown is
  declared rather than assumed, a declared block overrides a permissive default, and
  the gap is *not* declared where nothing inherits it

Mutation, per the convention in #112: with the resolution disabled the escalation case
fails; with the gap declaration disabled the unknown-default case fails. `-race`
covers the new fourth goroutine in `fetchCapabilityProbes`, since the probe test
schedules all four against each other.

Design doc updated — #107 moves from a known limitation to shipped behaviour. Also
fixes an `a`/`an` slip the #111 rename left behind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scans now account for repository-default workflow permissions.
  * Inherited write permissions are identified alongside explicitly granted write permissions.
  * Workflows with unknown or inaccessible defaults are flagged for review when they rely on inheritance.
  * Explicit workflow or job permissions take precedence over repository defaults.

* **Bug Fixes**
  * Push-burst evidence no longer escalates capability-only findings into suspicious results.

* **Documentation**
  * Expanded guidance on default permission resolution, reporting, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->