### PR TITLE
feat(scan): rank the scored findings by severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ direct shortcut you can press from inside the menu to skip selection.
   auto-execution surfaces, oversized / obfuscated payloads and forged
   or unsigned commit tips — matching the *invariant* of the attack,
   not a single filename, so renamed variants still trip it — lists
-  every auto-executing file it found, and shows per-branch commit-tip
-  provenance. When something looks wrong it offers a copy-paste
+  every auto-executing file it found **heaviest evidence first**, and
+  shows per-branch commit-tip provenance. When something looks wrong it offers a copy-paste
   remediation script (`y`) and the right OAuth-grant revoke links.
   **octoscope never mutates the repo.**
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,10 @@ direct shortcut you can press from inside the menu to skip selection.
   when you open them in an AI editor or install them. It flags
   auto-execution surfaces, oversized / obfuscated payloads and forged
   or unsigned commit tips — matching the *invariant* of the attack,
-  not a single filename, so renamed variants still trip it — lists
-  every auto-executing file it found **heaviest evidence first**, and
-  shows per-branch commit-tip provenance. When something looks wrong it offers a copy-paste
+  not a single filename, so renamed variants still trip it — ranks the
+  evidence behind the verdict **heaviest first**, lists every
+  auto-executing file it found, and shows per-branch commit-tip
+  provenance. When something looks wrong it offers a copy-paste
   remediation script (`y`) and the right OAuth-grant revoke links.
   **octoscope never mutates the repo.**
 

--- a/docs/guide/drill-ins.html
+++ b/docs/guide/drill-ins.html
@@ -56,7 +56,7 @@
 
         <h2>Supply-chain integrity scan</h2>
         <p>An on-demand, <b>read-only</b> check for the Shai-Hulud / Miasma class of self-replicating implant — the kind pushed to your own repos via a stolen token, that auto-executes the moment a repo is opened in an AI editor or <code>npm install</code>-ed.</p>
