### PR TITLE
chore(release): prep 0.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,17 +225,17 @@ direct shortcut you can press from inside the menu to skip selection.
   probes that need admin scope **fail open** on a minimal token, and the
   report says which ones it could not check.
 
-  Since v0.28.0 it stops taking a workflow file at its word. **Reusable-
-  workflow chains are followed**: a fork-triggered workflow holding
-  nothing that calls one reading a secret is one path to that secret,
-  not two harmless files, and the finding names the caller an outsider
-  comes through. Power travels the other way — a called workflow holds
-  what its caller *granted*, never more, so one whose caller hands over
-  nothing is not credited with anything it declares. And a workflow that
-  declares no `permissions:` runs with **your repository's default**,
-  which an owner can widen to read/write; octoscope reads that setting
-  and joins it to the file, and where it cannot, says so rather than
-  deciding the workflow holds nothing.
+  Since v0.28.0 it stops taking a workflow file at its word.
+  **Reusable-workflow chains are followed**: a fork-triggered workflow
+  holding nothing that calls one reading a secret is one path to that
+  secret, not two harmless files, and the finding names the caller an
+  outsider comes through. Power travels the other way — a called
+  workflow holds what its caller *granted*, never more, so one whose
+  caller hands over nothing is not credited with anything it declares.
+  And a workflow that declares no `permissions:` runs with **your
+  repository's default**, which an owner can widen to read/write;
+  octoscope reads that setting and joins it to the file, and where it
+  cannot, says so rather than deciding the workflow holds nothing.
 
 ### Rate-limit awareness
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,18 @@ direct shortcut you can press from inside the menu to skip selection.
   probes that need admin scope **fail open** on a minimal token, and the
   report says which ones it could not check.
 
+  Since v0.28.0 it stops taking a workflow file at its word. **Reusable-
+  workflow chains are followed**: a fork-triggered workflow holding
+  nothing that calls one reading a secret is one path to that secret,
+  not two harmless files, and the finding names the caller an outsider
+  comes through. Power travels the other way — a called workflow holds
+  what its caller *granted*, never more, so one whose caller hands over
+  nothing is not credited with anything it declares. And a workflow that
+  declares no `permissions:` runs with **your repository's default**,
+  which an owner can widen to read/write; octoscope reads that setting
+  and joins it to the file, and where it cannot, says so rather than
+  deciding the workflow holds nothing.
+
 ### Rate-limit awareness
 
 The footer surfaces your GitHub GraphQL budget live:

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -30,7 +30,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.27.0</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.28.0</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/guide/drill-ins.html
+++ b/docs/guide/drill-ins.html
@@ -83,6 +83,12 @@
         <h3>What a compromise could reach</h3>
         <p>The scan also reads your <b>capability footprint</b>: what permissions and triggers your workflows declare, plus self-hosted runners, write-access deploy keys and webhooks delivering off GitHub.</p>
         <p>Holding power is not itself a finding. A release workflow asking for <code>contents: write</code> and reading secrets is completely normal — only someone who can already push a tag can trigger it, so it stays inventory. What scores is power reachable from <b>untrusted input</b>: a <code>pull_request_target</code> workflow holding the repository's secrets, or a self-hosted runner that an outsider's pull request can reach.</p>
+        <p>Since <b>v0.28.0</b> it doesn't take a workflow file at its word, because one file is often not the whole story:</p>
+        <ul>
+          <li><b>Chains are followed.</b> A fork-triggered workflow holding nothing that calls one reading a secret is two harmless files apart and one path to that secret together. The finding names the caller an outsider arrives through, so you're never told a <code>workflow_call</code> file is fork-triggered without being shown how.</li>
+          <li><b>Power is bounded by whoever granted it.</b> A called workflow holds what its caller passed, never more — GitHub only lets it reduce that. So one whose caller hands over nothing isn't credited with the permissions it declares, and a file nobody in the repo calls says so rather than guessing.</li>
+          <li><b>The permission never written down.</b> A workflow declaring no <code>permissions:</code> runs with your <i>repository's</i> default, which an owner can widen to read/write — invisible in the file. octoscope reads that setting and joins it in; where it can't, the report says so instead of deciding the workflow holds nothing.</li>
+        </ul>
 
         <div class="note">
           <span class="ic">◑</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1251,7 +1251,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.27.0</span>
+                <span class="version-tag" id="version-pill">0.28.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1494,6 +1494,11 @@
                     <div class="feature-label">Integrity over time</div>
                     <h3>Notices what changed, not just what's there</h3>
                     <p>The supply-chain scan records a fingerprint of what auto-executes in a repo, then reports what moved since: a file that appeared, one whose contents changed, a branch tip that stopped being signed. It also maps what a compromise could reach — workflow permissions and triggers, self-hosted runners, deploy keys, off-platform webhooks — and says which checks your token couldn't run.</p>
