### PR TITLE
feat(scan): compose reusable-workflow chains before scoring

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -213,27 +213,61 @@ and teach everyone to ignore the axis. What scores is power reachable from
   both are ordinary in healthy repositories, and what would make one suspicious
   is its *appearance*, which the delta axis is the right place to catch.
 
-**Known limitation — reusable workflows** ([#106](https://github.com/gfazioli/octoscope/issues/106)). Each workflow file is assessed on
-its own, so a chain is not composed: a `pull_request_target` caller that invokes
-`./.github/workflows/reusable.yml` with `secrets: inherit` is caught (the
-caller's `secrets: inherit` counts as reaching secrets), but a callee that reads
-a secret the caller passed *by name* is scored independently, and on its own
-`workflow_call` is not untrusted input. Joining caller and callee needs a
-cross-file pass this axis does not yet do.
+**Reusable-workflow chains are composed before scoring** ([#106](https://github.com/gfazioli/octoscope/issues/106), `internal/github/chain.go`).
+A parser reads one file, which is the right shape for a parser and the wrong
+shape for this axis's question. Read separately, a `pull_request_target` caller
+that holds nothing of its own is not a finding, and a callee that reads a secret
+is not either, because on its own `workflow_call` is not untrusted input.
+Together they are a fork-triggered path to a repository secret.
 
-The same gap now reaches the inherited-permission fact below, and the direction
-of the error is worth stating because it is not obvious. GitHub's reference:
-*"If `jobs.<job_id>.permissions` is not specified in the calling job, the called
-workflow will have the default permissions for the `GITHUB_TOKEN`"*, and what it
-receives *"can be only downgraded (not elevated)"*. So for a file whose **only**
-trigger is `workflow_call`, whether it really runs on the repository default is
-the **caller's** decision: right whenever the caller declares nothing, wrong the
-moment the caller declares anything — including `permissions: {}`, which hands
-over nothing at all. Assessed per file, that is unknowable rather than merely
-unknown, so the fact is reported as it stands and the residual wrong claim is the
-*reachability* half: a callee has no triggers of its own to be "reachable only
-from". Suppressing the fact instead would trade one wrong answer for another, and
-guessing a caller is what #106 exists to stop doing.
+Two properties travel in **opposite directions** along a chain, and getting them
+the wrong way round is how a composition becomes a false-positive engine:
+
+- **Reachability accumulates.** Whatever can start the caller can reach
+  everything it calls, transitively. The callee's finding names the trigger *and*
+  the caller that carried it in, so a reader is never told a `workflow_call` file
+  is fork-triggered without being shown how.
+- **Power is bounded by the giver.** GitHub's reference: what a callee receives
+  *"can be only downgraded (not elevated)"*, and *"if
+  `jobs.<job_id>.permissions` is not specified in the calling job, the called
+  workflow will have the default permissions for the `GITHUB_TOKEN`"*. So a
+  callee declaring `contents: write` whose caller hands over nothing holds
+  nothing, and a `${{ secrets.X }}` reference resolves to nothing until a caller
+  passes secrets — by `inherit`, or by name. The `permissions: {}` case is the
+  one a per-file reading gets wrong in the dangerous direction: it grants nothing
+  elevated, yet it *is* a declaration, so the repository default never applies.
+
+Three consequences worth naming, because each removes a claim the pre-#106
+report made and could not support:
+
+- A callee-only file **nobody in the tree calls** now says so, rather than
+  reading its own silence on permissions as "runs with the repository default" —
+  a claim its caller actually makes.
+- A callee's inventory line says "reachable only through the workflows that call
+  it", not "reachable only from its own triggers", which a file with no triggers
+  of its own cannot be.
+- A call the scan **cannot** resolve — another repository, or this one addressed
+  by its full name and a ref — is disclosed as an unfollowed chain wherever an
+  outsider can reach the caller. Cross-repository resolution stays out of scope;
+  staying quiet about it would make the more obscure spelling the one that
+  evades composition unnoticed.
+
+Composition runs **per branch and is then unioned by path**: a side branch can
+wire the same files together differently, which is exactly the divergence this
+scan exists to catch, so flattening before composing would hide it.
+
+A cycle (`A` calls `B` calls `A`) is not valid Actions, but a scan reads whatever
+is in the tree — so propagation is a **fixpoint** rather than a recursion, and
+terminates by construction instead of depending on a visited set threaded through
+correctly.
+
+**This makes the axis ceiling carry more weight, not less.** One attack path can
+now emit an escalation finding per file in the chain — three files is 9 against a
+threshold of 5. Measured with the clamp disabled, the three-file chain test
+reaches **score 10 and "likely compromised" from capability alone**, against 7
+for the single-workflow shape that [#109](https://github.com/gfazioli/octoscope/pull/109)
+was opened for. The clamp bounds the arithmetic and not the disclosure: every
+file in the chain still appears in the report.
 
 - **Default workflow permissions** — `GET /repos/{owner}/{repo}/actions/permissions/workflow`
   ([#107](https://github.com/gfazioli/octoscope/issues/107)). A workflow that

--- a/internal/github/chain.go
+++ b/internal/github/chain.go
@@ -136,15 +136,17 @@ func union(a, b []string) []string {
 // branch and returns the composed facts per workflow path.
 //
 // index maps a repository-relative workflow path to the facts parsed from
-// it. Callers that are not in the index cannot be followed; callees that
-// are not either are recorded as unfollowed by nobody, since a `./` path
-// pointing at a file that is not there resolves to nothing at run time too.
+// it — only workflows this scan actually read. A `./` call whose target is
+// missing from it cannot be followed, and is recorded in the callee's
+// Unfollowed alongside the non-local ones rather than skipped: the comment
+// here previously claimed that and the code did not do it, which Copilot
+// caught on #117.
 func composeChain(index map[string]*workflowFacts) map[string]*composed {
 	out := make(map[string]*composed, len(index))
 	for path, f := range index {
 		c := &composed{
 			Triggers:      append([]string(nil), f.OutsiderTriggers...),
-			Unfollowed:    unfollowedTargets(f),
+			Unfollowed:    unfollowedTargets(f, index),
 			ownSecretRefs: f.UsesSecrets,
 		}
 		// A file nothing but another workflow can start has no power and no
@@ -270,13 +272,37 @@ func inheritsReaching(callerComposed *composed, caller *workflowFacts, call work
 	return true
 }
 
-// unfollowedTargets lists the `uses:` values naming a workflow that could
-// not be resolved locally.
-func unfollowedTargets(f *workflowFacts) []string {
+// unfollowedTargets lists the `uses:` values naming a workflow this scan
+// cannot resolve: a non-local target, or a local one whose file is not in
+// the index.
+//
+// Deduplicated because two jobs may call the same workflow, and the result
+// is joined into report text — repeating a target once per calling job
+// reads as several unfollowed chains where there is one. Found by Copilot
+// on #117.
+//
+// The missing-local case is the one worth having: a `./` path is absent
+// from the index either because the file is not there, which resolves to
+// nothing at run time too, or because its content never arrived (over
+// maxBlobScanBytes, or past the fetch budget) — and *that* is a chain
+// leading somewhere unread. The file itself is already declared through
+// uncheckedWorkflows; this says the chain pointed at it.
+func unfollowedTargets(f *workflowFacts, index map[string]*workflowFacts) []string {
 	var out []string
 	for _, c := range f.Calls {
-		if c.Remote != "" {
-			out = append(out, c.Remote)
+		switch {
+		case c.Remote != "":
+			if !contains(out, c.Remote) {
+				out = append(out, c.Remote)
+			}
+		case c.Path != "":
+			if _, resolved := index[c.Path]; resolved {
+				continue
+			}
+			target := "./" + c.Path
+			if !contains(out, target) {
+				out = append(out, target)
+			}
 		}
 	}
 	return out

--- a/internal/github/chain.go
+++ b/internal/github/chain.go
@@ -1,0 +1,301 @@
+package github
+
+// Axis 4 — capability escalation, the reusable-workflow chain (#106).
+//
+// parseWorkflow reads one file, which is the right shape for a parser and
+// the wrong shape for this axis's question. The shape that slips through a
+// per-file reading:
+//
+//	# caller — fork-triggered, holds no secret of its own
+//	on: pull_request_target
+//	jobs:
+//	  call:
+//	    uses: ./.github/workflows/reusable.yml
+//	    secrets: inherit
+//
+//	# callee — reads a secret, but on its own `workflow_call` is not
+//	# untrusted input
+//	on: workflow_call
+//	jobs:
+//	  build:
+//	    steps:
+//	      - run: deploy --token ${{ secrets.DEPLOY_TOKEN }}
+//
+// Separately the caller holds nothing and the callee is not reachable by
+// an outsider, so neither scores. Together they are a fork-triggered path
+// to a repository secret. Composing them is what this file does.
+//
+// Two properties travel in opposite directions along a chain, and getting
+// them the wrong way round is how a composition turns into a false
+// positive:
+//
+//   - **Reachability accumulates.** If an outsider can start the caller,
+//     an outsider can reach everything it calls, transitively.
+//   - **Power is bounded by the giver.** A callee's `${{ secrets.X }}`
+//     resolves to nothing unless the caller passed secrets, and its
+//     permissions are the caller's — GitHub's reference is explicit that
+//     what a callee receives "can be only downgraded (not elevated)". So a
+//     callee declaring `contents: write` while its caller hands over
+//     nothing holds nothing.
+//
+// Only local `./` calls are composed. Anything else — another repository,
+// or this one addressed by its full name and a ref — is disclosed as an
+// unfollowed chain rather than treated as absent.
+
+import "sort"
+
+// writeState is the elevated write reaching a workflow: the grants named,
+// or the repository default when nothing was declared anywhere above it.
+type writeState struct {
+	Perms []string
+	// InheritsDefault means the grant is whatever the repository setting
+	// says, which only the probe in capability.go can answer (#107).
+	InheritsDefault bool
+}
+
+// composed is one workflow's facts after the chain reaching it has been
+// resolved. It supersedes the per-file facts wherever the two disagree.
+type composed struct {
+	// Triggers are the outsider-controlled events that can reach this
+	// workflow, its own and any inherited from a caller.
+	Triggers []string
+	// ViaCallers names the callers that carried reachability in, so the
+	// report can say *how* an outsider reaches a file whose own triggers
+	// say they cannot.
+	ViaCallers []string
+	// Secrets reports whether the repository's secrets actually reach it.
+	Secrets bool
+	Write   writeState
+	// CallerFound records that some local caller in this branch invokes
+	// this workflow. Its absence is what stops a callee-only file from
+	// being reported as if the scan knew who calls it.
+	CallerFound bool
+	// Unfollowed are `uses:` values that name a workflow this scan cannot
+	// resolve — a different repository, or a ref it did not read.
+	Unfollowed []string
+
+	// ownSecretRefs is the file's own answer to "does anything here reach a
+	// secret" — a `${{ secrets.X }}` reference, or a `secrets: inherit`
+	// that forwards the whole set onward. Kept even for a callee-only file,
+	// where it is not an answer on its own but is exactly the half a
+	// passing caller completes: a reference resolves to nothing until
+	// somebody hands the secrets over.
+	ownSecretRefs bool
+}
+
+// composeBranchChains composes each branch's chains and merges the results
+// by path.
+//
+// Composition is per branch because a side branch can wire the same files
+// together differently — which is the divergence this scan exists to catch,
+// so it must not be flattened away before composing. The merge afterwards
+// is a union: a chain that exists on *any* branch is a real path to that
+// file, and the scoring loop already treats a workflow present on many
+// branches as one fact about the repository rather than one per branch.
+func composeBranchChains(branches []scanBranch, blobs map[string]blobAnalysis) map[string]*composed {
+	merged := map[string]*composed{}
+	for _, b := range branches {
+		index := map[string]*workflowFacts{}
+		for _, m := range b.Matches {
+			if m.Rule.Class != classCI {
+				continue
+			}
+			if ba, ok := blobs[m.BlobSHA]; ok && ba.Workflow != nil && !ba.Workflow.Unparsed {
+				index[m.Path] = ba.Workflow
+			}
+		}
+		for path, c := range composeChain(index) {
+			into, ok := merged[path]
+			if !ok {
+				merged[path] = c
+				continue
+			}
+			into.Triggers = union(into.Triggers, c.Triggers)
+			into.ViaCallers = union(into.ViaCallers, c.ViaCallers)
+			into.Unfollowed = union(into.Unfollowed, c.Unfollowed)
+			into.Write.Perms = union(into.Write.Perms, c.Write.Perms)
+			into.Secrets = into.Secrets || c.Secrets
+			into.Write.InheritsDefault = into.Write.InheritsDefault || c.Write.InheritsDefault
+			into.CallerFound = into.CallerFound || c.CallerFound
+		}
+	}
+	return merged
+}
+
+func union(a, b []string) []string {
+	for _, s := range b {
+		if !contains(a, s) {
+			a = append(a, s)
+		}
+	}
+	sort.Strings(a)
+	return a
+}
+
+// composeChain resolves the local reusable-workflow chains within one
+// branch and returns the composed facts per workflow path.
+//
+// index maps a repository-relative workflow path to the facts parsed from
+// it. Callers that are not in the index cannot be followed; callees that
+// are not either are recorded as unfollowed by nobody, since a `./` path
+// pointing at a file that is not there resolves to nothing at run time too.
+func composeChain(index map[string]*workflowFacts) map[string]*composed {
+	out := make(map[string]*composed, len(index))
+	for path, f := range index {
+		c := &composed{
+			Triggers:      append([]string(nil), f.OutsiderTriggers...),
+			Unfollowed:    unfollowedTargets(f),
+			ownSecretRefs: f.UsesSecrets,
+		}
+		// A file nothing but another workflow can start has no power and no
+		// exposure of its own to report — both arrive from its callers, and
+		// asserting either from the file alone is the bug this fixes. Every
+		// other file stands on its own facts.
+		if !f.CallableOnly {
+			c.Secrets = f.UsesSecrets
+			c.Write = writeState{Perms: f.WritePerms, InheritsDefault: f.InheritsDefaultPerms}
+		}
+		out[path] = c
+	}
+
+	// Propagate to a fixpoint rather than recursing, which makes a cycle
+	// (A calls B calls A) terminate by construction instead of needing a
+	// visited set threaded through. One round can extend a chain by one
+	// hop, so len(index) rounds is the most that can be needed; the loop
+	// exits as soon as a round changes nothing, which is the normal case
+	// after two.
+	for round := 0; round < len(index); round++ {
+		changed := false
+		// Deterministic order: these merges append to slices that end up in
+		// report text, and Go randomises map iteration.
+		for _, callerPath := range sortedKeys(index) {
+			caller := index[callerPath]
+			for _, call := range caller.Calls {
+				callee, ok := out[call.Path]
+				if call.Path == "" || !ok {
+					continue // unfollowable, or points at nothing in this branch
+				}
+				if mergeCall(out[callerPath], caller, callee, call, callerPath) {
+					changed = true
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	for _, c := range out {
+		sort.Strings(c.Triggers)
+		sort.Strings(c.ViaCallers)
+		sort.Strings(c.Unfollowed)
+		sort.Strings(c.Write.Perms)
+	}
+	return out
+}
+
+// mergeCall folds one call edge into the callee's composed facts and
+// reports whether anything changed, which is what drives the fixpoint.
+func mergeCall(callerComposed *composed, caller *workflowFacts, callee *composed, call workflowCall, callerPath string) bool {
+	changed := false
+
+	// Reachability accumulates: whatever can start the caller can reach
+	// the callee.
+	for _, t := range callerComposed.Triggers {
+		if !contains(callee.Triggers, t) {
+			callee.Triggers = append(callee.Triggers, t)
+			changed = true
+		}
+	}
+	if len(callerComposed.Triggers) > 0 && !contains(callee.ViaCallers, callerPath) {
+		callee.ViaCallers = append(callee.ViaCallers, callerPath)
+		changed = true
+	}
+	if !callee.CallerFound {
+		callee.CallerFound = true
+		changed = true
+	}
+
+	// Power is bounded by the giver. The callee's own references only
+	// resolve to something if this caller handed the secrets over.
+	if call.PassesSecrets && callee.ownSecretRefs && !callee.Secrets {
+		callee.Secrets = true
+		changed = true
+	}
+
+	for _, p := range grantReaching(callerComposed, caller, call) {
+		if !contains(callee.Write.Perms, p) {
+			callee.Write.Perms = append(callee.Write.Perms, p)
+			changed = true
+		}
+	}
+	if inheritsReaching(callerComposed, caller, call) && !callee.Write.InheritsDefault {
+		callee.Write.InheritsDefault = true
+		changed = true
+	}
+	return changed
+}
+
+// grantReaching is the elevated write this call confers on its callee.
+//
+// A calling job that declares grants confers those. One that declares a
+// block granting nothing elevated — `permissions: {}`, `contents: read` —
+// confers nothing, which is the case a per-file reading gets wrong in the
+// dangerous direction. One that declares nothing passes on whatever
+// reached *it*, which for a callee-only caller is what its own callers
+// gave it rather than the repository default.
+func grantReaching(callerComposed *composed, caller *workflowFacts, call workflowCall) []string {
+	if len(call.WritePerms) > 0 {
+		return call.WritePerms
+	}
+	if call.InheritsDefaultPerms && caller.CallableOnly {
+		return callerComposed.Write.Perms
+	}
+	return nil
+}
+
+// inheritsReaching reports whether what reaches the callee is the
+// repository default rather than a named grant — the half only the #107
+// probe can resolve.
+func inheritsReaching(callerComposed *composed, caller *workflowFacts, call workflowCall) bool {
+	if !call.InheritsDefaultPerms {
+		return false
+	}
+	if caller.CallableOnly {
+		// The caller is itself a callee: it declared nothing, so it passes
+		// on what it received, which is the repository default only if that
+		// is what reached it.
+		return callerComposed.Write.InheritsDefault
+	}
+	return true
+}
+
+// unfollowedTargets lists the `uses:` values naming a workflow that could
+// not be resolved locally.
+func unfollowedTargets(f *workflowFacts) []string {
+	var out []string
+	for _, c := range f.Calls {
+		if c.Remote != "" {
+			out = append(out, c.Remote)
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string]*workflowFacts) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/github/chain_test.go
+++ b/internal/github/chain_test.go
@@ -255,6 +255,66 @@ func TestComposeChainDoesNotInventCallers(t *testing.T) {
 	}
 }
 
+// Every outsider trigger carries its own reason. Composition made the
+// multi-trigger case ordinary — a chain unions its callers' triggers, and
+// so does the merge across branches — and the names sort alphabetically, so
+// explaining only the first handed `issue_comment` the explanation while
+// `pull_request_target` was listed with none. Copilot, #117.
+func TestDescribeTriggersExplainsEachOne(t *testing.T) {
+	got := describeTriggers([]string{"issue_comment", "pull_request_target"})
+	for _, ev := range []string{"issue_comment", "pull_request_target"} {
+		why := outsiderTriggers[ev]
+		if !strings.Contains(got, ev+" ("+why+")") {
+			t.Errorf("%s is listed without its own reason: %q", ev, got)
+		}
+	}
+	if one := describeTriggers([]string{"issues"}); one != "issues ("+outsiderTriggers["issues"]+")" {
+		t.Errorf("single trigger = %q, want no list punctuation", one)
+	}
+	if describeTriggers(nil) != "" {
+		t.Error("no triggers should render as nothing, not as stray punctuation")
+	}
+}
+
+// Two jobs calling the same workflow is one unfollowed chain, not two. The
+// value is joined into report text, so a duplicate reads as a second
+// target. Copilot, #117.
+func TestComposeChainDedupesUnfollowed(t *testing.T) {
+	got := composeChain(chainIndex(t, map[string]string{
+		".github/workflows/c.yml": `
+on: pull_request_target
+jobs:
+  one:
+    uses: octo-org/example/.github/workflows/a.yml@v1
+  two:
+    uses: octo-org/example/.github/workflows/a.yml@v1
+`,
+	}))
+	if u := got[".github/workflows/c.yml"].Unfollowed; len(u) != 1 {
+		t.Errorf("unfollowed = %v, want the target once", u)
+	}
+}
+
+// A `./` call the scan cannot resolve is a chain leading somewhere unread —
+// most usefully when the callee's content never arrived, over
+// maxBlobScanBytes or past the fetch budget. The doc comment claimed this
+// was recorded while the code skipped it. Copilot, #117.
+func TestComposeChainDisclosesAMissingLocalCallee(t *testing.T) {
+	got := composeChain(chainIndex(t, map[string]string{
+		".github/workflows/c.yml": `
+on: pull_request_target
+jobs:
+  one:
+    uses: ./.github/workflows/gone.yml
+    secrets: inherit
+`,
+	}))
+	u := got[".github/workflows/c.yml"].Unfollowed
+	if !contains(u, "./.github/workflows/gone.yml") {
+		t.Errorf("unfollowed = %v, want the unresolvable local call disclosed", u)
+	}
+}
+
 func TestComposeChainDisclosesUnfollowed(t *testing.T) {
 	// #106 scopes cross-repository resolution out. Staying quiet about it
 	// is the part that would be wrong — and a same-repository call written

--- a/internal/github/chain_test.go
+++ b/internal/github/chain_test.go
@@ -1,0 +1,288 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+// chainIndex parses a set of workflow sources into the path-keyed index
+// composeChain consumes, so the tests read as the YAML they are about.
+func chainIndex(t *testing.T, files map[string]string) map[string]*workflowFacts {
+	t.Helper()
+	index := make(map[string]*workflowFacts, len(files))
+	for path, src := range files {
+		f := parseWorkflow([]byte(src))
+		if f.Unparsed {
+			t.Fatalf("%s did not parse as YAML", path)
+		}
+		index[path] = &f
+	}
+	return index
+}
+
+const calleeReadsSecret = `
+on: workflow_call
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: deploy --token ${{ secrets.DEPLOY_TOKEN }}
+`
+
+func TestComposeChainReachesCalleeSecret(t *testing.T) {
+	// The shape #106 was opened for. Read one file at a time the caller
+	// holds nothing and the callee is not outsider-reachable, so neither
+	// scores; composed, they are a fork-triggered path to a secret.
+	tests := []struct {
+		name        string
+		caller      string
+		wantSecrets bool
+		wantWhy     string
+	}{
+		{
+			name: "secrets: inherit hands over the whole set",
+			caller: `
+on: pull_request_target
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    secrets: inherit
+`,
+			wantSecrets: true,
+		},
+		{
+			name: "a secret passed by name counts too",
+			caller: `
+on: pull_request_target
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    secrets:
+      token: ${{ secrets.DEPLOY_TOKEN }}
+`,
+			wantSecrets: true,
+		},
+		{
+			// The false positive the by-name check must not produce: a
+			// mapping is not automatically a secret.
+			name: "a by-name mapping carrying no secret passes nothing",
+			caller: `
+on: pull_request_target
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    secrets:
+      who: ${{ github.actor }}
+`,
+			wantSecrets: false,
+			wantWhy:     "the caller hands over no secret, so the callee's reference resolves to nothing",
+		},
+		{
+			name: "no secrets key at all passes nothing",
+			caller: `
+on: pull_request_target
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+`,
+			wantSecrets: false,
+			wantWhy:     "the caller hands over no secret, so the callee's reference resolves to nothing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := composeChain(chainIndex(t, map[string]string{
+				".github/workflows/caller.yml":   tt.caller,
+				".github/workflows/reusable.yml": calleeReadsSecret,
+			}))
+			callee := got[".github/workflows/reusable.yml"]
+			if callee == nil {
+				t.Fatal("callee missing from the composed set")
+			}
+			// Reachability accumulates regardless of what was handed over.
+			if !contains(callee.Triggers, "pull_request_target") {
+				t.Errorf("callee triggers = %v, want pull_request_target carried in from the caller", callee.Triggers)
+			}
+			if !contains(callee.ViaCallers, ".github/workflows/caller.yml") {
+				t.Errorf("callee ViaCallers = %v, want the caller named so the report can say how", callee.ViaCallers)
+			}
+			if callee.Secrets != tt.wantSecrets {
+				t.Errorf("callee secrets = %v, want %v — %s", callee.Secrets, tt.wantSecrets, tt.wantWhy)
+			}
+		})
+	}
+}
+
+func TestComposeChainBoundsPowerByTheGiver(t *testing.T) {
+	// A callee can only downgrade what it receives, never widen it, so
+	// what it declares is not what it holds.
+	calleeDeclaresWrite := `
+on: workflow_call
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`
+	tests := []struct {
+		name            string
+		callerPerms     string
+		wantPerms       []string
+		wantInheritsDef bool
+	}{
+		{
+			// The case a per-file reading gets wrong in the dangerous
+			// direction: `permissions: {}` grants nothing elevated, yet it
+			// *is* a declaration, so the repository default never applies.
+			name:            "an empty permissions block confers nothing and overrides the default",
+			callerPerms:     "permissions: {}",
+			wantPerms:       nil,
+			wantInheritsDef: false,
+		},
+		{
+			name:            "a read-only block confers nothing elevated",
+			callerPerms:     "permissions:\n  contents: read",
+			wantPerms:       nil,
+			wantInheritsDef: false,
+		},
+		{
+			name:            "declared write is conferred",
+			callerPerms:     "permissions:\n  id-token: write",
+			wantPerms:       []string{"id-token: write"},
+			wantInheritsDef: false,
+		},
+		{
+			// Nothing declared anywhere above it, so what reaches the
+			// callee is the repository setting only #107's probe can read.
+			name:            "declaring nothing passes the repository default along",
+			callerPerms:     "",
+			wantPerms:       nil,
+			wantInheritsDef: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caller := "on: pull_request_target\n" + tt.callerPerms + `
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+`
+			got := composeChain(chainIndex(t, map[string]string{
+				".github/workflows/caller.yml":   caller,
+				".github/workflows/reusable.yml": calleeDeclaresWrite,
+			}))
+			callee := got[".github/workflows/reusable.yml"]
+			if strings.Join(callee.Write.Perms, ",") != strings.Join(tt.wantPerms, ",") {
+				t.Errorf("callee write = %v, want %v — a callee holds the caller's grant, not its own declaration",
+					callee.Write.Perms, tt.wantPerms)
+			}
+			if callee.Write.InheritsDefault != tt.wantInheritsDef {
+				t.Errorf("callee InheritsDefault = %v, want %v", callee.Write.InheritsDefault, tt.wantInheritsDef)
+			}
+		})
+	}
+}
+
+func TestComposeChainTransitiveAndCyclic(t *testing.T) {
+	t.Run("reachability travels the whole chain", func(t *testing.T) {
+		got := composeChain(chainIndex(t, map[string]string{
+			".github/workflows/a.yml": `
+on: issue_comment
+jobs:
+  call:
+    uses: ./.github/workflows/b.yml
+    secrets: inherit
+`,
+			".github/workflows/b.yml": `
+on: workflow_call
+jobs:
+  call:
+    uses: ./.github/workflows/c.yml
+    secrets: inherit
+`,
+			".github/workflows/c.yml": calleeReadsSecret,
+		}))
+		c := got[".github/workflows/c.yml"]
+		if !contains(c.Triggers, "issue_comment") {
+			t.Errorf("c triggers = %v, want issue_comment carried two hops", c.Triggers)
+		}
+		if !c.Secrets {
+			t.Error("c should reach secrets: both hops forwarded them")
+		}
+		if !c.Write.InheritsDefault {
+			t.Errorf("c InheritsDefault = false: nothing in the chain declared permissions, so the repository default reaches it")
+		}
+	})
+
+	t.Run("a cycle terminates", func(t *testing.T) {
+		// Not valid Actions, but a scan reads whatever is in the tree and
+		// must not hang on it. The fixpoint makes this terminate by
+		// construction rather than by a visited set.
+		got := composeChain(chainIndex(t, map[string]string{
+			".github/workflows/a.yml": "on: pull_request_target\njobs:\n  x:\n    uses: ./.github/workflows/b.yml\n    secrets: inherit\n",
+			".github/workflows/b.yml": "on: workflow_call\njobs:\n  y:\n    uses: ./.github/workflows/a.yml\n    secrets: inherit\n",
+		}))
+		if !contains(got[".github/workflows/b.yml"].Triggers, "pull_request_target") {
+			t.Error("b should still inherit reachability from a")
+		}
+	})
+}
+
+func TestComposeChainDoesNotInventCallers(t *testing.T) {
+	// A callee nobody in this branch calls: the scan does not know who
+	// invokes it, so it must claim neither power nor exposure. Before
+	// #106 this file read as "declares no permissions, so it runs with the
+	// repository default" — a claim its caller actually decides.
+	got := composeChain(chainIndex(t, map[string]string{
+		".github/workflows/orphan.yml": calleeReadsSecret,
+	}))
+	c := got[".github/workflows/orphan.yml"]
+	if c.CallerFound {
+		t.Error("CallerFound = true with no caller in the index")
+	}
+	if len(c.Triggers) != 0 {
+		t.Errorf("triggers = %v, want none: workflow_call is not untrusted input on its own", c.Triggers)
+	}
+	if c.Secrets {
+		t.Error("secrets = true: the reference resolves to nothing until a caller passes them")
+	}
+	if c.Write.InheritsDefault || len(c.Write.Perms) > 0 {
+		t.Errorf("write = %+v, want empty: a callee's permissions are its caller's to grant", c.Write)
+	}
+}
+
+func TestComposeChainDisclosesUnfollowed(t *testing.T) {
+	// #106 scopes cross-repository resolution out. Staying quiet about it
+	// is the part that would be wrong — and a same-repository call written
+	// as a full name plus a ref must not become the spelling that evades
+	// composition unnoticed.
+	got := composeChain(chainIndex(t, map[string]string{
+		".github/workflows/caller.yml": `
+on: pull_request_target
+jobs:
+  far:
+    uses: octo-org/example/.github/workflows/a.yml@v1
+    secrets: inherit
+  byname:
+    uses: gfazioli/octoscope/.github/workflows/b.yml@main
+    secrets: inherit
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`,
+	}))
+	c := got[".github/workflows/caller.yml"]
+	if len(c.Unfollowed) != 2 {
+		t.Fatalf("unfollowed = %v, want both workflow calls disclosed", c.Unfollowed)
+	}
+	for _, u := range c.Unfollowed {
+		if strings.Contains(u, "actions/checkout") {
+			t.Errorf("a step-level action was read as a reusable-workflow call: %q", u)
+		}
+	}
+}

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1069,6 +1069,10 @@ func evaluateScan(in scanInput) *RepoScan {
 	// default-branch copy mask a dangerous side-branch variant — which
 	// is precisely the side-branch divergence this scan exists to catch.
 	seenWorkflow := map[string]bool{}
+	// Reusable-workflow chains, resolved before anything is scored (#106).
+	// It has to happen up front because a callee can be reached in the loop
+	// before the caller that gives it its power and its exposure.
+	chains := composeBranchChains(in.Branches, in.Blobs)
 	for _, b := range in.Branches {
 		for _, m := range b.Matches {
 			wfKey := fingerprintKey(m.BlobSHA, m.Path)
@@ -1112,22 +1116,45 @@ func evaluateScan(in scanInput) *RepoScan {
 			// An unknown default resolves to false, not to permissive. The
 			// gap is declared instead, further down, and only when a workflow
 			// actually depends on it.
-			inheritsWrite := wf.InheritsDefaultPerms && in.Probes.DefaultWorkflowPerms == "write"
-			if wf.InheritsDefaultPerms && in.Probes.DefaultWorkflowPerms == "" {
+			// Scored on the *composed* chain, not on the file alone (#106).
+			// Where the two disagree the chain wins, in both directions: a
+			// caller's fork trigger reaches everything it invokes, and a
+			// callee holds only what its caller handed over.
+			ch := chains[m.Path]
+			if ch == nil {
+				// No chain data for this path — the file's own reading is
+				// then the whole answer.
+				ch = &composed{
+					Triggers: wf.OutsiderTriggers,
+					Secrets:  wf.UsesSecrets,
+					Write:    writeState{Perms: wf.WritePerms, InheritsDefault: wf.InheritsDefaultPerms},
+				}
+			}
+			inheritsWrite := ch.Write.InheritsDefault && in.Probes.DefaultWorkflowPerms == "write"
+			if ch.Write.InheritsDefault && in.Probes.DefaultWorkflowPerms == "" {
 				inheritedDefaultUnknown = true
 			}
-			holdsWrite := len(wf.WritePerms) > 0 || inheritsWrite
+			holdsWrite := len(ch.Write.Perms) > 0 || inheritsWrite
+
+			// How an outsider gets in, when it is not this file's own
+			// triggers that let them. Without this the reader is told a
+			// `workflow_call` file is fork-triggered and has no way to see
+			// why.
+			via := ""
+			if len(wf.OutsiderTriggers) == 0 && len(ch.ViaCallers) > 0 {
+				via = fmt.Sprintf(", reached through %s", strings.Join(ch.ViaCallers, ", "))
+			}
 
 			switch {
-			case len(wf.OutsiderTriggers) > 0 && (wf.UsesSecrets || holdsWrite):
+			case len(ch.Triggers) > 0 && (ch.Secrets || holdsWrite):
 				held := "the repository's secrets"
 				if holdsWrite {
-					if len(wf.WritePerms) > 0 {
-						held = strings.Join(wf.WritePerms, ", ")
+					if len(ch.Write.Perms) > 0 {
+						held = strings.Join(ch.Write.Perms, ", ")
 					} else {
 						held = "the repository's default write permission, which it does not declare"
 					}
-					if wf.UsesSecrets {
+					if ch.Secrets {
 						held += " and the repository's secrets"
 					}
 				}
@@ -1136,16 +1163,16 @@ func evaluateScan(in scanInput) *RepoScan {
 					Branch: b.Prov.Name,
 					Path:   m.Path,
 					Weight: wCapEscalation,
-					Reason: fmt.Sprintf("triggered by %s — %s — while holding %s",
-						strings.Join(wf.OutsiderTriggers, ", "), outsiderTriggers[wf.OutsiderTriggers[0]], held),
+					Reason: fmt.Sprintf("triggered by %s — %s%s — while holding %s",
+						strings.Join(ch.Triggers, ", "), outsiderTriggers[ch.Triggers[0]], via, held),
 				})
-			case len(wf.OutsiderTriggers) > 0:
+			case len(ch.Triggers) > 0:
 				// "Holds nothing" is a claim, so it must not be made where
 				// the unknown default is the thing that would decide it.
-				reason := fmt.Sprintf("triggered by %s, but holds no secrets or write scopes", strings.Join(wf.OutsiderTriggers, ", "))
-				if wf.InheritsDefaultPerms && in.Probes.DefaultWorkflowPerms == "" {
-					reason = fmt.Sprintf("triggered by %s and declares no permissions, so it runs with the repository default — which could not be read",
-						strings.Join(wf.OutsiderTriggers, ", "))
+				reason := fmt.Sprintf("triggered by %s%s, but holds no secrets or write scopes", strings.Join(ch.Triggers, ", "), via)
+				if ch.Write.InheritsDefault && in.Probes.DefaultWorkflowPerms == "" {
+					reason = fmt.Sprintf("triggered by %s%s and declares no permissions, so it runs with the repository default — which could not be read",
+						strings.Join(ch.Triggers, ", "), via)
 				}
 				addCap(Finding{
 					Axis:   AxisCapability,
@@ -1156,16 +1183,50 @@ func evaluateScan(in scanInput) *RepoScan {
 				})
 			case holdsWrite:
 				// Power on a trusted trigger: inventory, not a finding.
-				grants := strings.Join(wf.WritePerms, ", ")
-				if len(wf.WritePerms) == 0 {
+				grants := strings.Join(ch.Write.Perms, ", ")
+				if len(ch.Write.Perms) == 0 {
 					grants = "the repository's default write permission"
+				}
+				where := "reachable only from its own triggers"
+				if wf.CallableOnly {
+					// It has none of its own; what reaches it is whatever
+					// reaches the workflows that call it.
+					where = "reachable only through the workflows that call it"
 				}
 				addCap(Finding{
 					Axis:   AxisCapability,
 					Branch: b.Prov.Name,
 					Path:   m.Path,
 					Weight: 0,
-					Reason: fmt.Sprintf("grants %s, reachable only from its own triggers", grants),
+					Reason: fmt.Sprintf("grants %s, %s", grants, where),
+				})
+			case wf.CallableOnly && !ch.CallerFound:
+				// Nothing in the tree calls it, so its power and its exposure
+				// are both decided by a caller the scan never saw. Saying so
+				// beats the pre-#106 report, which read this file's silence
+				// on permissions as "runs with the repository default" — a
+				// claim its caller actually makes.
+				addCap(Finding{
+					Axis:   AxisCapability,
+					Branch: b.Prov.Name,
+					Path:   m.Path,
+					Weight: 0,
+					Reason: fmt.Sprintf("%s is only callable by another workflow, and none in this repository calls it — so its permissions and its exposure are whatever a caller grants, which this scan cannot see", m.Path),
+				})
+			}
+
+			// A chain the scan could not follow. Disclosed only where an
+			// outsider can reach the caller: a repository calling a
+			// third-party reusable workflow from a tag push is ordinary, and
+			// listing every one of those is how an axis gets ignored.
+			if len(ch.Triggers) > 0 && len(ch.Unfollowed) > 0 {
+				addCap(Finding{
+					Axis:   AxisCapability,
+					Branch: b.Prov.Name,
+					Path:   m.Path,
+					Weight: 0,
+					Reason: fmt.Sprintf("calls %s, which this scan does not resolve — what that workflow does with what it is handed was not checked",
+						strings.Join(ch.Unfollowed, ", ")),
 				})
 			}
 

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1163,8 +1163,8 @@ func evaluateScan(in scanInput) *RepoScan {
 					Branch: b.Prov.Name,
 					Path:   m.Path,
 					Weight: wCapEscalation,
-					Reason: fmt.Sprintf("triggered by %s — %s%s — while holding %s",
-						strings.Join(ch.Triggers, ", "), outsiderTriggers[ch.Triggers[0]], via, held),
+					Reason: fmt.Sprintf("triggered by %s%s — while holding %s",
+						describeTriggers(ch.Triggers), via, held),
 				})
 			case len(ch.Triggers) > 0:
 				// "Holds nothing" is a claim, so it must not be made where

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -251,6 +251,271 @@ func capInput(path string, wf *workflowFacts) scanInput {
 	}
 }
 
+// chainScanInput builds a scan over several real workflow sources on one
+// branch, parsed the way a scan would parse them, so the chain tests
+// exercise parseWorkflow and the composition together rather than
+// hand-built facts that could drift from what the parser really produces.
+func chainScanInput(t *testing.T, files map[string]string) scanInput {
+	t.Helper()
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 1,
+		Branches:      []scanBranch{{Prov: provBranch("main", true)}},
+		Blobs:         map[string]blobAnalysis{},
+		Now:           time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC),
+	}
+	for path, src := range files {
+		f := parseWorkflow([]byte(src))
+		if f.Unparsed {
+			t.Fatalf("%s did not parse as YAML", path)
+		}
+		sha := "sha-" + path
+		in.Branches[0].Matches = append(in.Branches[0].Matches, ignitionMatch{
+			Path: path, Size: 900, BlobSHA: sha,
+			Rule: ignitionRule{Class: classCI, Weight: 0},
+		})
+		in.Blobs[sha] = blobAnalysis{Size: 900, Fetched: true, IsText: true, Workflow: &f}
+	}
+	return in
+}
+
+func findingFor(s *RepoScan, path string) (Finding, bool) {
+	for _, f := range s.Findings {
+		if f.Axis == AxisCapability && f.Path == path && f.Weight > 0 {
+			return f, true
+		}
+	}
+	return Finding{}, false
+}
+
+func reasonsFor(s *RepoScan, path string) []string {
+	var out []string
+	for _, f := range s.Findings {
+		if f.Axis == AxisCapability && f.Path == path {
+			out = append(out, f.Reason)
+		}
+	}
+	return out
+}
+
+// The shape #106 exists for: a fork-triggered caller that holds nothing of
+// its own, and a callee that reads a secret but whose only trigger is
+// `workflow_call`. Read one file at a time neither is a finding. Composed,
+// the callee is a fork-triggered path to a repository secret.
+func TestScanScoresTheComposedChain(t *testing.T) {
+	in := chainScanInput(t, map[string]string{
+		".github/workflows/caller.yml": `
+on: pull_request_target
+permissions: {}
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    secrets: inherit
+`,
+		".github/workflows/reusable.yml": `
+on: workflow_call
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: deploy --token ${{ secrets.DEPLOY_TOKEN }}
+`,
+	})
+
+	got := evaluateScan(in)
+	f, ok := findingFor(got, ".github/workflows/reusable.yml")
+	if !ok {
+		t.Fatalf("the callee did not score: %v", reasonsFor(got, ".github/workflows/reusable.yml"))
+	}
+	if !strings.Contains(f.Reason, "pull_request_target") {
+		t.Errorf("reason does not name the trigger that reaches it: %q", f.Reason)
+	}
+	if !strings.Contains(f.Reason, "reached through .github/workflows/caller.yml") {
+		t.Errorf("reason does not say how an outsider reaches a workflow_call file: %q", f.Reason)
+	}
+	if !strings.Contains(f.Reason, "secrets") {
+		t.Errorf("reason does not name what it holds: %q", f.Reason)
+	}
+}
+
+// The other direction, and the one that keeps the composition from being a
+// false-positive engine: a callee holds what its caller granted, not what
+// it declares. `permissions: {}` in the caller confers nothing, and GitHub
+// lets a callee only downgrade what it receives.
+func TestScanDoesNotCreditACalleeWithUngrantedPower(t *testing.T) {
+	in := chainScanInput(t, map[string]string{
+		".github/workflows/caller.yml": `
+on: pull_request_target
+jobs:
+  call:
+    permissions: {}
+    uses: ./.github/workflows/reusable.yml
+`,
+		".github/workflows/reusable.yml": `
+on: workflow_call
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`,
+	})
+	// Even a permissive repository default must not reach it: the caller
+	// declared a block, so the default never applies.
+	in.Probes.DefaultWorkflowPerms = "write"
+
+	got := evaluateScan(in)
+	reasons := reasonsFor(got, ".github/workflows/reusable.yml")
+	if len(reasons) != 1 {
+		t.Fatalf("want one finding for the callee, got %v", reasons)
+	}
+
+	// The two halves have to be asserted together, because either alone is
+	// satisfied by the pre-#106 behaviour for the wrong reason: without the
+	// composition the callee simply has no outsider trigger, so "it did not
+	// score" was already true. What proves the bound is the *pair* —
+	// reachability composed in, power left out.
+	if !strings.Contains(reasons[0], "pull_request_target") {
+		t.Errorf("reachability did not reach the callee, so this asserts nothing about the bound: %q", reasons[0])
+	}
+	if !strings.Contains(reasons[0], "holds no secrets or write scopes") {
+		t.Errorf("callee credited with power its caller never granted: %q", reasons[0])
+	}
+	if f, ok := findingFor(got, ".github/workflows/reusable.yml"); ok {
+		t.Errorf("callee scored %d though `permissions: {}` conferred nothing: %q", f.Weight, f.Reason)
+	}
+	// Nothing in this pair holds anything: the caller's only job declares
+	// `permissions: {}` and passes no secret, and the callee cannot hold
+	// more than it was given. A composition that scored here would be
+	// manufacturing power out of a chain that carries none.
+	if got.Score != 0 {
+		t.Errorf("score = %d, want 0 (findings %+v)", got.Score, got.Findings)
+	}
+}
+
+// A callee-only file nobody calls: the scan does not know who invokes it,
+// so it must claim neither power nor exposure. Before #106 this file read
+// as "grants the repository's default write permission, reachable only from
+// its own triggers" — two claims its caller actually decides.
+func TestScanDoesNotInventACallerForAnOrphanCallee(t *testing.T) {
+	in := chainScanInput(t, map[string]string{
+		".github/workflows/orphan.yml": `
+on: workflow_call
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`,
+	})
+	in.Probes.DefaultWorkflowPerms = "write"
+
+	got := evaluateScan(in)
+	reasons := reasonsFor(got, ".github/workflows/orphan.yml")
+	if len(reasons) != 1 {
+		t.Fatalf("want exactly one disclosure for an orphan callee, got %v", reasons)
+	}
+	if !strings.Contains(reasons[0], "none in this repository calls it") {
+		t.Errorf("reason does not disclose that no caller was found: %q", reasons[0])
+	}
+	if strings.Contains(reasons[0], "reachable only from its own triggers") {
+		t.Errorf("reason still claims reachability a callee does not have: %q", reasons[0])
+	}
+}
+
+// #106 scopes cross-repository resolution out; staying quiet about it is
+// what would be wrong. The same-repository call written as a full name plus
+// a ref is here too, so the more obscure spelling does not become the one
+// that evades composition unnoticed.
+func TestScanDisclosesAnUnfollowedChain(t *testing.T) {
+	in := chainScanInput(t, map[string]string{
+		".github/workflows/caller.yml": `
+on: pull_request_target
+permissions:
+  contents: write
+jobs:
+  far:
+    uses: octo-org/example/.github/workflows/a.yml@v1
+    secrets: inherit
+`,
+	})
+
+	got := evaluateScan(in)
+	var disclosed bool
+	for _, r := range reasonsFor(got, ".github/workflows/caller.yml") {
+		if strings.Contains(r, "does not resolve") && strings.Contains(r, "octo-org/example") {
+			disclosed = true
+		}
+	}
+	if !disclosed {
+		t.Errorf("the unfollowed chain was not disclosed: %v", reasonsFor(got, ".github/workflows/caller.yml"))
+	}
+}
+
+// A chain adds contributors to a sum the axis promises to keep under
+// tSuspicious, and the rule for that promise is to enumerate them rather
+// than trust one term: composing caller and callee means one attack path
+// can now emit an escalation finding per file in the chain, three of which
+// would be 9 against a threshold of 5. The clamp has to absorb that.
+func TestChainCannotBreachTheCapabilityCeiling(t *testing.T) {
+	in := chainScanInput(t, map[string]string{
+		".github/workflows/a.yml": `
+on: [pull_request_target, issue_comment, issues]
+permissions: write-all
+jobs:
+  call:
+    uses: ./.github/workflows/b.yml
+    secrets: inherit
+`,
+		".github/workflows/b.yml": `
+on: workflow_call
+jobs:
+  call:
+    uses: ./.github/workflows/c.yml
+    secrets: inherit
+  work:
+    runs-on: [self-hosted, linux]
+    steps:
+      - run: echo ${{ secrets.A }}
+`,
+		".github/workflows/c.yml": `
+on: workflow_call
+jobs:
+  work:
+    runs-on: ubuntu-latest
+    steps:
+      - run: deploy --token ${{ secrets.B }}
+`,
+	})
+	in.Probes = capabilityProbes{
+		SelfHostedRunners:    []string{"builder-1"},
+		WriteDeployKeys:      []string{"ci deploy key"},
+		OffPlatformHooks:     []string{"hooks.example.com"},
+		DefaultWorkflowPerms: "write",
+	}
+
+	got := evaluateScan(in)
+	total := 0
+	for _, f := range capFindings(got) {
+		total += f.Weight
+	}
+	if total > maxCapabilityScore {
+		t.Errorf("axis total %d exceeds the ceiling %d — a chain multiplies findings the clamp must absorb", total, maxCapabilityScore)
+	}
+	if got.Verdict == VerdictSuspicious || got.Verdict == VerdictCompromised {
+		t.Errorf("verdict = %v from capability alone, score %d", got.Verdict, got.Score)
+	}
+	// The clamp bounds the arithmetic, not the disclosure: every file in the
+	// chain must still appear, or the report hides the path it just found.
+	for _, p := range []string{".github/workflows/a.yml", ".github/workflows/b.yml", ".github/workflows/c.yml"} {
+		if len(reasonsFor(got, p)) == 0 {
+			t.Errorf("%s was clamped out of the report entirely", p)
+		}
+	}
+}
+
 func capFindings(s *RepoScan) []Finding {
 	var out []Finding
 	for _, f := range s.Findings {

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -53,6 +53,42 @@ var outsiderTriggers = map[string]string{
 	"issues":              "fires on an issue anyone can open, carrying their title and body",
 }
 
+// workflowCall is one reusable-workflow invocation — a job whose `uses:`
+// names another workflow rather than running steps.
+//
+// It carries what the *calling job* hands over, because that is what
+// decides the callee's power and the callee's own file cannot show it:
+// GitHub's reference is explicit that "if jobs.<job_id>.permissions is
+// not specified in the calling job, the called workflow will have the
+// default permissions for the GITHUB_TOKEN", and that what a callee
+// receives "can be only downgraded (not elevated)". So the callee is
+// scored on the caller's grant, reduced by its own if it declares one.
+type workflowCall struct {
+	// Path is the callee, repository-relative, resolved from the `./`
+	// form GitHub requires for a workflow in the same repository. Empty
+	// when the target is not local — see Remote.
+	Path string
+	// Remote is the raw `uses:` value when it is not a local `./` path:
+	// another repository, or this one addressed by its full name and a
+	// ref. Both are followed by nobody here, so the chain is *disclosed*
+	// rather than silently treated as absent (#106 scopes the cross-repo
+	// case out; pretending it was checked is the part that would be
+	// wrong).
+	Remote string
+	// PassesSecrets is true when the calling job hands the repository's
+	// secrets over — `secrets: inherit`, or a by-name mapping whose values
+	// reference the secrets context. It matters because without it a
+	// callee's own `${{ secrets.X }}` resolves to nothing: the reference
+	// is there, the secret is not.
+	PassesSecrets bool
+	// WritePerms are the elevated grants the calling job confers.
+	WritePerms []string
+	// InheritsDefaultPerms is true when neither the calling job nor its
+	// workflow declares a `permissions:` block, so what reaches the callee
+	// is the repository default (#107).
+	InheritsDefaultPerms bool
+}
+
 // workflowFacts is what one workflow file tells us about capability.
 type workflowFacts struct {
 	// OutsiderTriggers are the untrusted-input events this workflow answers.
@@ -66,6 +102,16 @@ type workflowFacts struct {
 	// SelfHostedJobs is true when any job targets a self-hosted runner,
 	// which is what makes an attached runner actually *reachable*.
 	SelfHostedJobs bool
+	// Calls are the reusable workflows this file invokes, one per calling
+	// job. Composing caller and callee is what turns two innocent-looking
+	// files into a scored path (#106); the composition itself lives in the
+	// scoring engine, which is the only place that can see the other files.
+	Calls []workflowCall
+	// CallableOnly is true when `workflow_call` is this file's only
+	// trigger, i.e. nothing reaches it except another workflow. Its
+	// permissions and its reachability are then both its callers' to
+	// decide, so claiming either from the file alone is wrong.
+	CallableOnly bool
 	// InheritsDefaultPerms is true when at least one job would run with
 	// the *repository's* default permissions instead of declared ones,
 	// because neither the workflow nor that job declares a `permissions:`
@@ -131,11 +177,15 @@ func parseWorkflow(content []byte) workflowFacts {
 	if trigger == nil {
 		trigger = root["true"]
 	}
-	for _, ev := range eventNames(trigger) {
+	events := eventNames(trigger)
+	for _, ev := range events {
 		if _, ok := outsiderTriggers[ev]; ok {
 			f.OutsiderTriggers = append(f.OutsiderTriggers, ev)
 		}
 	}
+	// Nothing but another workflow can start this file, so both its power
+	// and its exposure are decided elsewhere (#106).
+	f.CallableOnly = len(events) == 1 && events[0] == "workflow_call"
 
 	f.WritePerms = append(f.WritePerms, writeGrants(root["permissions"])...)
 	// Whether the *top level* declares a block at all, which is a
@@ -173,7 +223,36 @@ func parseWorkflow(content []byte) workflowFacts {
 			if s, ok := job["secrets"].(string); ok && strings.TrimSpace(s) == "inherit" {
 				f.UsesSecrets = true
 			}
+
+			// A job whose `uses:` names a workflow is a call, not steps.
+			// Only the job level counts: a step's `uses:` is an action, and
+			// treating the two alike would read every actions/checkout as a
+			// reusable-workflow chain.
+			if uses, ok := job["uses"].(string); ok {
+				if call, ok := parseWorkflowCall(uses); ok {
+					call.PassesSecrets = passesSecrets(job["secrets"])
+					// What the callee receives is the calling job's grant,
+					// falling back to the workflow's, and to the repository
+					// default only when neither declares anything.
+					if _, jobDeclares := job["permissions"]; jobDeclares {
+						call.WritePerms = writeGrants(job["permissions"])
+					} else if topDeclaresPerms {
+						call.WritePerms = writeGrants(root["permissions"])
+					} else {
+						call.InheritsDefaultPerms = true
+					}
+					f.Calls = append(f.Calls, call)
+				}
+			}
 		}
+		// Go randomises map iteration and these drive report text; see
+		// eventNames.
+		sort.Slice(f.Calls, func(i, j int) bool {
+			if f.Calls[i].Path != f.Calls[j].Path {
+				return f.Calls[i].Path < f.Calls[j].Path
+			}
+			return f.Calls[i].Remote < f.Calls[j].Remote
+		})
 	}
 	f.WritePerms = dedupeStrings(f.WritePerms)
 	return f
@@ -239,6 +318,65 @@ func expressionCode(s string) []string {
 		out = append(out, code.String())
 		s = s[i:]
 	}
+}
+
+// parseWorkflowCall classifies a job-level `uses:` value.
+//
+// GitHub requires the `./`-prefixed path for a workflow in the same
+// repository — `uses: ./.github/workflows/workflow-2.yml`, no ref — while
+// another repository is `owner/repo/.github/workflows/x.yml@ref`. Only the
+// first can be resolved against the tree this scan already walked.
+//
+// Everything else that still points at a workflow file is returned as
+// Remote rather than dropped, including *this* repository addressed by its
+// full name and a ref: that spelling is a same-repository call the scan
+// cannot follow, since the ref may not be a branch it read. Reporting it
+// as an unfollowed chain is the honest answer; silently ignoring it would
+// make the more obscure spelling the one that evades composition.
+func parseWorkflowCall(uses string) (workflowCall, bool) {
+	u := strings.TrimSpace(uses)
+	if u == "" {
+		return workflowCall{}, false
+	}
+	if rest, ok := strings.CutPrefix(u, "./"); ok {
+		// A local call carries no ref; if one is present the file is not
+		// what GitHub would resolve either, so treat it as unfollowable.
+		if strings.Contains(rest, "@") {
+			return workflowCall{Remote: u}, true
+		}
+		return workflowCall{Path: rest}, true
+	}
+	// A workflow call always names a workflow file. A step-level action
+	// (actions/checkout@v4) never does, which is the discriminator that
+	// keeps composite actions out of this — they are a different problem
+	// and run under their caller's token anyway.
+	if strings.Contains(u, ".github/workflows/") {
+		return workflowCall{Remote: u}, true
+	}
+	return workflowCall{}, false
+}
+
+// passesSecrets reports whether a calling job hands the repository's
+// secrets to the workflow it calls. Two shapes count: the `inherit`
+// keyword, and a by-name mapping whose values reference the secrets
+// context (`secrets: {token: ${{ secrets.GITHUB_TOKEN }}}`).
+//
+// A mapping whose values reference something else — an input, a var, a
+// literal — passes no secret, and counting it would score a callee that
+// receives nothing sensitive.
+func passesSecrets(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return strings.TrimSpace(t) == "inherit"
+	case map[string]any:
+		for _, val := range t {
+			s, ok := val.(string)
+			if ok && mentionsSecretsContext(s) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // mentionsSecretsContext reports whether any Actions expression in s names

--- a/internal/github/workflow.go
+++ b/internal/github/workflow.go
@@ -53,6 +53,35 @@ var outsiderTriggers = map[string]string{
 	"issues":              "fires on an issue anyone can open, carrying their title and body",
 }
 
+// describeTriggers renders outsider triggers each with its own reason for
+// being untrusted.
+//
+// Pairing them is not cosmetic. The reason line used to join the names and
+// then explain only the first, which composition made common — a chain
+// unions its callers' triggers, and so does the merge across branches. The
+// names sort alphabetically, so `issue_comment, pull_request_target` got
+// the comment explanation while the fork-trigger, the more dangerous of
+// the two, was listed with none and the sentence read as if the one
+// explanation covered both. Found by Copilot on #117.
+func describeTriggers(triggers []string) string {
+	parts := make([]string, 0, len(triggers))
+	for _, t := range triggers {
+		if why, ok := outsiderTriggers[t]; ok {
+			parts = append(parts, t+" ("+why+")")
+			continue
+		}
+		parts = append(parts, t)
+	}
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + " and " + parts[len(parts)-1]
+	}
+}
+
 // workflowCall is one reusable-workflow invocation — a job whose `uses:`
 // names another workflow rather than running steps.
 //


### PR DESCRIPTION
Closes #106.

A parser reads one file, which is the right shape for a parser and the wrong shape for this axis's question. Read separately, a `pull_request_target` caller that holds nothing of its own is not a finding, and a callee that reads a secret is not either, because on its own `workflow_call` is not untrusted input. Together they are a fork-triggered path to a repository secret.

## Two properties, opposite directions

Getting these the wrong way round is how a composition becomes a false-positive engine, so they are separated explicitly in `internal/github/chain.go`:

**Reachability accumulates.** Whatever can start the caller reaches everything it calls, transitively. The callee's finding names the trigger *and* the caller that carried it in — nobody is told a `workflow_call` file is fork-triggered without being shown how.

**Power is bounded by the giver.** GitHub's reference: what a callee receives *"can be only downgraded (not elevated)"*, and *"if `jobs.<job_id>.permissions` is not specified in the calling job, the called workflow will have the default permissions for the `GITHUB_TOKEN`"*. So a callee declaring `contents: write` whose caller hands over nothing holds nothing, and a `${{ secrets.X }}` reference resolves to nothing until a caller passes secrets — by `inherit`, or **by name**, which is the spelling this issue was opened for. `permissions: {}` is the case a per-file reading gets wrong in the dangerous direction: it grants nothing elevated, yet it *is* a declaration, so the repository default never applies.

## Three claims that are gone

Each one the pre-#106 report made and could not support:

- a callee-only file **nobody in the tree calls** now says so, instead of reading its own silence on permissions as "runs with the repository default" — a claim its caller actually makes;
- a callee's inventory line says "reachable only through the workflows that call it", not "reachable only from its own triggers", which a file with no triggers of its own cannot be;
- a call the scan **cannot** resolve is disclosed rather than dropped. Cross-repository resolution stays out of scope per the issue, but staying quiet would make the obscure spelling — this repository addressed by its full name and a ref — the one that evades composition unnoticed.

## Structure

Composition runs **per branch and is unioned by path**: a side branch can wire the same files together differently, which is exactly the divergence this scan exists to catch, so flattening before composing would hide it.

Propagation is a **fixpoint, not a recursion**. A cycle (`A` calls `B` calls `A`) is not valid Actions, but a scan reads whatever is in the tree — this way it terminates by construction rather than depending on a visited set threaded through correctly.

## The ceiling now carries more weight, not less

One attack path can emit an escalation finding per file in the chain — three files is 9 against a threshold of 5. Measured with the clamp disabled, the three-file chain test reaches **score 10 and "likely compromised" from capability alone**, against 7 for the single-workflow shape [#109](https://github.com/gfazioli/octoscope/pull/109) was opened for. `TestChainCannotBreachTheCapabilityCeiling` also asserts the clamp bounds the arithmetic and *not* the disclosure: every file in the chain still appears in the report.

## Verified live, on production code

Scanned `Skyscanner/backpack-ios`, which does this for real. Its `pr.yml` declares `permissions: {}` at the top level and `statuses: write` / `pull-requests: write` **on the calling job**, and passes `GH_APP_PRIVATE_KEY` **by name**:

```yaml
permissions: {}
jobs:
  Build:
    permissions:
      statuses: write
      pull-requests: write
    uses: ./.github/workflows/_build.yml
    secrets:
      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
```

The scan attributes exactly those two grants to `_build.yml`, and none of `_build.yml`'s own `permissions: {}` — the bound working on code nobody wrote for a test. Verdict stayed **clean** on all three repositories scanned: `pr.yml` triggers on `pull_request`, deliberately not an outsider trigger, so nothing propagates and nothing scores. The smoke test was deleted before committing, per the hermetic-suite rule.

## Mutation-tested rather than believed

Composition disabled, clamp disabled, reachability propagation off, passed-secrets guard off, callee-only power guard off, bound-by-giver off and unfollowed disclosure off — each fails the test that names it.

One test was **inert on the first pass**: it asserted the callee did not score, which was already true without the composition, because the callee had no trigger at all. It now asserts the pair only the bound can produce — reachability composed in, power left out. Worth recording, since this is the third inert assertion the mutation discipline has caught since #109.