-        <p>It scores four filename-agnostic axes, explains the verdict with the evidence behind it, and now openly declares when its coverage was partial — because in a security tool a false negative is the expensive direction to be wrong in.</p>
+        <p>It scores four filename-agnostic axes, explains the verdict with the evidence behind it — <b>heaviest first</b>, so what drove the verdict is what you read first — and now openly declares when its coverage was partial, because in a security tool a false negative is the expensive direction to be wrong in.</p>
         <p>Verdicts run <b>clean → watch → suspicious → likely&nbsp;compromised</b>. When there's something to act on, <kbd>y</kbd> copies a <b>remediation script</b> and the report deep-links the right OAuth-grant revoke pages. It never mutates the repo.</p>
         <figure class="shot">
           <div class="frame">

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -622,10 +622,18 @@ func (s *RepoScan) IgnitionInventory() []Finding {
 // deliberately not ranked because everything in it is weight 0 and there is
 // nothing to rank by.
 //
-// Stable, so equal weights keep engine order and the same scan always
-// renders identically. A plain sort.Slice would let two +3 findings swap
-// between runs of the same scan, which reads as a change where there is
-// none — the same determinism the report text already sorts for.
+// Stable, so equal weights keep the order the engine added them in — the
+// same determinism the report text already sorts for elsewhere.
+//
+// Not because sort.Slice is random: pdqsort is deterministic for a fixed
+// input, which is how the divergence point below was measured in the first
+// place. What it does not promise is *which* of two equal elements comes
+// first, so it reorders them relative to engine order, and that ordering is
+// free to change with the Go version or the input length. Stability is what
+// makes the arrangement a property of the findings rather than of the
+// implementation. Measured: for weights cycling the way this engine emits
+// them, sort.Slice first disagrees with sort.SliceStable at thirteen
+// findings — which is why TestScoredFindingsSortIsStable is that long.
 func (s *RepoScan) ScoredFindings() []Finding {
 	var out []Finding
 	for _, f := range s.Findings {

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -607,7 +607,25 @@ func (s *RepoScan) IgnitionInventory() []Finding {
 }
 
 // ScoredFindings returns the findings that contributed to the score
-// (Weight > 0), i.e. the actual evidence behind the verdict.
+// (Weight > 0), i.e. the actual evidence behind the verdict — **heaviest
+// first** (#105).
+//
+// The engine adds findings axis by axis (ignition, blob, provenance,
+// capability, delta), which is the right order to *evaluate* in and the
+// wrong one to *read*: it put a +1 above a +4, so the thing that actually
+// drove the verdict was not necessarily the first thing anyone saw, and a
+// reader had to compare every number to work out where to look first.
+//
+// Presentation only. The score, the verdict and the findings themselves are
+// untouched, and s.Findings keeps engine order — ContextFindings depends on
+// it to keep related weight-0 lines together, and the Context block is
+// deliberately not ranked because everything in it is weight 0 and there is
+// nothing to rank by.
+//
+// Stable, so equal weights keep engine order and the same scan always
+// renders identically. A plain sort.Slice would let two +3 findings swap
+// between runs of the same scan, which reads as a change where there is
+// none — the same determinism the report text already sorts for.
 func (s *RepoScan) ScoredFindings() []Finding {
 	var out []Finding
 	for _, f := range s.Findings {
@@ -615,6 +633,7 @@ func (s *RepoScan) ScoredFindings() []Finding {
 			out = append(out, f)
 		}
 	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Weight > out[j].Weight })
 	return out
 }
 

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -228,6 +229,83 @@ func TestEvaluateScanWatch(t *testing.T) {
 	got := evaluateScan(in)
 	if got.Verdict != VerdictWatch {
 		t.Fatalf("verdict = %v, want watch (score %d)", got.Verdict, got.Score)
+	}
+}
+
+// The scored block reads heaviest-first, so the evidence that drove the
+// verdict is the first thing seen rather than something to be found by
+// comparing every number (#105). The engine adds axis by axis, which put a
+// +1 above a +4.
+func TestScoredFindingsAreRankedBySeverity(t *testing.T) {
+	s := &RepoScan{Findings: []Finding{
+		{Axis: AxisIgnition, Path: "a", Weight: 1},
+		{Axis: AxisIgnition, Path: "b", Weight: 0}, // filtered out
+		{Axis: AxisBlob, Path: "c", Weight: 4},
+		{Axis: AxisProvenance, Path: "d", Weight: 3},
+		{Axis: AxisCapability, Path: "e", Weight: 3},
+		{Axis: AxisDelta, Path: "f", Weight: 2},
+	}}
+
+	got := s.ScoredFindings()
+	var weights []int
+	var paths []string
+	for _, f := range got {
+		weights = append(weights, f.Weight)
+		paths = append(paths, f.Path)
+	}
+	if len(got) != 5 {
+		t.Fatalf("scored = %d, want 5 (weight-0 filtered): %v", len(got), paths)
+	}
+	for i := 1; i < len(weights); i++ {
+		if weights[i-1] < weights[i] {
+			t.Errorf("weights %v are not descending at %d — a lighter finding reads above a heavier one", weights, i)
+		}
+	}
+
+	if paths[1] != "d" || paths[2] != "e" {
+		t.Errorf("equal weights reordered: got %v, want the +3 pair as d then e", paths)
+	}
+
+	// Presentation only: the engine's own slice keeps its order, because
+	// ContextFindings walks it to keep related weight-0 lines together.
+	if s.Findings[0].Path != "a" || s.Findings[2].Path != "c" {
+		t.Errorf("ScoredFindings mutated s.Findings: %v", s.Findings)
+	}
+}
+
+// Equal weights must keep engine order, so the same scan always renders
+// identically — the determinism the report text already sorts for
+// elsewhere. The sort therefore has to be *stable*, and asserting that
+// needs an input where an unstable sort visibly disagrees.
+//
+// Measured rather than assumed: with the five-finding case above,
+// sort.Slice and sort.SliceStable produce identical output, so swapping one
+// for the other there proves nothing. Go's pdqsort is deterministic for a
+// fixed input, and for weights cycling the way an axis-by-axis engine emits
+// them the two first disagree at **thirteen** findings — a size a repo with
+// several branches and workflows reaches easily. Hence the length.
+func TestScoredFindingsSortIsStable(t *testing.T) {
+	// The cycle mirrors the engine's own order: ignition, blob, provenance
+	// (two of equal weight), delta.
+	weights := []int{1, 4, 3, 3, 2}
+	var s RepoScan
+	for i := 0; i < 13; i++ {
+		s.Findings = append(s.Findings, Finding{
+			Axis:   AxisIgnition,
+			Path:   fmt.Sprintf("p%02d", i),
+			Weight: weights[i%len(weights)],
+		})
+	}
+
+	got := s.ScoredFindings()
+	// Within each weight, paths must appear in ascending index order,
+	// because that is the order the engine added them in.
+	lastByWeight := map[int]string{}
+	for _, f := range got {
+		if prev, ok := lastByWeight[f.Weight]; ok && f.Path < prev {
+			t.Errorf("weight %d reordered: %q came after %q — the sort is not stable", f.Weight, f.Path, prev)
+		}
+		lastByWeight[f.Weight] = f.Path
 	}
 }
 

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -285,8 +285,10 @@ func TestScoredFindingsAreRankedBySeverity(t *testing.T) {
 // them the two first disagree at **thirteen** findings — a size a repo with
 // several branches and workflows reaches easily. Hence the length.
 func TestScoredFindingsSortIsStable(t *testing.T) {
-	// The cycle mirrors the engine's own order: ignition, blob, provenance
-	// (two of equal weight), delta.
+	// The cycle mirrors the engine's own order — ignition, blob, provenance,
+	// capability, delta — so the equal-weight pair is provenance next to
+	// capability, which is exactly where an unstable sort would swap two
+	// findings from different axes.
 	weights := []int{1, 4, 3, 3, 2}
 	var s RepoScan
 	for i := 0; i < 13; i++ {


### PR DESCRIPTION
Closes #105.

The engine adds findings axis by axis — ignition, blob, provenance, capability, delta — which is the right order to *evaluate* in and the wrong one to *read*. It put a `+1` above a `+4`, so the evidence that actually drove the verdict was not necessarily the first thing anyone saw, and a reader had to compare every number to work out where to look first.

`ScoredFindings()` now returns heaviest-first.

## What deliberately does not change

- **`s.Findings` keeps engine order.** `ContextFindings` walks it to keep related weight-0 lines together, so the sort happens on the copy `ScoredFindings` already builds.
- **The Context block stays unranked**, per the issue: everything in it is weight 0, so there is nothing to rank by, and axis order keeps related lines adjacent.
- **Score, verdict and the findings themselves are untouched.** Nothing about detection or weighting moves.

Sorting inside the accessor covers both callers. The other one, `remediationScript`, collects branches and paths into sets and sorts those itself, so it is order-insensitive.

## The stability requirement had to be measured, not asserted

This is the part worth reading. The issue asks for `sort.SliceStable` so equal weights keep engine order and the same scan always renders identically. I wrote the obvious five-finding test — and then swapping `sort.SliceStable` for `sort.Slice` **left it green**. Go's pdqsort is deterministic for a fixed input, and at that size the two produce identical output, so the assertion named stability without testing it.

So I probed for where they actually diverge:

| layout | first divergence |
| --- | --- |
| all equal weights | none up to n=64 |
| descending with an equal tail | none up to n=64 |
| weights cycling `1,4,3,3,2` (axis-by-axis, as the engine emits) | **n=13** |

Thirteen findings is a size a repo with several branches and workflows reaches easily, and the cycling layout is the realistic one. `TestScoredFindingsSortIsStable` is that long deliberately, and under `sort.Slice` it fails on three separate weights:

```
weight 4 reordered: "p01" came after "p06" — the sort is not stable
weight 3 reordered: "p02" came after "p08" — the sort is not stable
weight 1 reordered: "p00" came after "p05" — the sort is not stable
```

Both mutations are covered: removing the sort entirely fails the ranking test, and downgrading to `sort.Slice` fails the stability test. That is the fourth inert assertion the mutation discipline has caught since #109 — this one in a change small enough that skipping the check would have felt entirely reasonable.

## Docs

One clause each in `README.md` and `docs/guide/drill-ins.html`, proportionate to an ordering change. Full suite green under `-race`, `gofmt` and `go vet` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Integrity and security scan findings are now presented with the strongest evidence first.
  * Findings with equal severity retain their original order, providing consistent results.
  * Zero-weight findings are excluded from ranked results.

* **Documentation**
  * Updated scan guidance to explain the new evidence ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->