+                </div>
+                <div class="feature w-l">
+                    <div class="feature-label">Workflow chains</div>
+                    <h3>Reads the path, not the file</h3>
+                    <p>Since v0.28.0. A fork-triggered workflow that holds nothing, calling one that reads a secret, is two harmless files read one at a time and <strong style="color: var(--text);">one path to your secrets</strong> read together — so the scan follows the chain and names the caller an outsider comes through. Power travels the other way: a called workflow holds what its caller granted, never what it merely declares. And a workflow with no <code class="inline">permissions:</code> runs with your repository's default, which octoscope now reads instead of assuming.</p>
                 </div>
 
                 <div class="feature w-m">

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -27,6 +27,27 @@ type whatsNewEntry struct {
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
 var whatsNew = map[string]whatsNewEntry{
+	"0.28.0": {
+		headline: "The capability axis stops taking a workflow at its word.",
+		items: []whatsNewItem{
+			{
+				title: "Reusable-workflow chains are followed",
+				desc:  "A fork-triggered workflow that holds nothing, calling one that reads a secret, used to be two innocent files. It is one path to your secrets, and the scan now reads it as one — naming the trigger and the caller that carries it in. Power travels the other way: a called workflow holds what its caller granted, not what it declares, so a callee whose caller hands over nothing is no longer credited with anything.",
+			},
+			{
+				title: "The permission a workflow never mentions",
+				desc:  "A workflow that declares no permissions runs with your repository's default, which an owner can widen to read/write — so the file can hold write access it never names. octoscope now reads that setting and joins it to the file. Where it cannot, the report says so instead of quietly deciding the workflow holds nothing.",
+			},
+			{
+				title: "Secrets found by structure, and two more untrusted triggers",
+				desc:  "Secret detection now walks parsed YAML rather than matching text, so alternate spellings of secrets: inherit no longer slip past and a commented-out reference no longer counts. The list of events an outsider can cause gained issues — anyone can open one, and the run gets your token and secrets.",
+			},
+			{
+				title: "The evidence is ranked",
+				desc:  "The scan report's scored findings now read heaviest first, so what drove the verdict is the first thing you see rather than something to find by comparing every number.",
+			},
+		},
+	},
 	"0.27.0": {
 		headline: "The integrity scan stops describing, and starts noticing.",
 		items: []whatsNewItem{

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.27.0"
+const version = "0.28.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Makes `main` taggable for **v0.28.0**. All five PRs in this cycle merged without release-prep changes, so this is the dedicated prep PR the checklist calls for rather than an atomic-in-PR bump.

## The cycle

Five issues, closed: [#105](https://github.com/gfazioli/octoscope/issues/105), [#106](https://github.com/gfazioli/octoscope/issues/106), [#107](https://github.com/gfazioli/octoscope/issues/107), [#110](https://github.com/gfazioli/octoscope/issues/110), [#111](https://github.com/gfazioli/octoscope/issues/111). Four of them are the capability axis, and the honest summary of what changed is one sentence: **it stops taking a workflow file at its word.** Chains are followed, the repository default it never declares is resolved, secrets are read as parsed YAML rather than as text, and two more outsider-triggerable events are recognised. The fifth ranks the report's evidence heaviest-first.

Worth recording for whoever reads this later: the most serious defects the cycle fixed were **not in the new code**. They were claims the report already made and could not support — a push-burst gate that contradicted two code comments and the design doc at once, a reachability claim for callee-only workflows, a repository default attributed to files that do not inherit it. The axis was safer than it said it was, not less safe.

## What this PR touches

| file | change |
| --- | --- |
| `main.go` | `version` → `0.28.0` |
| `internal/ui/whatsnew.go` | the `"0.28.0"` entry, four highlights — without it the tab falls back to a link after the upgrade |
| `README.md` | capability-footprint paragraph extended with chains and the repository default (the severity ranking went in with #105) |
| `docs/index.html` | pill fallback, plus an *At a glance* card for the chain composition |
| `docs/guide/drill-ins.html` | three bullets under the capability section |
| `docs/guide/docs.js` | the `#guide-ver` fallback |

## Verified, not eyeballed

Both docs pages were rendered through headless Chrome and checked in the resulting DOM. That is also how the landing card was confirmed to sit inside `.glance-track`: the marquee JS duplicates the track, so the card appearing **exactly twice** is the proof it scrolls with the rest rather than sitting outside the band.

The version pill reads `0.27.0` in that render, and that is correct — it fetches the Releases API on load, so it will read `0.28.0` once the tag exists; the inline value is only the offline fallback. Suite green, `gofmt` and `go vet` clean, `./octoscope --version` reports `0.28.0`.

## Deliberately not here

The landing hero screenshot. It reads the version from the built binary, so it is a post-merge, pre-tag refresh, and a version bump refreshes **only** the hero — the drill-in stills lagging a version is the accepted trade-off, since regenerating one slide on its own reintroduces the cross-fade jump.

No tag work until the explicit go-ahead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow-chain analysis documentation, including permission inheritance, repository defaults, and uncertainty reporting.
  * Documented structural secret detection, additional untrusted triggers, and ranked findings.
  * Added a “Workflow chains” feature highlight to the product site.

* **Documentation**
  * Updated version references and the documentation sidebar to v0.28.0.
  * Added v0.28.0 content to the in-app “What’s New” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->