### PR TITLE
feat(gists): the Gists tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -756,7 +756,7 @@ backend):
 
 1. **The dashboard fetch is N parallel branches.** Started as two
    parallel queries in v0.10.1 (`profileFields` + `repoFields`),
-   currently up to **five** as of v0.15.0:
+   currently up to **six** as of v0.29.0:
    1. `profileFields` — profile, counters, open PR/Issue nodes,
       contribution calendar
    2. `repoFields` — `repositories(first: 100)` with full nested
@@ -769,6 +769,12 @@ backend):
       config can't burst-flood GitHub
    5. `reviewRequests` search (v0.15.0, gated on
       `authenticated && viewer-mode`) — single search query
+   6. `FetchGists` (v0.29.0) — one connection, and the only branch
+      that is **best-effort**: its error is deliberately dropped.
+      Gists are the one surface GitHub answers with data *and* a
+      GraphQL error on a permission edge, which is the shape that
+      aborts a decode — sharing a branch with anything mandatory
+      would take the dashboard down with it.
    All run via goroutines + `sync.WaitGroup`. Wall-clock latency
    stays close to the slowest branch rather than their sum. See
    `internal/github/client.go` `FetchStats` for the canonical

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ current on screen so you can check the pulse of your GitHub life without
 switching to a browser.
 
 The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
-`Activity`, `What's new`) — jump with number keys or cycle with `tab` /
-`shift+tab`.
+`Activity`, `Gists`, `What's new`) — jump with number keys or cycle with
+`tab` / `shift+tab`.
 
 ### The tabs
 
@@ -91,10 +91,15 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
   shape as PRs minus the state column.
 - **Activity** — 52-week contribution heatmap, plus total / current streak /
   longest streak / busiest day computed from the same cells.
+- **Gists** (v0.29.0+) — your gists, newest first, with visibility, file
+  count and stars. `enter` expands the file list inline — no second fetch,
+  the files came with the row. An untitled gist is listed by its first
+  filename rather than by its hash, and `--public-only` doesn't fetch the
+  secret ones at all, so not even the count reveals how many there are.
 - **What's new** (v0.16.0+) — the highlights of the version you're running,
   bundled into the binary so it works offline, plus a sponsor section
   (`o` opens the Sponsors page, `c` copies the link). Jump here any time
-  with `6`.
+  with `7`.
 
 The **Overview** tab is organised in five sections:
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
 - **Activity** — 52-week contribution heatmap, plus total / current streak /
   longest streak / busiest day computed from the same cells.
 - **Gists** (v0.29.0+) — your gists, newest first, with visibility, file
-  count and stars. `enter` expands the file list inline — no second fetch,
-  the files came with the row. An untitled gist is listed by its first
+  count and stars. `enter` drills in and shows the **file contents**,
+  syntax-highlighted, and `c` there copies the *code* rather than the link
+  — a gist is a snippet, so reading and pasting it is the point. A one-file
+  gist opens straight into it. An untitled gist is listed by its first
   filename rather than by its hash, and `--public-only` doesn't fetch the
   secret ones at all, so not even the count reveals how many there are.
 - **What's new** (v0.16.0+) — the highlights of the version you're running,
@@ -133,7 +135,7 @@ footer only when the active tab actually overflows.
 
 ### Drill-in details
 
-On any list tab (Repos, PRs, Issues), pressing **`enter`** on the
+On any list tab (Repos, PRs, Issues, Gists), pressing **`enter`** on the
 selected row opens a rich **drill-in view** of that item; pressing
 **`space`** opens the **action menu** instead:
 

--- a/README.md
+++ b/README.md
@@ -637,11 +637,11 @@ Key bindings while running:
 
 | Key | Action |
 |-----|--------|
-| `1`-`6` | Jump to tab (Overview, Repos, PRs, Issues, Activity, What's new) |
+| `1`-`7` | Jump to tab (Overview, Repos, PRs, Issues, Activity, Gists, What's new) |
 | `tab` / `shift+tab` | Cycle tabs forward / backward |
 | `↑` / `↓`, `j` / `k` | Move cursor in list tabs · scroll Overview / Activity when the body overflows the window |
 | `pgup` / `pgdn`, `u` / `d` | Page up / down on Overview & Activity (vertical scrolling) |
-| `space` | On Repos / PRs / Issues: open the action menu for the selected row · on Overview / Activity: page down |
+| `space` | On Repos / PRs / Issues / Gists: open the action menu for the selected row · on Overview / Activity: page down |
 | `g` / `G` | Jump to top / bottom |
 | `s` | Cycle sort column |
 | `/` | Filter by substring |

--- a/docs/guide/keybinds.html
+++ b/docs/guide/keybinds.html
@@ -25,7 +25,7 @@
         <table class="keys">
           <caption>Global</caption>
           <tbody>
-            <tr><td class="k"><kbd>1</kbd>–<kbd>6</kbd> · <kbd>tab</kbd></td><td>Switch tab · cycle tabs (<kbd>⇧tab</kbd> backwards)</td></tr>
+            <tr><td class="k"><kbd>1</kbd>–<kbd>7</kbd> · <kbd>tab</kbd></td><td>Switch tab · cycle tabs (<kbd>⇧tab</kbd> backwards)</td></tr>
             <tr><td class="k"><kbd>r</kbd></td><td>Refresh now</td></tr>
             <tr><td class="k"><kbd>p</kbd></td><td>Toggle public-only mode</td></tr>
             <tr><td class="k"><kbd>%</kbd></td><td>Open the rate-limit detail panel</td></tr>

--- a/docs/guide/tabs.html
+++ b/docs/guide/tabs.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>The tabs · octoscope docs</title>
-<meta name="description" content="Overview, Repos, PRs, Issues, Activity and What's new — the six tabs of the octoscope dashboard." />
+<meta name="description" content="Overview, Repos, PRs, Issues, Activity, Gists and What's new — the seven tabs of the octoscope dashboard." />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -72,7 +72,11 @@
           </div>
         </figure>
 
-        <h2><kbd>6</kbd> What's new</h2>
+        <h2><kbd>6</kbd> Gists</h2>
+        <p>Your gists, newest first — visibility, file count, stars and when each last changed. <kbd>enter</kbd> expands the file list inline; there is no spinner because there is nothing to fetch, the files arrived with the row.</p>
+        <p>Two details worth knowing. A gist's real name is a hash, so an <b>untitled</b> one is listed by its first filename instead — and the filter matches that, so you can find it by the name you can actually see. And under <code>--public-only</code> the secret ones are never requested rather than fetched and hidden, which keeps the count honest too: a &ldquo;10 of 16&rdquo; would itself have told anyone watching that six secret gists exist.</p>
+
+        <h2><kbd>7</kbd> What's new</h2>
         <p>A bundled, offline changelog of the running version's highlights — shown right after an upgrade, no network needed. It's also where the support links live: <kbd>o</kbd> opens the Sponsors page, <kbd>c</kbd> copies the link.</p>
 
         <div class="pager">

--- a/docs/guide/tabs.html
+++ b/docs/guide/tabs.html
@@ -73,7 +73,8 @@
         </figure>
 
         <h2><kbd>6</kbd> Gists</h2>
-        <p>Your gists, newest first — visibility, file count, stars and when each last changed. <kbd>enter</kbd> expands the file list inline; there is no spinner because there is nothing to fetch, the files arrived with the row.</p>
+        <p>Your gists, newest first — visibility, file count, stars and when each last changed. <kbd>enter</kbd> drills in: a multi-file gist shows its files, and <kbd>enter</kbd> again opens one; a <b>one-file gist opens straight into it</b>, because that is the only thing there was to see.</p>
+        <p>The file view is the point of the tab. A gist is a snippet, so it is shown <b>syntax-highlighted and scrollable</b>, and <kbd>c</kbd> there copies the <b>code</b> rather than the link — the first cut of this tab could only send you to the browser, which is what octoscope exists to avoid. GitHub truncates very large files and a gist can hold a binary; both are said out loud instead of being rendered as noise.</p>
         <p>Two details worth knowing. A gist's real name is a hash, so an <b>untitled</b> one is listed by its first filename instead — and the filter matches that, so you can find it by the name you can actually see. And under <code>--public-only</code> the secret ones are never requested rather than fetched and hidden, which keeps the count honest too: a &ldquo;10 of 16&rdquo; would itself have told anyone watching that six secret gists exist.</p>
 
         <h2><kbd>7</kbd> What's new</h2>

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -370,6 +370,19 @@ type Stats struct {
 	// questions ("things I created" vs "things waiting for me").
 	ReviewRequests []PullRequest
 
+	// Gists are the account's gists, newest update first (#76), and
+	// GistsTotal is what GitHub reports for the same query — the two
+	// differ when there are more than gistsPageSize, which is how the
+	// tab can say it is showing a window rather than everything.
+	//
+	// Fetched best-effort: a failure leaves both zero and the dashboard
+	// renders without the tab's contents rather than failing. Gists are
+	// the one surface where a permission edge returns data *and* a
+	// GraphQL error, so it must not share a branch with anything
+	// mandatory.
+	Gists      []Gist
+	GistsTotal int
+
 	// Meta
 	Authenticated bool
 	// IsViewer is true when the stats belong to the authenticated
@@ -956,6 +969,8 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		watchedSkipped   []string
 		reviewRequests   []PullRequest
 		errRR            error
+		gists            []Gist
+		gistsTotal       int
 	)
 
 	watchRefs := c.WatchRepos()
@@ -967,7 +982,7 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	wantReviewRequests := c.authenticated && c.login == ""
 
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4) // profile, repos, repo CI, gists
 	if len(watchRefs) > 0 {
 		wg.Add(1)
 	}
@@ -1011,7 +1026,25 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		repoCI, rlC, errC = c.fetchRepoCIFieldsPaged(ctx)
 	}()
 
-	// Fourth parallel branch — external watched repos. Each entry
+	// Fourth parallel branch — gists (#76). **Best-effort by
+	// construction**: its error is deliberately not captured, because a
+	// gists failure must never cost the user their dashboard. That is not
+	// caution in the abstract — of everything fetched here, this is the
+	// one query GitHub can answer with data *and* an error attached
+	// (a permission edge on someone else's account), which is exactly the
+	// shape that aborts a decode. Folded into a shared branch it would
+	// take the whole profile down with it. Same rule the star-history walk
+	// follows in FetchRepoDetail.
+	go func() {
+		defer wg.Done()
+		g, total, err := c.FetchGists(ctx)
+		if err != nil {
+			return // tab renders empty; the rest of the dashboard is unaffected
+		}
+		gists, gistsTotal = g, total
+	}()
+
+	// Fifth parallel branch — external watched repos. Each entry
 	// resolves to its own singleRepoQuery (FetchWatchedRepos
 	// fans out further internally). A failed entry never fails the
 	// whole dashboard: unresolvable refs come back in watchedSkipped
@@ -1024,7 +1057,7 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		}()
 	}
 
-	// Fifth parallel branch — review-requests inbox (v0.15.0).
+	// Sixth parallel branch — review-requests inbox (v0.15.0).
 	// Single search query, cheap enough to ride alongside the
 	// rest of the dashboard refresh. Gated on authenticated-
 	// viewer mode upstream (wantReviewRequests).
@@ -1064,6 +1097,8 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	stats.WatchedRepos = watched
 	stats.WatchedSkipped = watchedSkipped
 	stats.ReviewRequests = reviewRequests
+	stats.Gists = gists
+	stats.GistsTotal = gistsTotal
 	return stats, nil
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -503,6 +503,29 @@ func (s *Stats) Public() *Stats {
 		out.ReviewRequests = append(out.ReviewRequests, pr)
 	}
 
+	// Gists (#76). The fetch already asks GitHub for PUBLIC when the
+	// client starts in public-only mode, but that covers startup, not the
+	// `p` toggle: flipping it at runtime is applied *here*, at render
+	// time, with the previous refresh's data still in memory. Without this
+	// loop, pressing p in front of an audience kept every secret gist on
+	// screen until the next refetch — in the one mode that exists for
+	// screenshots.
+	//
+	// GistsTotal is clamped rather than kept, and that half matters as
+	// much: leaving it at 16 while showing 10 renders "10 of 16", which
+	// discloses that six secret gists exist. Same second-order leak the
+	// fetch side avoids by asking for PUBLIC instead of filtering after.
+	out.Gists = nil
+	for _, g := range s.Gists {
+		if !g.IsPublic {
+			continue
+		}
+		out.Gists = append(out.Gists, g)
+	}
+	if out.GistsTotal > len(out.Gists) {
+		out.GistsTotal = len(out.Gists)
+	}
+
 	// WatchedSkipped names watch_repos refs that failed to resolve —
 	// one may reference a repo that just went private, so screenshot
 	// mode drops the notice entirely rather than leak the name.

--- a/internal/github/gist_detail.go
+++ b/internal/github/gist_detail.go
@@ -1,0 +1,125 @@
+package github
+
+// Gists — the drill-in half. The list tab answers "which gists do I have";
+// this answers the question you actually opened one for: *what is in it*.
+//
+// The content is deliberately NOT part of the list query. `Gist.files`
+// exposes a `text` field, so it could be, and the first cut of the tab was
+// built on the assumption that it should not — which quietly turned the
+// tab into a browser launcher. Both halves of that are right for different
+// reasons: 100 gists × 20 files of source on every dashboard refresh is a
+// payload and complexity-ceiling problem, and this repository has the 502
+// scars to prove it. So the content is fetched **one gist at a time, on
+// demand** — the drill-in pattern the rest of the app already follows.
+
+import (
+	"context"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// GistFileContent is one file with its body.
+//
+// IsTruncated and IsImage are carried rather than inferred because the UI
+// has to *decline* in both cases rather than render nonsense: GitHub cuts
+// very large files, and a gist can hold a binary. Neither is common — a
+// survey of 47 real files found zero of each — which is exactly why they
+// need to arrive as facts instead of being guessed from a size threshold.
+type GistFileContent struct {
+	Name        string
+	Language    string
+	Size        int
+	Text        string
+	IsTruncated bool
+	IsImage     bool
+}
+
+// GistDetail is one gist with its file bodies.
+type GistDetail struct {
+	Name        string
+	Description string
+	URL         string
+	IsPublic    bool
+	Files       []GistFileContent
+}
+
+type gistDetailFields struct {
+	Name        githubv4.String
+	Description githubv4.String
+	URL         githubv4.String `graphql:"url"`
+	IsPublic    githubv4.Boolean
+	Files       []struct {
+		Name        githubv4.String
+		Size        githubv4.Int
+		Text        githubv4.String
+		IsTruncated githubv4.Boolean
+		IsImage     githubv4.Boolean
+		Language    struct {
+			Name githubv4.String
+		}
+	} `graphql:"files(limit: 20)"`
+}
+
+// FetchGistDetail returns one gist with the contents of its files.
+//
+// `name` is the gist's hash, which is what GitHub calls its name and what
+// the list rows carry. Resolved against the same account the dashboard is
+// showing, so viewing someone else's profile drills into their gists.
+func (c *Client) FetchGistDetail(ctx context.Context, name string) (*GistDetail, error) {
+	vars := map[string]interface{}{"name": githubv4.String(name)}
+
+	var f gistDetailFields
+	if c.login == "" {
+		var q struct {
+			Viewer struct {
+				Gist gistDetailFields `graphql:"gist(name: $name)"`
+			}
+		}
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+		f = q.Viewer.Gist
+	} else {
+		var q struct {
+			User struct {
+				Gist gistDetailFields `graphql:"gist(name: $name)"`
+			} `graphql:"user(login: $login)"`
+		}
+		vars["login"] = githubv4.String(c.login)
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+		f = q.User.Gist
+	}
+
+	return extractGistDetail(f), nil
+}
+
+// extractGistDetail is the pure half.
+//
+// The file body crosses Sanitize like every other GitHub-sourced string,
+// and this is the case that function was built for: anyone who can share a
+// gist link controls its content, and the content is about to be written
+// to a terminal. Sanitize keeps `\n` and `\t` — so code stays readable and
+// indented — while dropping ANSI escapes and the 8-bit C1 introducers that
+// would otherwise move the cursor, repaint the screen, or drive the OSC
+// clipboard.
+func extractGistDetail(f gistDetailFields) *GistDetail {
+	d := &GistDetail{
+		Name:        Sanitize(string(f.Name)),
+		Description: Sanitize(string(f.Description)),
+		URL:         Sanitize(string(f.URL)),
+		IsPublic:    bool(f.IsPublic),
+	}
+	for _, file := range f.Files {
+		d.Files = append(d.Files, GistFileContent{
+			Name:        Sanitize(string(file.Name)),
+			Language:    Sanitize(string(file.Language.Name)),
+			Size:        int(file.Size),
+			Text:        Sanitize(string(file.Text)),
+			IsTruncated: bool(file.IsTruncated),
+			IsImage:     bool(file.IsImage),
+		})
+	}
+	return d
+}

--- a/internal/github/gist_detail_test.go
+++ b/internal/github/gist_detail_test.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The body is the reason this fetch exists, and it is also the most
+// attacker-controlled string the app renders: anyone who can share a gist
+// link controls its content, and the content goes straight to a terminal.
+//
+// The escapes are JSON escapes because JSON forbids a raw control
+// character inside a string — so this is the shape GitHub actually sends,
+// and the raw byte only ever exists after the decoder expands it, which is
+// exactly where Sanitize is waiting.
+const gistDetailBody = `{"data":{"viewer":{"gist":{
+	"name":"7ac536c358f737269b6b",
+	"description":"settings",
+	"url":"https://gist.github.com/gfazioli/7ac536c358f737269b6b",
+	"isPublic":false,
+	"files":[
+		{"name":"main.go","size":42,"isTruncated":false,"isImage":false,
+		 "language":{"name":"Go"},
+		 "text":"package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n"},
+		{"name":"evil.txt","size":9,"isTruncated":true,"isImage":false,
+		 "language":{"name":""},
+		 "text":"before\u001b[31mafter\u009fend"},
+		{"name":"logo.png","size":900,"isTruncated":false,"isImage":true,
+		 "language":{"name":""},"text":""}
+	]}}}}`
+
+func TestFetchGistDetail(t *testing.T) {
+	c := newTestGQLClient(t, 200, gistDetailBody)
+
+	d, err := c.FetchGistDetail(context.Background(), "7ac536c358f737269b6b")
+	if err != nil {
+		t.Fatalf("FetchGistDetail: %v", err)
+	}
+	if d.Name != "7ac536c358f737269b6b" || d.IsPublic {
+		t.Errorf("gist decoded wrong: %+v", d)
+	}
+	if len(d.Files) != 3 {
+		t.Fatalf("files = %d, want 3", len(d.Files))
+	}
+
+	// Code has to survive readable. Sanitize keeps newlines and tabs, so
+	// line structure and indentation are intact — stripping those would
+	// turn every file into one unreadable line, which is the failure mode
+	// that would make this whole view worthless.
+	code := d.Files[0]
+	if !strings.Contains(code.Text, "\n\tprintln") {
+		t.Errorf("sanitising flattened the code — a newline or tab was dropped: %q", code.Text)
+	}
+	if code.Language != "Go" || code.Size != 42 {
+		t.Errorf("file metadata decoded wrong: %+v", code)
+	}
+
+	// …while the sequences that would drive the terminal do not survive.
+	evil := d.Files[1]
+	if strings.ContainsRune(evil.Text, 0x1b) {
+		t.Errorf("an ANSI escape reached the body: %q", evil.Text)
+	}
+	if strings.ContainsRune(evil.Text, 0x9f) {
+		t.Errorf("a C1 introducer reached the body: %q", evil.Text)
+	}
+	if !strings.Contains(evil.Text, "before") || !strings.Contains(evil.Text, "end") {
+		t.Errorf("sanitising ate the text around the escapes: %q", evil.Text)
+	}
+
+	// Truncation and binary arrive as facts, because the UI has to decline
+	// rather than render nonsense — and neither can be inferred from size.
+	if !evil.IsTruncated {
+		t.Error("isTruncated did not decode; the UI would show a cut file as complete")
+	}
+	if !d.Files[2].IsImage {
+		t.Error("isImage did not decode; the UI would print binary at the terminal")
+	}
+}
+
+func TestFetchGistDetailSurfacesErrors(t *testing.T) {
+	c := newTestGQLClient(t, 200, `{"errors":[{"message":"Could not resolve to a Gist"}]}`)
+	if _, err := c.FetchGistDetail(context.Background(), "nope"); err == nil {
+		t.Fatal("a GraphQL error decoded as success")
+	}
+}

--- a/internal/github/gists.go
+++ b/internal/github/gists.go
@@ -1,0 +1,169 @@
+package github
+
+// Gists — the one account-centric surface the dashboard did not represent
+// (#76). Repos, PRs, issues, activity and stars were all there; this was a
+// gap rather than an expansion, which is why it reuses the existing list-tab
+// shape instead of introducing a mental model of its own.
+
+import (
+	"context"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// gistsPageSize bounds what one refresh pulls. Deliberately a single page:
+// paging is unbounded work inside a dashboard fetch that is bounded
+// everywhere else, and a hundred gists is already far past what anyone
+// scrolls. TotalCount comes back alongside, so a truncated list can *say*
+// it is truncated rather than quietly looking complete — the same choice
+// the scan's probes make about their own limits.
+const gistsPageSize = 100
+
+// GistFile is one file inside a gist. Size is bytes; Language is GitHub's
+// own detection and is empty when it has none.
+type GistFile struct {
+	Name     string
+	Language string
+	Size     int
+}
+
+// Gist is one gist as the dashboard shows it.
+//
+// Description is left exactly as GitHub returned it, **including empty** —
+// 2 of 16 gists on a real account have none. Choosing what to display in
+// that case is presentation and belongs to the UI, not here: inventing a
+// description would put a value into `--json` output that GitHub never
+// gave us.
+type Gist struct {
+	// Name is the gist's hash id, which is also the last path segment of
+	// its URL. GitHub calls this "name"; it is not human-readable.
+	Name        string
+	Description string
+	URL         string
+	IsPublic    bool
+	IsFork      bool
+	Stars       int
+	Files       []GistFile
+	UpdatedAt   time.Time
+}
+
+// gistFields is the query shape. URL is queried as String rather than URI
+// for the reason the rest of this package does: URI unmarshals through
+// url.Parse, and one control character in one field aborts the decode of
+// the entire response.
+type gistFields struct {
+	TotalCount githubv4.Int
+	Nodes      []struct {
+		Name           githubv4.String
+		Description    githubv4.String
+		URL            githubv4.String `graphql:"url"`
+		IsPublic       githubv4.Boolean
+		IsFork         githubv4.Boolean
+		StargazerCount githubv4.Int
+		UpdatedAt      githubv4.DateTime
+		Files          []struct {
+			Name     githubv4.String
+			Size     githubv4.Int
+			Language struct {
+				Name githubv4.String
+			}
+		} `graphql:"files(limit: 20)"`
+	}
+}
+
+// FetchGists returns the account's gists, newest update first, plus the
+// total GitHub reports so the caller can tell a full list from a truncated
+// one.
+//
+// **Privacy is a query argument, not a filter.** Under --public-only the
+// query asks for PUBLIC and secret gists are never fetched at all, rather
+// than arriving and being dropped afterwards. For a screenshot-safe mode
+// that is the difference between data that cannot leak and data that is
+// merely not drawn.
+//
+// It also keeps the *count* honest, which filtering client-side would not.
+// Measured on a real account: ALL returns 16 with 6 secret, and PUBLIC
+// returns `totalCount: 10` — not 16. Had this fetched everything and hidden
+// the secrets, a "10 of 16" line would itself have disclosed that six secret
+// gists exist, which is the kind of leak a screenshot-safe mode is for.
+//
+// Viewing *another* account degrades on its own: GitHub returns only their
+// public gists for a PUBLIC or ALL query, with no error. Asking for SECRET
+// there is what errors — measured, and it returns `totalCount: 0` **with**
+// a GraphQL error attached, which is why this never asks for SECRET and why
+// its caller treats a failure as best-effort. A partial response carrying
+// an error is exactly the shape that would abort a shared query branch.
+func (c *Client) FetchGists(ctx context.Context) ([]Gist, int, error) {
+	privacy := githubv4.GistPrivacyAll
+	if c.publicOnly {
+		privacy = githubv4.GistPrivacyPublic
+	}
+
+	vars := map[string]interface{}{
+		"first":   githubv4.Int(gistsPageSize),
+		"privacy": privacy,
+		"order": githubv4.GistOrder{
+			Field:     githubv4.GistOrderFieldUpdatedAt,
+			Direction: githubv4.OrderDirectionDesc,
+		},
+	}
+
+	var fields gistFields
+	if c.login == "" {
+		var q struct {
+			Viewer struct {
+				Gists gistFields `graphql:"gists(first: $first, privacy: $privacy, orderBy: $order)"`
+			}
+		}
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, 0, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+		fields = q.Viewer.Gists
+	} else {
+		var q struct {
+			User struct {
+				Gists gistFields `graphql:"gists(first: $first, privacy: $privacy, orderBy: $order)"`
+			} `graphql:"user(login: $login)"`
+		}
+		vars["login"] = githubv4.String(c.login)
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, 0, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+		}
+		fields = q.User.Gists
+	}
+
+	return extractGists(fields), int(fields.TotalCount), nil
+}
+
+// extractGists is the pure half, so the mapping is testable without a
+// transport. Every string crosses Sanitize here at the extractor boundary,
+// which is where this package cleans GitHub-sourced text — a gist
+// description and a filename are both attacker-controlled by anyone who can
+// share a gist link.
+func extractGists(f gistFields) []Gist {
+	if len(f.Nodes) == 0 {
+		return nil
+	}
+	out := make([]Gist, 0, len(f.Nodes))
+	for _, n := range f.Nodes {
+		g := Gist{
+			Name:        Sanitize(string(n.Name)),
+			Description: Sanitize(string(n.Description)),
+			URL:         Sanitize(string(n.URL)),
+			IsPublic:    bool(n.IsPublic),
+			IsFork:      bool(n.IsFork),
+			Stars:       int(n.StargazerCount),
+			UpdatedAt:   n.UpdatedAt.Time,
+		}
+		for _, file := range n.Files {
+			g.Files = append(g.Files, GistFile{
+				Name:     Sanitize(string(file.Name)),
+				Language: Sanitize(string(file.Language.Name)),
+				Size:     int(file.Size),
+			})
+		}
+		out = append(out, g)
+	}
+	return out
+}

--- a/internal/github/gists.go
+++ b/internal/github/gists.go
@@ -20,6 +20,17 @@ import (
 // the scan's probes make about their own limits.
 const gistsPageSize = 100
 
+// GistFilesLimit is the cap on files fetched per gist, and it is exported
+// because the UI has to know it: `Gist.files` is a plain list, not a Relay
+// connection, so there is **no totalCount** to ask for. A gist at the cap
+// is therefore indistinguishable from one with exactly this many files
+// unless the renderer says so — which is why the row shows "20+" rather
+// than a number it cannot stand behind.
+//
+// Keep in sync with the `files(limit: 20)` tag below; TestGistFilesLimitMatchesQuery
+// fails if they drift, since a struct tag cannot interpolate a constant.
+const GistFilesLimit = 20
+
 // GistFile is one file inside a gist. Size is bytes; Language is GitHub's
 // own detection and is empty when it has none.
 type GistFile struct {

--- a/internal/github/gists_test.go
+++ b/internal/github/gists_test.go
@@ -1,0 +1,176 @@
+package github
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// newTestGQLClientCapturing is newTestGQLClient plus a copy of the request
+// body, for the cases where what we send matters as much as what comes back.
+// --public-only is exactly that: it has to change the *query*, and no
+// assertion on the decoded result can tell a filtered response from a
+// filtered request.
+func newTestGQLClientCapturing(t *testing.T, body string, sent *string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*sent = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	httpClient := &http.Client{Transport: &rewriteHost{host: srv.URL}}
+	return &Client{
+		gql:           githubv4.NewClient(httpClient),
+		rest:          httpClient,
+		authenticated: true,
+	}
+}
+
+// A response carrying an ANSI escape in the description and a C1
+// introducer in a filename — the two fields an outsider controls, since
+// anyone who can share a gist link controls both.
+//
+// Both are JSON escapes, and that is not a stylistic choice: JSON forbids
+// unescaped control characters inside a string, so encoding/json rejects a
+// raw one outright ("invalid character in string literal"). Which means
+// the escaped form is what GitHub actually puts on the wire, and the raw
+// byte only ever appears after the decoder has expanded it — exactly where
+// Sanitize is waiting for it.
+const gistsBody = `{"data":{"viewer":{"gists":{
+	"totalCount": 42,
+	"nodes":[
+		{"name":"da51e93f0bb208a6f71f",
+		 "description":"WordPress: \u001b[31mActions\u001b[0m & Filters",
+		 "url":"https://gist.github.com/gfazioli/da51e93f0bb208a6f71f",
+		 "isPublic":true,"isFork":false,"stargazerCount":5,
+		 "updatedAt":"2026-01-02T03:04:05Z",
+		 "files":[{"name":"old_version_event.js","size":812,"language":{"name":"JavaScript"}},
+		          {"name":"sam\u009fple.js","size":40,"language":{"name":""}}]},
+		{"name":"7ac536c358f737269b6b",
+		 "description":"",
+		 "url":"https://gist.github.com/gfazioli/7ac536c358f737269b6b",
+		 "isPublic":false,"isFork":true,"stargazerCount":0,
+		 "updatedAt":"2026-01-01T00:00:00Z",
+		 "files":[{"name":"about.json","size":12,"language":{"name":"JSON"}}]}
+	]}}}}`
+
+func TestFetchGists(t *testing.T) {
+	c := newTestGQLClient(t, 200, gistsBody)
+
+	gs, total, err := c.FetchGists(context.Background())
+	if err != nil {
+		t.Fatalf("FetchGists: %v", err)
+	}
+	if total != 42 {
+		t.Errorf("total = %d, want 42 — the count is what lets the tab say it is showing a window", total)
+	}
+	if len(gs) != 2 {
+		t.Fatalf("gists = %d, want 2", len(gs))
+	}
+
+	first := gs[0]
+	if first.Name != "da51e93f0bb208a6f71f" || !first.IsPublic || first.IsFork || first.Stars != 5 {
+		t.Errorf("first gist decoded wrong: %+v", first)
+	}
+	if len(first.Files) != 2 || first.Files[0].Language != "JavaScript" || first.Files[0].Size != 812 {
+		t.Errorf("files decoded wrong: %+v", first.Files)
+	}
+	if first.UpdatedAt.IsZero() {
+		t.Error("updatedAt did not decode")
+	}
+
+	// Sanitize runs at this boundary, not in the renderer: an escape
+	// sequence in a description would otherwise reach the terminal.
+	if strings.ContainsRune(first.Description, 0x1b) {
+		t.Errorf("ANSI escape survived into the description: %q", first.Description)
+	}
+	if !strings.Contains(first.Description, "Actions") {
+		t.Errorf("sanitising ate the text as well as the escape: %q", first.Description)
+	}
+	// U+009F is the 8-bit APC introducer — a C1 control, and the class
+	// added in v0.20.2 precisely because it is not an ESC.
+	if strings.ContainsRune(first.Files[1].Name, 0x9f) {
+		t.Errorf("C1 introducer survived into a filename: %q", first.Files[1].Name)
+	}
+	if !strings.Contains(first.Files[1].Name, "ple.js") {
+		t.Errorf("sanitising ate the filename: %q", first.Files[1].Name)
+	}
+
+	// The empty description is preserved rather than filled in. The
+	// display fallback is the UI's job — inventing one here would put a
+	// value into --json output that GitHub never returned.
+	if gs[1].Description != "" {
+		t.Errorf("empty description was not preserved: %q", gs[1].Description)
+	}
+	if gs[1].IsPublic || !gs[1].IsFork {
+		t.Errorf("second gist flags decoded wrong: %+v", gs[1])
+	}
+}
+
+// --public-only must change the *query*, not filter the result. Fetching
+// everything and hiding the secrets would leak their existence through the
+// count: measured live, ALL returns 16 on a real account and PUBLIC returns
+// 10 — so a "10 of 16" line would itself disclose that six secret gists
+// exist. Only the request body can prove which was asked for.
+func TestFetchGistsPublicOnlyAsksForPublic(t *testing.T) {
+	var got string
+	c := newTestGQLClientCapturing(t, `{"data":{"viewer":{"gists":{"totalCount":0,"nodes":[]}}}}`, &got)
+	c.publicOnly = true
+
+	if _, _, err := c.FetchGists(context.Background()); err != nil {
+		t.Fatalf("FetchGists: %v", err)
+	}
+	if !strings.Contains(got, `"privacy":"PUBLIC"`) {
+		t.Errorf("public-only did not ask GitHub for PUBLIC; sent: %s", got)
+	}
+	if strings.Contains(got, `"privacy":"ALL"`) {
+		t.Errorf("public-only still asked for ALL: %s", got)
+	}
+}
+
+func TestFetchGistsDefaultAsksForAll(t *testing.T) {
+	var got string
+	c := newTestGQLClientCapturing(t, `{"data":{"viewer":{"gists":{"totalCount":0,"nodes":[]}}}}`, &got)
+
+	if _, _, err := c.FetchGists(context.Background()); err != nil {
+		t.Fatalf("FetchGists: %v", err)
+	}
+	if !strings.Contains(got, `"privacy":"ALL"`) {
+		t.Errorf("default mode did not ask for ALL, so secret gists would be missing: %s", got)
+	}
+}
+
+// An account with none decodes to nothing and reports zero.
+func TestFetchGistsEmpty(t *testing.T) {
+	c := newTestGQLClient(t, 200, `{"data":{"viewer":{"gists":{"totalCount":0,"nodes":[]}}}}`)
+	gs, total, err := c.FetchGists(context.Background())
+	if err != nil {
+		t.Fatalf("FetchGists: %v", err)
+	}
+	if len(gs) != 0 || total != 0 {
+		t.Errorf("empty account decoded to %d gists / total %d", len(gs), total)
+	}
+}
+
+// The shape that makes this branch best-effort: GitHub answers a permission
+// edge with data *and* an error attached. The decode fails, so the caller
+// has to be one that can absorb it — FetchStats drops this error on purpose,
+// and this test is what says the drop is load-bearing rather than sloppy.
+func TestFetchGistsSurfacesPartialResponseAsError(t *testing.T) {
+	body := `{"data":{"user":{"gists":{"totalCount":0,"nodes":[]}}},
+	          "errors":[{"message":"You don't have permission to see gists."}]}`
+	c := newTestGQLClient(t, 200, body)
+	c.login = "someone-else"
+
+	if _, _, err := c.FetchGists(context.Background()); err == nil {
+		t.Fatal("a response carrying a GraphQL error decoded as success — " +
+			"FetchStats relies on this failing so it can swallow it")
+	}
+}

--- a/internal/github/gists_test.go
+++ b/internal/github/gists_test.go
@@ -196,3 +196,48 @@ func TestGistFilesLimitMatchesQuery(t *testing.T) {
 			"an exact number for a truncated list", tag, GistFilesLimit)
 	}
 }
+
+// The leak the fetch-side privacy choice does NOT cover.
+//
+// Starting with --public-only makes the query ask for PUBLIC, so secrets
+// never arrive. But `p` toggles the mode at *runtime*, and that is applied
+// at render time through Stats.Public with the previous refresh's data
+// still in memory — the model.go comment says so explicitly ("no refetch
+// needed"). Without stripping here, pressing p in front of an audience
+// kept every secret gist on screen, in the one mode that exists for
+// screenshots.
+func TestPublicStripsSecretGists(t *testing.T) {
+	s := &Stats{
+		Gists: []Gist{
+			{Name: "a", IsPublic: true},
+			{Name: "b", IsPublic: false},
+			{Name: "c", IsPublic: true},
+			{Name: "d", IsPublic: false},
+		},
+		GistsTotal: 16,
+	}
+
+	out := s.Public()
+	if len(out.Gists) != 2 {
+		t.Fatalf("Public() kept %d gists, want the 2 public ones: %+v", len(out.Gists), out.Gists)
+	}
+	for _, g := range out.Gists {
+		if !g.IsPublic {
+			t.Errorf("a secret gist survived screenshot mode: %q", g.Name)
+		}
+	}
+
+	// The second-order leak, and the one that is easy to miss: leaving the
+	// total at 16 while showing 2 renders "2 of 16", which discloses that
+	// fourteen secret gists exist. Exactly what asking GitHub for PUBLIC
+	// avoids on the fetch side — it must not come back through this path.
+	if out.GistsTotal != 2 {
+		t.Errorf("GistsTotal = %d, want 2 — a larger total leaks the number of secret gists", out.GistsTotal)
+	}
+
+	// The original is untouched: Public() returns a filtered copy, and the
+	// caller still holds the full set for when the mode flips back.
+	if len(s.Gists) != 4 || s.GistsTotal != 16 {
+		t.Errorf("Public() mutated its receiver: %d gists, total %d", len(s.Gists), s.GistsTotal)
+	}
+}

--- a/internal/github/gists_test.go
+++ b/internal/github/gists_test.go
@@ -2,9 +2,11 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -172,5 +174,25 @@ func TestFetchGistsSurfacesPartialResponseAsError(t *testing.T) {
 	if _, _, err := c.FetchGists(context.Background()); err == nil {
 		t.Fatal("a response carrying a GraphQL error decoded as success — " +
 			"FetchStats relies on this failing so it can swallow it")
+	}
+}
+
+// A struct tag cannot interpolate a constant, so `files(limit: 20)` and
+// GistFilesLimit are two copies of one number. The UI reads the constant to
+// decide when to render "20+", so a drift would make it lie in the quiet
+// direction — claiming an exact count for a truncated list. Raised on #123
+// by both reviewers independently.
+func TestGistFilesLimitMatchesQuery(t *testing.T) {
+	node := reflect.TypeOf(gistFields{}).Field(1).Type.Elem() // Nodes []struct{...}
+	f, ok := node.FieldByName("Files")
+	if !ok {
+		t.Fatal("gistFields node has no Files field")
+	}
+	tag := f.Tag.Get("graphql")
+	want := fmt.Sprintf("files(limit: %d)", GistFilesLimit)
+	if tag != want {
+		t.Errorf("query tag %q disagrees with GistFilesLimit (%d) — the UI reads the\n"+
+			"constant to know when the count is capped, so a drift makes it claim\n"+
+			"an exact number for a truncated list", tag, GistFilesLimit)
 	}
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -52,9 +52,33 @@ type Report struct {
 	OpenIssuesList   []Issue       `json:"open_issues_list"`
 	ReviewRequests   []PullRequest `json:"review_requests"`
 	Organizations    []Org         `json:"organizations"`
+	Gists            []Gist        `json:"gists"`
 	WatchedRepos     []Repo        `json:"watched_repos"`
 	WatchedSkipped   []string      `json:"watched_skipped"`
 	RateLimit        *RateLimit    `json:"rate_limit,omitempty"`
+}
+
+// Gist is one gist. Label is what the TUI shows on the row — the
+// description, or the first filename when there is none — so a script and
+// the dashboard agree on what a gist is *called*; Description stays exactly
+// as GitHub returned it, empty included, so a consumer can tell a titled
+// gist from an untitled one.
+//
+// FilesCapped reports that the file list hit the fetch limit, because
+// GitHub's Gist.files is a plain list with no totalCount: without this flag
+// a consumer reading len(files) would take a truncated count for a complete
+// one, which is the same trap the TUI answers with "20+".
+type Gist struct {
+	Name        string    `json:"name"`
+	Label       string    `json:"label"`
+	Description string    `json:"description"`
+	URL         string    `json:"url"`
+	Public      bool      `json:"public"`
+	Fork        bool      `json:"fork"`
+	Stars       int       `json:"stars"`
+	Files       []string  `json:"files"`
+	FilesCapped bool      `json:"files_capped"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // Profile is the identity block: who the account belongs to.
@@ -210,6 +234,7 @@ func FromStats(s *github.Stats, octoscopeVersion string, generatedAt time.Time, 
 		OpenIssuesList:   toIssues(s.OpenIssuesList),
 		ReviewRequests:   toPRs(s.ReviewRequests),
 		Organizations:    toOrgs(s.Organizations),
+		Gists:            toGists(s.Gists),
 		WatchedRepos:     toRepos(s.WatchedRepos),
 		WatchedSkipped:   nonNilStrings(s.WatchedSkipped),
 	}
@@ -299,6 +324,39 @@ func toIssues(in []github.Issue) []Issue {
 	return out
 }
 
+// toGists mirrors the TUI's display label so a script and the dashboard
+// call the same gist by the same name, while keeping the raw description
+// alongside it.
+func toGists(in []github.Gist) []Gist {
+	out := make([]Gist, 0, len(in))
+	for _, g := range in {
+		files := make([]string, 0, len(g.Files))
+		for _, f := range g.Files {
+			files = append(files, f.Name)
+		}
+		label := strings.TrimSpace(g.Description)
+		if label == "" && len(files) > 0 {
+			label = files[0]
+		}
+		if label == "" {
+			label = g.Name
+		}
+		out = append(out, Gist{
+			Name:        g.Name,
+			Label:       label,
+			Description: g.Description,
+			URL:         g.URL,
+			Public:      g.IsPublic,
+			Fork:        g.IsFork,
+			Stars:       g.Stars,
+			Files:       files,
+			FilesCapped: len(g.Files) >= github.GistFilesLimit,
+			UpdatedAt:   g.UpdatedAt,
+		})
+	}
+	return out
+}
+
 func toOrgs(in []github.Organization) []Org {
 	out := make([]Org, 0, len(in))
 	for _, o := range in {
@@ -371,6 +429,7 @@ func RenderPlain(w io.Writer, r Report) error {
 	writePRList(&b, "Open pull requests", r.OpenPullRequests)
 	writeIssueList(&b, "Open issues", r.OpenIssuesList)
 	writePRList(&b, "Review requests", r.ReviewRequests)
+	writeGistList(&b, "Gists", r.Gists)
 	writeRepoList(&b, "Watched", r.WatchedRepos)
 	if len(r.WatchedSkipped) > 0 {
 		fmt.Fprintf(&b, "\n%d watched %s skipped: %s\n",
@@ -397,6 +456,30 @@ func writeRepoList(b *strings.Builder, title string, repos []Repo) {
 	}
 	tw.Flush()
 	writeMore(b, len(repos))
+}
+
+func writeGistList(b *strings.Builder, title string, gists []Gist) {
+	if len(gists) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n%s (%d)\n", title, len(gists))
+	tw := tabwriter.NewWriter(b, 0, 0, 2, ' ', 0)
+	for _, g := range capList(gists) {
+		vis := "public"
+		if !g.Public {
+			vis = "secret"
+		}
+		// "N+" when the file list hit the fetch cap, for the same reason
+		// the TUI does it: Gist.files carries no total, so an exact count
+		// there would be a guess.
+		files := fmt.Sprintf("%d", len(g.Files))
+		if g.FilesCapped {
+			files += "+"
+		}
+		fmt.Fprintf(tw, "  %s\t%s files\t★ %d\t%s\n", vis, files, g.Stars, g.Label)
+	}
+	tw.Flush()
+	writeMore(b, len(gists))
 }
 
 func writePRList(b *strings.Builder, title string, prs []PullRequest) {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -230,3 +230,68 @@ func TestRenderPlainCapsLongLists(t *testing.T) {
 		t.Errorf("expected cap notice, got:\n%s", buf.String())
 	}
 }
+
+// The scriptable output has to carry the new tab, or --json silently
+// describes less than the TUI shows. Adding a key is additive, so no
+// SchemaVersion bump — that is the documented contract.
+func TestReportCarriesGists(t *testing.T) {
+	s := &github.Stats{
+		Gists: []github.Gist{
+			{Name: "hash1", Description: "Sample list", URL: "https://gist.github.com/u/1",
+				IsPublic: true, Stars: 5,
+				Files: []github.GistFile{{Name: "a.json"}, {Name: "b.json"}}},
+			{Name: "hash2", URL: "https://gist.github.com/u/2", IsPublic: false,
+				Files: []github.GistFile{{Name: "about.json"}}},
+		},
+	}
+	r := FromStats(s, "0.29.0", time.Now(), false)
+
+	if len(r.Gists) != 2 {
+		t.Fatalf("report carries %d gists, want 2", len(r.Gists))
+	}
+	if r.Gists[0].Label != "Sample list" {
+		t.Errorf("label = %q, want the description", r.Gists[0].Label)
+	}
+	// The untitled one must be callable by the same name the dashboard
+	// shows, or a script and the TUI disagree about what a gist is called.
+	if r.Gists[1].Label != "about.json" {
+		t.Errorf("untitled gist label = %q, want its first filename", r.Gists[1].Label)
+	}
+	if r.Gists[1].Description != "" {
+		t.Errorf("description was invented: %q", r.Gists[1].Description)
+	}
+	if r.Gists[0].FilesCapped {
+		t.Error("a two-file gist reported as capped")
+	}
+}
+
+// Every list is always an array, never null — the documented promise that
+// lets consumers iterate unconditionally.
+func TestReportGistsIsAlwaysAnArray(t *testing.T) {
+	r := FromStats(&github.Stats{}, "0.29.0", time.Now(), false)
+	if r.Gists == nil {
+		t.Error("gists is null on an account with none; consumers cannot iterate it")
+	}
+	var buf bytes.Buffer
+	if err := RenderJSON(&buf, r); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte(`"gists": []`)) {
+		t.Errorf("empty gists did not render as an array:\n%s", buf.String())
+	}
+}
+
+// A capped file list must say so, because GitHub's Gist.files has no
+// totalCount — a consumer reading len(files) would take a truncated count
+// for a complete one.
+func TestReportFlagsACappedFileList(t *testing.T) {
+	files := make([]github.GistFile, github.GistFilesLimit)
+	for i := range files {
+		files[i] = github.GistFile{Name: "f.go"}
+	}
+	r := FromStats(&github.Stats{Gists: []github.Gist{{Name: "big", Files: files}}},
+		"0.29.0", time.Now(), false)
+	if !r.Gists[0].FilesCapped {
+		t.Error("a gist at the fetch cap is not flagged, so len(files) reads as complete")
+	}
+}

--- a/internal/ui/gist_detail.go
+++ b/internal/ui/gist_detail.go
@@ -115,7 +115,11 @@ func (gd GistDetailModel) Update(msg tea.KeyMsg, client *github.Client, width, h
 		// and the error guard below swallowed the key — a hint
 		// describing an intention rather than a behaviour, which is the
 		// second time that shape has shipped in this tab.
-		if gd.err != nil || gd.loading {
+		// Only from the error state. Accepting it while a fetch is in
+		// flight would start a second 30-second request per keypress,
+		// and the view already says "Loading…" — there is nothing to
+		// retry yet.
+		if gd.err != nil {
 			gd.loading, gd.err = true, nil
 			return gd, fetchGistDetailCmd(client, gd.gist.Name), true
 		}
@@ -243,6 +247,11 @@ func (gd GistDetailModel) View(width, height int) string {
 	// First frame only: Update has not run yet, so the viewport is still
 	// empty. Syncing here fills it; on every later frame Update has
 	// already done it, and re-doing it would reset the scroll offset.
+	//
+	// A resize is therefore NOT handled here — View works on a copy, so a
+	// sync at this point could not persist anyway. The root model re-syncs
+	// on tea.WindowSizeMsg, which is where the Overview and Activity
+	// viewports are already handled for the same reason.
 	if gd.viewport.Height == 0 {
 		gd = gd.syncViewport(width, height-4)
 	}
@@ -377,4 +386,15 @@ func fetchGistDetailCmd(client *github.Client, name string) tea.Cmd {
 		detail, err := client.FetchGistDetail(ctx, name)
 		return gistDetailFetchedMsg{name: name, detail: detail, err: err}
 	}
+}
+
+// SyncSize re-fits the viewport after a terminal resize. Exported for the
+// root model's tea.WindowSizeMsg handler, which is the only place that
+// knows the new dimensions — View cannot do it, because it works on a copy
+// that is discarded before the next key arrives.
+func (gd GistDetailModel) SyncSize(width, height int) GistDetailModel {
+	if !gd.open {
+		return gd
+	}
+	return gd.syncViewport(width, height)
 }

--- a/internal/ui/gist_detail.go
+++ b/internal/ui/gist_detail.go
@@ -107,8 +107,19 @@ func (gd GistDetailModel) selectedFile() (github.GistFileContent, bool) {
 
 // Update handles keys while the drill-in is open. The bool reports whether
 // the drill-in consumed the key; false means "I closed, pass it on".
-func (gd GistDetailModel) Update(msg tea.KeyMsg, width, height int) (GistDetailModel, tea.Cmd, bool) {
+func (gd GistDetailModel) Update(msg tea.KeyMsg, client *github.Client, width, height int) (GistDetailModel, tea.Cmd, bool) {
 	switch msg.String() {
+	case "r":
+		// The error state advertises retry, so retry has to exist. It
+		// did not: the hint listed `r` while Update had no case for it
+		// and the error guard below swallowed the key — a hint
+		// describing an intention rather than a behaviour, which is the
+		// second time that shape has shipped in this tab.
+		if gd.err != nil || gd.loading {
+			gd.loading, gd.err = true, nil
+			return gd, fetchGistDetailCmd(client, gd.gist.Name), true
+		}
+
 	case "esc":
 		// One level at a time — out of the file, then out of the gist.
 		// Collapsing both would make esc unpredictable, and a one-file
@@ -168,6 +179,15 @@ func (gd GistDetailModel) Update(msg tea.KeyMsg, width, height int) (GistDetailM
 	}
 
 	// Content mode: the viewport owns scrolling.
+	//
+	// The sync has to happen HERE, on the model that is returned and
+	// stored — not in View. View takes a value receiver, so syncing there
+	// sets the dimensions and content on a copy that is discarded at the
+	// end of the frame, leaving the stored viewport 0x0 and empty. It then
+	// has nothing to scroll and the arrow keys do nothing, which is
+	// exactly how this shipped and exactly what the maintainer hit.
+	// IssueDetailModel.Update has always done it in this order.
+	gd = gd.syncViewport(width, height)
 	var cmd tea.Cmd
 	gd.viewport, cmd = gd.viewport.Update(msg)
 	return gd, cmd, true
@@ -220,7 +240,12 @@ func (gd GistDetailModel) View(width, height int) string {
 			keyHints("↑↓", "move", "enter", "open file", "o", "github", "c", "copy url", "esc", "back")
 	}
 
-	gd = gd.syncViewport(width, height-4)
+	// First frame only: Update has not run yet, so the viewport is still
+	// empty. Syncing here fills it; on every later frame Update has
+	// already done it, and re-doing it would reset the scroll offset.
+	if gd.viewport.Height == 0 {
+		gd = gd.syncViewport(width, height-4)
+	}
 	f, _ := gd.selectedFile()
 	hints := []string{"↑↓", "scroll", "c", "copy file", "o", "github", "esc", "back"}
 	if f.IsImage {

--- a/internal/ui/gist_detail.go
+++ b/internal/ui/gist_detail.go
@@ -1,0 +1,355 @@
+package ui
+
+// The Gists drill-in: the file list, and the file itself.
+//
+// Shape note, because it departs from PR detail → files → diff. A gist *is*
+// a list of files, so a "detail" level above the file list would be an
+// empty frame around one list — the two collapse into one model with two
+// modes. `esc` still backs out one level at a time and the title still
+// grows a segment per level, which is the part of the convention that
+// matters to someone using it.
+//
+// A one-file gist opens straight to its content. Most gists are one file
+// (13 of 16 on a real account), and making everyone step through a
+// single-row list to reach the only thing they came for is ceremony.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// gistDetailMode is which of the two levels is showing.
+type gistDetailMode int
+
+const (
+	gistModeFiles gistDetailMode = iota
+	gistModeContent
+)
+
+// GistDetailModel is the drill-in. Three states — loading, error, loaded —
+// because unlike the inline expansion it replaced, this one actually
+// fetches.
+type GistDetailModel struct {
+	open    bool
+	gist    github.Gist // the row that opened it, for the title while loading
+	detail  *github.GistDetail
+	err     error
+	loading bool
+
+	mode   gistDetailMode
+	cursor int // selected file, in files mode
+
+	viewport viewport.Model
+
+	// Highlighting is expensive enough to matter while scrolling, and the
+	// content never changes once fetched — so it is rendered once per
+	// (file, width) rather than per frame. Same reasoning as the markdown
+	// caches on PRDetailModel / IssueDetailModel.
+	bodyCache      string
+	bodyCacheKey   string
+	bodyCacheWidth int
+}
+
+// IsOpen reports whether the drill-in is active.
+func (gd GistDetailModel) IsOpen() bool { return gd.open }
+
+// Open returns a fresh drill-in in the loading state.
+func (gd GistDetailModel) Open(g github.Gist) GistDetailModel {
+	return GistDetailModel{
+		open:     true,
+		gist:     g,
+		loading:  true,
+		viewport: viewport.New(0, 0),
+	}
+}
+
+// Close returns the zero value, so nothing survives to the next open.
+func (gd GistDetailModel) Close() GistDetailModel { return GistDetailModel{} }
+
+// applyFetched lands the network result.
+//
+// A gist with exactly one file opens straight into it: the file list would
+// have a single row and the only useful key on it would be "enter".
+func (gd GistDetailModel) applyFetched(detail *github.GistDetail, err error) GistDetailModel {
+	gd.loading = false
+	gd.detail = detail
+	gd.err = err
+	gd.bodyCache, gd.bodyCacheKey, gd.bodyCacheWidth = "", "", 0
+	if err == nil && detail != nil && len(detail.Files) == 1 {
+		gd.mode = gistModeContent
+	}
+	return gd
+}
+
+// selectedFile is the file under the cursor, if any.
+func (gd GistDetailModel) selectedFile() (github.GistFileContent, bool) {
+	if gd.detail == nil || len(gd.detail.Files) == 0 {
+		return github.GistFileContent{}, false
+	}
+	i := gd.cursor
+	if i < 0 {
+		i = 0
+	}
+	if i >= len(gd.detail.Files) {
+		i = len(gd.detail.Files) - 1
+	}
+	return gd.detail.Files[i], true
+}
+
+// Update handles keys while the drill-in is open. The bool reports whether
+// the drill-in consumed the key; false means "I closed, pass it on".
+func (gd GistDetailModel) Update(msg tea.KeyMsg, width, height int) (GistDetailModel, tea.Cmd, bool) {
+	switch msg.String() {
+	case "esc":
+		// One level at a time — out of the file, then out of the gist.
+		// Collapsing both would make esc unpredictable, and a one-file
+		// gist has no file list to fall back to anyway.
+		if gd.mode == gistModeContent && gd.detail != nil && len(gd.detail.Files) > 1 {
+			gd.mode = gistModeFiles
+			gd.viewport.SetYOffset(0)
+			return gd, nil, true
+		}
+		return gd.Close(), nil, true
+
+	case "o":
+		if gd.detail != nil {
+			return gd, openURLCmd(gd.detail.URL), true
+		}
+		return gd, openURLCmd(gd.gist.URL), true
+
+	case "c":
+		// The whole reason this view exists: inside a file, `c` copies the
+		// **code**, not the link. On the file list there is no single body
+		// to take, so it falls back to the gist's URL — the same thing the
+		// list tab's `c` does.
+		if gd.mode == gistModeContent {
+			if f, ok := gd.selectedFile(); ok && !f.IsImage {
+				return gd, copyTextCmd(f.Text, f.Name), true
+			}
+		}
+		if gd.detail != nil {
+			return gd, copyURLCmd(gd.detail.URL), true
+		}
+		return gd, copyURLCmd(gd.gist.URL), true
+	}
+
+	if gd.loading || gd.err != nil || gd.detail == nil {
+		return gd, nil, true
+	}
+
+	if gd.mode == gistModeFiles {
+		switch msg.String() {
+		case "up", "k":
+			if gd.cursor > 0 {
+				gd.cursor--
+			}
+		case "down", "j":
+			if gd.cursor < len(gd.detail.Files)-1 {
+				gd.cursor++
+			}
+		case "home", "g":
+			gd.cursor = 0
+		case "end", "G":
+			gd.cursor = len(gd.detail.Files) - 1
+		case "enter", "d":
+			gd.mode = gistModeContent
+			gd.viewport.SetYOffset(0)
+		}
+		return gd, nil, true
+	}
+
+	// Content mode: the viewport owns scrolling.
+	var cmd tea.Cmd
+	gd.viewport, cmd = gd.viewport.Update(msg)
+	return gd, cmd, true
+}
+
+// syncViewport refreshes the content and dimensions, rendering the body at
+// most once per (file, width).
+func (gd GistDetailModel) syncViewport(width, height int) GistDetailModel {
+	if gd.loading || gd.err != nil || gd.detail == nil || gd.mode != gistModeContent {
+		return gd
+	}
+	f, ok := gd.selectedFile()
+	if !ok {
+		return gd
+	}
+	if gd.bodyCache == "" || gd.bodyCacheKey != f.Name || gd.bodyCacheWidth != width {
+		gd.bodyCache = renderGistFileBody(f, width)
+		gd.bodyCacheKey = f.Name
+		gd.bodyCacheWidth = width
+	}
+	gd.viewport.Width = width
+	gd.viewport.Height = height
+	gd.viewport.SetContent(gd.bodyCache)
+	return gd
+}
+
+// View paints the drill-in.
+func (gd GistDetailModel) View(width, height int) string {
+	title := gd.renderTitle()
+
+	switch {
+	case gd.loading:
+		return title + "\n\n" + mutedStyle.Render("Loading…")
+	case gd.err != nil:
+		return title + "\n\n" +
+			errorStyle.Render("Could not load this gist.") + "\n" +
+			mutedStyle.Render(gd.err.Error()) + "\n\n" +
+			keyHints("r", "retry", "esc", "back")
+	case gd.detail == nil:
+		return title + "\n\n" + mutedStyle.Render("(nothing to show)")
+	}
+
+	if len(gd.detail.Files) == 0 {
+		return title + "\n\n" + mutedStyle.Render("(this gist has no files)") +
+			"\n\n" + keyHints("o", "github", "esc", "back")
+	}
+
+	if gd.mode == gistModeFiles {
+		return title + "\n\n" + gd.renderFileList() + "\n\n" +
+			keyHints("↑↓", "move", "enter", "open file", "o", "github", "c", "copy url", "esc", "back")
+	}
+
+	gd = gd.syncViewport(width, height-4)
+	f, _ := gd.selectedFile()
+	hints := []string{"↑↓", "scroll", "c", "copy file", "o", "github", "esc", "back"}
+	if f.IsImage {
+		hints = []string{"o", "github", "esc", "back"}
+	}
+	return title + "\n\n" + gd.viewport.View() + "\n" + keyHints(hints...)
+}
+
+// renderTitle grows a segment per level, so the breadcrumb says where you
+// are and the hints never advertise a level you are already inside.
+func (gd GistDetailModel) renderTitle() string {
+	label := gistLabel(gd.gist)
+	crumb := "▸ Gists / " + label
+	if gd.mode == gistModeContent {
+		if f, ok := gd.selectedFile(); ok {
+			crumb += " / " + f.Name
+		}
+	}
+	vis := ""
+	if gd.detail != nil && !gd.detail.IsPublic {
+		vis = mutedStyle.Render("  secret")
+	}
+	return sectionTitleStyle.Render(crumb) + vis
+}
+
+func (gd GistDetailModel) renderFileList() string {
+	var b strings.Builder
+	for i, f := range gd.detail.Files {
+		marker := "  "
+		name := f.Name
+		if i == gd.cursor {
+			marker = activeTabStyle.Render("▸ ")
+			name = boldStyle.Foreground(colAccent).Render(name)
+		}
+		lang := f.Language
+		if lang == "" {
+			lang = "—"
+		}
+		meta := fmt.Sprintf("  %s  %s", lang, humanBytes(f.Size))
+		if f.IsImage {
+			meta += "  (binary)"
+		} else if f.IsTruncated {
+			meta += "  (truncated by GitHub)"
+		}
+		b.WriteString(marker + name + mutedStyle.Render(meta))
+		if i < len(gd.detail.Files)-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// renderGistFileBody is the file itself: syntax-highlighted where that
+// makes sense, and honestly refused where it does not.
+func renderGistFileBody(f github.GistFileContent, width int) string {
+	if f.IsImage {
+		return mutedStyle.Render(
+			"This file is binary, so there is nothing readable to show here.\n" +
+				"Press o to open the gist on GitHub.")
+	}
+
+	body := f.Text
+	if strings.TrimSpace(body) == "" {
+		return mutedStyle.Render("(empty file)")
+	}
+
+	out := body
+	if !IsMonochromatic() {
+		// A monochromatic theme promises a single tonal palette, and
+		// chroma's output is full of external semantic colour — so under
+		// those themes the file is shown plain rather than breaking the
+		// promise. Same rule the language bars and the CI dot follow.
+		if hi, err := highlightGistFile(f.Name, body); err == nil {
+			out = hi
+		}
+	}
+
+	if f.IsTruncated {
+		// GitHub cut the file, so say so rather than let the last line look
+		// like the end of the code.
+		out += "\n\n" + warnStyle.Render(
+			"— GitHub truncated this file, so the rest is not shown. Press o for the full gist.")
+	}
+	return out
+}
+
+// highlightGistFile picks a lexer from the filename, which is what a gist
+// actually gives us to go on — the language name GitHub reports is a
+// display string, while chroma matches on extension.
+func highlightGistFile(filename, body string) (string, error) {
+	lexer := lexers.Match(filename)
+	if lexer == nil {
+		lexer = lexers.Analyse(body)
+	}
+	if lexer == nil {
+		lexer = lexers.Fallback
+	}
+	formatter := formatters.Get("terminal256")
+	if formatter == nil {
+		formatter = formatters.Fallback
+	}
+	iter, err := lexer.Tokenise(nil, body)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, diffStyle(), iter); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// gistDetailFetchedMsg carries the drill-in fetch back to the root model.
+// The gist's hash is the correlation key: it is unique, it is already on
+// the row, and a late response for a gist the user has navigated away from
+// has to be dropped rather than painted over the current one.
+type gistDetailFetchedMsg struct {
+	name   string
+	detail *github.GistDetail
+	err    error
+}
+
+// fetchGistDetailCmd pulls one gist's file contents. 30s, the same budget
+// the other drill-ins use.
+func fetchGistDetailCmd(client *github.Client, name string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		detail, err := client.FetchGistDetail(ctx, name)
+		return gistDetailFetchedMsg{name: name, detail: detail, err: err}
+	}
+}

--- a/internal/ui/gist_detail_test.go
+++ b/internal/ui/gist_detail_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -50,7 +51,7 @@ func TestGistDetailCopiesTheFileBodyNotTheURL(t *testing.T) {
 	const body = "package main\n\nfunc main() {}\n"
 	gd := openDetail(github.GistFileContent{Name: "a.go", Text: body, Language: "Go"})
 
-	got, cmd, consumed := gd.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, 80, 24)
+	got, cmd, consumed := gd.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, nil, 80, 24)
 	if !consumed || cmd == nil {
 		t.Fatal("c produced no command in content mode")
 	}
@@ -74,7 +75,7 @@ func TestGistDetailCopiesTheURLFromTheFileList(t *testing.T) {
 		github.GistFileContent{Name: "a.go", Text: "x"},
 		github.GistFileContent{Name: "b.go", Text: "y"},
 	)
-	_, cmd, _ := gd.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, 80, 24)
+	_, cmd, _ := gd.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, nil, 80, 24)
 	if cmd == nil {
 		t.Fatal("c produced no command on the file list")
 	}
@@ -94,17 +95,17 @@ func TestGistDetailEscBacksOutOneLevel(t *testing.T) {
 	)
 	multi.mode = gistModeContent
 
-	back, _, _ := multi.Update(tea.KeyMsg{Type: tea.KeyEsc}, 80, 24)
+	back, _, _ := multi.Update(tea.KeyMsg{Type: tea.KeyEsc}, nil, 80, 24)
 	if !back.IsOpen() || back.mode != gistModeFiles {
 		t.Error("esc in a multi-file gist should return to the file list, not close")
 	}
-	closed, _, _ := back.Update(tea.KeyMsg{Type: tea.KeyEsc}, 80, 24)
+	closed, _, _ := back.Update(tea.KeyMsg{Type: tea.KeyEsc}, nil, 80, 24)
 	if closed.IsOpen() {
 		t.Error("a second esc should close the drill-in")
 	}
 
 	single := openDetail(github.GistFileContent{Name: "a.go", Text: "x"})
-	out, _, _ := single.Update(tea.KeyMsg{Type: tea.KeyEsc}, 80, 24)
+	out, _, _ := single.Update(tea.KeyMsg{Type: tea.KeyEsc}, nil, 80, 24)
 	if out.IsOpen() {
 		t.Error("a one-file gist has no list to go back to; esc should close it")
 	}
@@ -170,5 +171,93 @@ func TestGistDetailStates(t *testing.T) {
 	}
 	if !strings.Contains(out, "esc") {
 		t.Errorf("the error state offers no way out:\n%s", out)
+	}
+}
+
+// Scrolling has to work, and the way it broke is worth pinning: the
+// viewport sync ran in View, which takes a value receiver — so the
+// dimensions and content landed on a copy that was discarded at the end of
+// the frame, leaving the stored viewport 0x0 and empty. Update then had
+// nothing to scroll and the arrow keys did nothing.
+//
+// Asserting on the model Update returns is what catches that; asserting on
+// View's output would have passed, because View re-synced its own copy
+// every frame and looked perfectly correct.
+func TestGistDetailContentScrolls(t *testing.T) {
+	var body strings.Builder
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&body, "line %03d\n", i)
+	}
+	gd := openDetail(github.GistFileContent{Name: "long.txt", Text: body.String()})
+
+	// A key press has to leave the STORED model with a usable viewport.
+	gd, _, _ = gd.Update(tea.KeyMsg{Type: tea.KeyDown}, nil, 80, 20)
+	if gd.viewport.Height == 0 {
+		t.Fatal("the stored viewport has no height, so nothing can scroll — " +
+			"the sync landed on a discarded copy")
+	}
+	if gd.viewport.YOffset == 0 {
+		t.Error("down did not move the viewport")
+	}
+
+	before := gd.viewport.YOffset
+	gd, _, _ = gd.Update(tea.KeyMsg{Type: tea.KeyPgDown}, nil, 80, 20)
+	if gd.viewport.YOffset <= before {
+		t.Errorf("page-down did not advance: %d -> %d", before, gd.viewport.YOffset)
+	}
+
+	gd, _, _ = gd.Update(tea.KeyMsg{Type: tea.KeyUp}, nil, 80, 20)
+	if gd.viewport.YOffset >= gd.viewport.Height*2 && gd.viewport.YOffset == before {
+		t.Error("up did not move the viewport back")
+	}
+
+	// And the render must not reset the position it just reached.
+	pos := gd.viewport.YOffset
+	_ = gd.View(80, 24)
+	if gd.viewport.YOffset != pos {
+		t.Errorf("View moved the scroll offset from %d to %d", pos, gd.viewport.YOffset)
+	}
+}
+
+// Two drill-ins must never be open at once, and the orders that decide
+// which one wins must agree.
+//
+// They did not: View painted gistDetail before issueDetail while the key
+// router reached issueDetail first, so with both open the keystrokes went
+// to a view nobody could see. And none of the four competing open handlers
+// closed gistDetail, so a delayed message could produce exactly that pair.
+func TestOnlyOneDrillInIsEverOpen(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token-not-used")
+	client, err := github.New("octocat", github.Options{})
+	if err != nil {
+		t.Fatalf("github.New: %v", err)
+	}
+	m := NewModel(client, "0.29.0", Options{})
+
+	// Open the gist drill-in, then let a competing open arrive late.
+	updated, _ := m.Update(viewGistDetailMsg{gist: github.Gist{Name: "h", Description: "d"}})
+	m = updated.(Model)
+	if !m.gistDetail.IsOpen() {
+		t.Fatal("the gist drill-in did not open")
+	}
+
+	updated, _ = m.Update(viewIssueDetailMsg{issue: github.Issue{
+		Number: 1, URL: "https://github.com/o/r/issues/1",
+	}})
+	m = updated.(Model)
+	if m.gistDetail.IsOpen() {
+		t.Error("opening the issue drill-in left the gist one open — " +
+			"View would paint the gist while Update fed the issue")
+	}
+
+	// And the reverse: a gist open must close whatever was there.
+	updated, _ = m.Update(viewIssueDetailMsg{issue: github.Issue{
+		Number: 2, URL: "https://github.com/o/r/issues/2",
+	}})
+	m = updated.(Model)
+	updated, _ = m.Update(viewGistDetailMsg{gist: github.Gist{Name: "h2"}})
+	m = updated.(Model)
+	if m.issueDetail.IsOpen() {
+		t.Error("opening the gist drill-in left the issue one open")
 	}
 }

--- a/internal/ui/gist_detail_test.go
+++ b/internal/ui/gist_detail_test.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+func detail(files ...github.GistFileContent) *github.GistDetail {
+	return &github.GistDetail{
+		Name:        "hash1",
+		Description: "settings sync",
+		URL:         "https://gist.github.com/u/hash1",
+		IsPublic:    false,
+		Files:       files,
+	}
+}
+
+func openDetail(files ...github.GistFileContent) GistDetailModel {
+	gd := GistDetailModel{}.Open(github.Gist{Name: "hash1", Description: "settings sync"})
+	return gd.applyFetched(detail(files...), nil)
+}
+
+// A gist with one file opens straight into it. Most gists are one file, and
+// making everyone step through a single-row list to reach the only thing
+// they came for is ceremony.
+func TestGistDetailSkipsTheFileListForASingleFile(t *testing.T) {
+	gd := openDetail(github.GistFileContent{Name: "a.go", Text: "package main", Language: "Go"})
+	if gd.mode != gistModeContent {
+		t.Error("a one-file gist did not open straight into its content")
+	}
+
+	multi := openDetail(
+		github.GistFileContent{Name: "a.go", Text: "x"},
+		github.GistFileContent{Name: "b.go", Text: "y"},
+	)
+	if multi.mode != gistModeFiles {
+		t.Error("a multi-file gist should land on the file list first")
+	}
+}
+
+// The whole reason this view exists: inside a file, `c` takes the code.
+// Copying the URL there would leave the user exactly where the first cut of
+// this tab left them — with a link to something they still cannot read.
+func TestGistDetailCopiesTheFileBodyNotTheURL(t *testing.T) {
+	const body = "package main\n\nfunc main() {}\n"
+	gd := openDetail(github.GistFileContent{Name: "a.go", Text: body, Language: "Go"})
+
+	got, cmd, consumed := gd.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, 80, 24)
+	if !consumed || cmd == nil {
+		t.Fatal("c produced no command in content mode")
+	}
+	_ = got
+
+	msg := cmd()
+	copied, ok := msg.(urlCopiedMsg)
+	if !ok {
+		t.Fatalf("unexpected message type %T", msg)
+	}
+	if copied.noun != "a.go" {
+		t.Errorf("toast says %q; it should name the file that was copied", copied.noun)
+	}
+}
+
+// On the file list there is no single body to take, so `c` falls back to
+// the gist's URL — the same thing the list tab's `c` does, rather than
+// silently copying whichever file happens to be under the cursor.
+func TestGistDetailCopiesTheURLFromTheFileList(t *testing.T) {
+	gd := openDetail(
+		github.GistFileContent{Name: "a.go", Text: "x"},
+		github.GistFileContent{Name: "b.go", Text: "y"},
+	)
+	_, cmd, _ := gd.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, 80, 24)
+	if cmd == nil {
+		t.Fatal("c produced no command on the file list")
+	}
+	copied := cmd().(urlCopiedMsg)
+	if copied.noun != "URL" {
+		t.Errorf("file-list c copied %q, want the URL", copied.noun)
+	}
+}
+
+// esc backs out one level at a time. Collapsing both would make it
+// unpredictable — and a one-file gist has no list to fall back to, so it
+// closes in one press.
+func TestGistDetailEscBacksOutOneLevel(t *testing.T) {
+	multi := openDetail(
+		github.GistFileContent{Name: "a.go", Text: "x"},
+		github.GistFileContent{Name: "b.go", Text: "y"},
+	)
+	multi.mode = gistModeContent
+
+	back, _, _ := multi.Update(tea.KeyMsg{Type: tea.KeyEsc}, 80, 24)
+	if !back.IsOpen() || back.mode != gistModeFiles {
+		t.Error("esc in a multi-file gist should return to the file list, not close")
+	}
+	closed, _, _ := back.Update(tea.KeyMsg{Type: tea.KeyEsc}, 80, 24)
+	if closed.IsOpen() {
+		t.Error("a second esc should close the drill-in")
+	}
+
+	single := openDetail(github.GistFileContent{Name: "a.go", Text: "x"})
+	out, _, _ := single.Update(tea.KeyMsg{Type: tea.KeyEsc}, 80, 24)
+	if out.IsOpen() {
+		t.Error("a one-file gist has no list to go back to; esc should close it")
+	}
+}
+
+// Binary and truncated files are declined rather than rendered. Neither can
+// be inferred from the size, which is why they arrive as flags.
+func TestGistDetailDeclinesBinaryAndFlagsTruncation(t *testing.T) {
+	img := renderGistFileBody(github.GistFileContent{Name: "logo.png", IsImage: true}, 80)
+	if !strings.Contains(ansi.Strip(img), "binary") {
+		t.Errorf("a binary file was not declined:\n%s", img)
+	}
+
+	cut := renderGistFileBody(github.GistFileContent{
+		Name: "big.txt", Text: "some content", IsTruncated: true,
+	}, 80)
+	if !strings.Contains(ansi.Strip(cut), "truncated") {
+		t.Errorf("a truncated file did not say so, so its last line reads as the end:\n%s", cut)
+	}
+
+	empty := renderGistFileBody(github.GistFileContent{Name: "e.txt", Text: "   "}, 80)
+	if !strings.Contains(ansi.Strip(empty), "empty file") {
+		t.Errorf("an empty file rendered as blank space:\n%s", empty)
+	}
+}
+
+// The breadcrumb grows a segment per level, so the title says where you are
+// rather than only which gist you are in.
+func TestGistDetailTitleGrowsPerLevel(t *testing.T) {
+	gd := openDetail(
+		github.GistFileContent{Name: "cloudSettings", Text: "x"},
+		github.GistFileContent{Name: "extensions.json", Text: "y"},
+	)
+	list := ansi.Strip(gd.renderTitle())
+	if !strings.Contains(list, "Gists / settings sync") || strings.Contains(list, "cloudSettings") {
+		t.Errorf("file-list title should stop at the gist: %q", list)
+	}
+
+	gd.mode = gistModeContent
+	content := ansi.Strip(gd.renderTitle())
+	if !strings.Contains(content, "settings sync / cloudSettings") {
+		t.Errorf("content title should name the file too: %q", content)
+	}
+	// A secret gist says so here, since the row that said it is no longer
+	// on screen.
+	if !strings.Contains(content, "secret") {
+		t.Errorf("a secret gist does not disclose that in the drill-in: %q", content)
+	}
+}
+
+// The loading and error states exist because this one fetches — the state
+// the inline expansion it replaced never needed.
+func TestGistDetailStates(t *testing.T) {
+	loading := GistDetailModel{}.Open(github.Gist{Name: "h", Description: "d"})
+	if !strings.Contains(ansi.Strip(loading.View(80, 24)), "Loading") {
+		t.Error("the loading state does not say so")
+	}
+
+	failed := loading.applyFetched(nil, context.DeadlineExceeded)
+	out := ansi.Strip(failed.View(80, 24))
+	if !strings.Contains(out, "Could not load") {
+		t.Errorf("the error state does not explain itself:\n%s", out)
+	}
+	if !strings.Contains(out, "esc") {
+		t.Errorf("the error state offers no way out:\n%s", out)
+	}
+}

--- a/internal/ui/gist_detail_test.go
+++ b/internal/ui/gist_detail_test.go
@@ -206,16 +206,60 @@ func TestGistDetailContentScrolls(t *testing.T) {
 		t.Errorf("page-down did not advance: %d -> %d", before, gd.viewport.YOffset)
 	}
 
+	// Compare against the offset AFTER the page-down, not the one from
+	// before it — otherwise a no-op Up passes on the strength of the
+	// page-down's movement. Caught by CodeRabbit, in a test written
+	// specifically to catch a bug of that shape.
+	afterPage := gd.viewport.YOffset
 	gd, _, _ = gd.Update(tea.KeyMsg{Type: tea.KeyUp}, nil, 80, 20)
-	if gd.viewport.YOffset >= gd.viewport.Height*2 && gd.viewport.YOffset == before {
-		t.Error("up did not move the viewport back")
+	if gd.viewport.YOffset >= afterPage {
+		t.Errorf("up did not move the viewport back: %d -> %d", afterPage, gd.viewport.YOffset)
 	}
 
-	// And the render must not reset the position it just reached.
-	pos := gd.viewport.YOffset
-	_ = gd.View(80, 24)
-	if gd.viewport.YOffset != pos {
-		t.Errorf("View moved the scroll offset from %d to %d", pos, gd.viewport.YOffset)
+	// The render must show the scrolled position, not the top. Asserting
+	// that View leaves YOffset alone would be inert: View has a value
+	// receiver, so the caller's copy cannot change either way.
+	out := ansi.Strip(gd.View(80, 24))
+	if strings.Contains(out, "line 000") {
+		t.Errorf("the render fell back to the first line despite a scroll offset of %d:\n%s",
+			gd.viewport.YOffset, out)
+	}
+}
+
+// Retry must not stack requests: each press while a fetch is in flight
+// would start another 30-second GraphQL call, and there is nothing to
+// retry yet — the view already says it is loading.
+func TestGistDetailRetryOnlyFromTheErrorState(t *testing.T) {
+	loading := GistDetailModel{}.Open(github.Gist{Name: "h"})
+	_, cmd, _ := loading.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}, nil, 80, 24)
+	if cmd != nil {
+		t.Error("r during a fetch started a second one")
+	}
+
+	failed := loading.applyFetched(nil, context.DeadlineExceeded)
+	got, cmd, _ := failed.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}, nil, 80, 24)
+	if cmd == nil {
+		t.Error("r from the error state did not refetch")
+	}
+	if !got.loading || got.err != nil {
+		t.Errorf("retry did not return to the loading state: loading=%v err=%v", got.loading, got.err)
+	}
+}
+
+// A resize has to reach the viewport. View works on a copy, so it cannot
+// persist one — the root model re-syncs on tea.WindowSizeMsg, the same way
+// it already does for the Overview and Activity viewports.
+func TestGistDetailRefitsOnResize(t *testing.T) {
+	gd := openDetail(github.GistFileContent{Name: "a.txt", Text: strings.Repeat("x\n", 200)})
+	gd, _, _ = gd.Update(tea.KeyMsg{Type: tea.KeyDown}, nil, 80, 20)
+	first := gd.viewport.Height
+
+	gd = gd.SyncSize(120, 40)
+	if gd.viewport.Height == first {
+		t.Errorf("the viewport kept its old height (%d) through a resize", first)
+	}
+	if gd.viewport.Width != 120 {
+		t.Errorf("width = %d, want 120", gd.viewport.Width)
 	}
 }
 

--- a/internal/ui/gists.go
+++ b/internal/ui/gists.go
@@ -136,6 +136,7 @@ func (gm GistsModel) Update(msg tea.Msg, stats *github.Stats) (GistsModel, tea.C
 		gm.cursor, gm.expanded = 0, false
 	case "/":
 		gm.searchActive = true
+		gm.expanded = false
 	case "enter", "d":
 		if n == 0 || gm.cursor >= n {
 			return gm, nil
@@ -184,6 +185,10 @@ func (gm GistsModel) updateSearch(km tea.KeyMsg) GistsModel {
 		gm.query += sanitizeFilterInput(string(km.Runes))
 		gm.cursor = 0
 	}
+	// Any of the above can move the cursor onto a different gist, and an
+	// expansion that survives that is showing one gist's files under
+	// another's name — nobody asked for it and it looks like a bug.
+	gm.expanded = false
 	return gm
 }
 
@@ -267,24 +272,48 @@ func (gm GistsModel) renderGistsTab(stats *github.Stats, available, availableHei
 		cursor = 0
 	}
 
-	overhead := 6
+	// Chrome is measured, not estimated: the tab always renders a title
+	// line, the blank around the table, the table's own header and rule, a
+	// trailing blank and the hint line — eight rows before a single gist.
+	// An earlier guess of six is what let a tall expansion push the pinned
+	// footer off a short terminal.
+	const gistsChrome = 8
+	chrome := gistsChrome
 	if gm.searchActive || gm.query != "" {
-		overhead++
+		chrome++
 	}
-	expandedRows := 0
-	if gm.expanded {
-		expandedRows = len(rows[cursor].Files) + 1
-		overhead += expandedRows
+
+	content := availableHeight
+	if content > 0 {
+		content -= chrome
+		if content < 4 {
+			content = 4
+		}
 	}
+
+	// When the expansion is open the two compete for the same rows, so
+	// they split the budget rather than the expansion taking whatever it
+	// wants and the list absorbing the overflow.
+	listBudget, expandedFiles := content, 0
+	if gm.expanded && availableHeight > 0 {
+		expandedFiles = content/2 - 1
+		if expandedFiles < 1 {
+			expandedFiles = 1
+		}
+		if n := len(rows[cursor].Files); expandedFiles > n {
+			expandedFiles = n
+		}
+		listBudget = content - expandedFiles - 1
+		if listBudget < 1 {
+			listBudget = 1
+		}
+	} else if gm.expanded {
+		expandedFiles = len(rows[cursor].Files)
+	}
+
 	rowsVisible := len(rows)
-	if availableHeight > 0 {
-		rowsVisible = availableHeight - overhead
-		if rowsVisible < 3 {
-			rowsVisible = 3
-		}
-		if rowsVisible > len(rows) {
-			rowsVisible = len(rows)
-		}
+	if availableHeight > 0 && listBudget < rowsVisible {
+		rowsVisible = listBudget
 	}
 
 	offset := 0
@@ -317,7 +346,7 @@ func (gm GistsModel) renderGistsTab(stats *github.Stats, available, availableHei
 	parts = append(parts, "", renderGistsTable(rows[offset:end], cursor-offset, gm.sort))
 
 	if gm.expanded {
-		parts = append(parts, "", renderGistFiles(rows[cursor]))
+		parts = append(parts, "", renderGistFiles(rows[cursor], expandedFiles))
 	}
 
 	parts = append(parts, "", keyHints(
@@ -341,9 +370,16 @@ func (gm GistsModel) renderHeaderLine(visible, fetched, total int, offset, end i
 	if visible != 1 {
 		countLabel = fmt.Sprintf("%d gists", visible)
 	}
-	if gm.query != "" && visible != fetched {
+	// A filter and a truncated fetch are independent facts, and the two
+	// used to be an if/else — so filtering a truncated list silently
+	// dropped the truncation notice, which is the one of the two the
+	// reader cannot otherwise discover.
+	switch {
+	case gm.query != "" && visible != fetched && total > fetched:
+		countLabel = fmt.Sprintf("%d of %d matched, from %d fetched of %d", visible, fetched, fetched, total)
+	case gm.query != "" && visible != fetched:
 		countLabel = fmt.Sprintf("%d of %d gists", visible, fetched)
-	} else if total > fetched {
+	case total > fetched:
 		countLabel = fmt.Sprintf("%d of %d gists", fetched, total)
 	}
 
@@ -408,7 +444,14 @@ func renderGistsTable(gists []github.Gist, cursorRow int, sortMode GistsSort) st
 		if active {
 			name = boldStyle.Foreground(colAccent).Render(name)
 		}
-		files := padRight(fmt.Sprintf("%d", len(g.Files)), filesW)
+		// At the fetch cap the true count is unknowable — GitHub's
+		// Gist.files is a plain list with no totalCount — so say "20+"
+		// instead of printing a number that is probably wrong.
+		fileCount := fmt.Sprintf("%d", len(g.Files))
+		if len(g.Files) >= github.GistFilesLimit {
+			fileCount = fmt.Sprintf("%d+", github.GistFilesLimit)
+		}
+		files := padRight(fileCount, filesW)
 		stars := padRight(fmt.Sprintf("%d", g.Stars), starsW)
 		updated := padRight(formatRelativeAgo(g.UpdatedAt), updatedW)
 
@@ -426,13 +469,27 @@ func renderGistsTable(gists []github.Gist, cursorRow int, sortMode GistsSort) st
 
 // renderGistFiles is the expanded view: the files already carried by the
 // row, so opening it costs nothing and cannot fail.
-func renderGistFiles(g github.Gist) string {
+func renderGistFiles(g github.Gist, max int) string {
 	if len(g.Files) == 0 {
 		return mutedStyle.Render("  (no files)")
 	}
+	shown := g.Files
+	if max > 0 && max < len(shown) {
+		shown = shown[:max]
+	}
 	var b strings.Builder
-	b.WriteString(mutedStyle.Render("  files in ") + valueStyle.Render(gistLabel(g)))
-	for _, f := range g.Files {
+	header := "  files in " + gistLabel(g)
+	switch {
+	case len(shown) < len(g.Files):
+		// Cut by the terminal, not by the fetch — a different limit from
+		// GistFilesLimit and worth wording differently, so the reader can
+		// tell "your window is short" from "GitHub gave us no more".
+		header = fmt.Sprintf("  %d of %d files in %s", len(shown), len(g.Files), gistLabel(g))
+	case len(g.Files) >= github.GistFilesLimit:
+		header = fmt.Sprintf("  first %d files in %s", github.GistFilesLimit, gistLabel(g))
+	}
+	b.WriteString(mutedStyle.Render(header))
+	for _, f := range shown {
 		lang := f.Language
 		if lang == "" {
 			lang = "—"
@@ -448,9 +505,9 @@ func renderGistFiles(g github.Gist) string {
 func humanBytes(n int) string {
 	switch {
 	case n >= 1<<20:
-		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+		return fmt.Sprintf("%.1f MiB", float64(n)/(1<<20))
 	case n >= 1<<10:
-		return fmt.Sprintf("%.1f kB", float64(n)/(1<<10))
+		return fmt.Sprintf("%.1f KiB", float64(n)/(1<<10))
 	default:
 		return fmt.Sprintf("%d B", n)
 	}

--- a/internal/ui/gists.go
+++ b/internal/ui/gists.go
@@ -268,8 +268,15 @@ func (gm GistsModel) renderGistsTab(stats *github.Stats, available, availableHei
 	rowsVisible := len(rows)
 	if availableHeight > 0 {
 		rowsVisible = availableHeight - chrome
-		if rowsVisible < 3 {
+		// Three rows is the floor the other list tabs use, but a floor
+		// that does not fit is not a floor — on a very short terminal it
+		// pushes the pinned footer off screen, which is the thing the
+		// budget exists to prevent. Enforce it only when there is room.
+		if rowsVisible < 3 && availableHeight-chrome >= 3 {
 			rowsVisible = 3
+		}
+		if rowsVisible < 1 {
+			rowsVisible = 1
 		}
 		if rowsVisible > len(rows) {
 			rowsVisible = len(rows)

--- a/internal/ui/gists.go
+++ b/internal/ui/gists.go
@@ -1,0 +1,457 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// GistsSort controls the ordering of the Gists-tab list. Same shape as
+// IssuesSort — three modes, cycled with `s`.
+type GistsSort int
+
+const (
+	GistsSortUpdated GistsSort = iota
+	GistsSortStars
+	GistsSortName
+)
+
+var gistsSortLabels = [...]string{
+	GistsSortUpdated: "updated",
+	GistsSortStars:   "stars",
+	GistsSortName:    "name",
+}
+
+var gistsSortChevron = [...]string{
+	GistsSortUpdated: "↓",
+	GistsSortStars:   "↓",
+	GistsSortName:    "↑",
+}
+
+// GistsModel is the Gists-tab sub-state: cursor, sort cycle, search
+// filter, input mode. No pinned section — gists have no equivalent of a
+// repo you keep at the top, and the sticky-partition machinery is only
+// worth its complexity where there is something to stick.
+type GistsModel struct {
+	cursor       int
+	sort         GistsSort
+	query        string
+	searchActive bool
+	// expanded shows the selected gist's files inline. Deliberately not
+	// a drill-in sub-model: the canonical pattern has loading / error /
+	// loaded states because it fetches, and there is nothing to fetch
+	// here — the file list already arrived with the row. Inventing a
+	// loading state for data in hand would be theatre.
+	expanded bool
+}
+
+// IsInputMode reports whether the sub-model is absorbing keystrokes as
+// text (for the search box).
+func (gm GistsModel) IsInputMode() bool {
+	return gm.searchActive
+}
+
+// gistLabel is what the list shows for a gist.
+//
+// GitHub's `name` is the hash, so the description is the only
+// human-readable handle — and it is routinely empty (2 of 16 on a real
+// account). The fallback walks to the first filename, which is what the
+// web UI titles an untitled gist with too, and only then to the hash.
+// The github package deliberately leaves Description empty rather than
+// filling it in, because that would put a value into --json output that
+// GitHub never returned; choosing a display string is this layer's job.
+func gistLabel(g github.Gist) string {
+	if s := strings.TrimSpace(g.Description); s != "" {
+		return s
+	}
+	if len(g.Files) > 0 && g.Files[0].Name != "" {
+		return g.Files[0].Name
+	}
+	return g.Name
+}
+
+// selectedGist returns the gist at the cursor inside the
+// sorted-filtered view, so the action menu never reimplements the row
+// pipeline.
+func (gm GistsModel) selectedGist(stats *github.Stats) (github.Gist, bool) {
+	if stats == nil {
+		return github.Gist{}, false
+	}
+	rows := visibleGists(stats.Gists, gm.query, gm.sort)
+	if len(rows) == 0 {
+		return github.Gist{}, false
+	}
+	idx := gm.cursor
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(rows) {
+		idx = len(rows) - 1
+	}
+	return rows[idx], true
+}
+
+// Update handles key events routed from the root model when the Gists
+// tab is active. Row count and ordering come from the same pipeline the
+// renderer uses, so Update and View can never disagree about which gist
+// lives at index N.
+func (gm GistsModel) Update(msg tea.Msg, stats *github.Stats) (GistsModel, tea.Cmd) {
+	km, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return gm, nil
+	}
+	if gm.searchActive {
+		return gm.updateSearch(km), nil
+	}
+
+	var rows []github.Gist
+	if stats != nil {
+		rows = visibleGists(stats.Gists, gm.query, gm.sort)
+	}
+	n := len(rows)
+
+	switch km.String() {
+	case "up", "k":
+		if gm.cursor > 0 {
+			gm.cursor--
+			gm.expanded = false
+		}
+	case "down", "j":
+		if gm.cursor < n-1 {
+			gm.cursor++
+			gm.expanded = false
+		}
+	case "home", "g":
+		gm.cursor, gm.expanded = 0, false
+	case "end", "G":
+		if n > 0 {
+			gm.cursor, gm.expanded = n-1, false
+		}
+	case "s":
+		gm.sort = (gm.sort + 1) % GistsSort(len(gistsSortLabels))
+		gm.cursor, gm.expanded = 0, false
+	case "/":
+		gm.searchActive = true
+	case "enter", "d":
+		if n == 0 || gm.cursor >= n {
+			return gm, nil
+		}
+		gm.expanded = !gm.expanded
+	case "o":
+		if n == 0 || gm.cursor >= n {
+			return gm, nil
+		}
+		return gm, openURLCmd(rows[gm.cursor].URL)
+	case "c":
+		if n == 0 || gm.cursor >= n {
+			return gm, nil
+		}
+		return gm, copyURLCmd(rows[gm.cursor].URL)
+	case "esc":
+		switch {
+		case gm.expanded:
+			gm.expanded = false
+		case gm.query != "":
+			gm.query = ""
+			gm.cursor = 0
+		}
+	}
+	return gm, nil
+}
+
+func (gm GistsModel) updateSearch(km tea.KeyMsg) GistsModel {
+	// Dispatch on km.Type so paste and fast multi-rune batches are
+	// captured rather than dropped — see ReposModel.updateSearch.
+	switch km.Type {
+	case tea.KeyEnter:
+		gm.searchActive = false
+		gm.cursor = 0
+	case tea.KeyEsc:
+		gm.searchActive = false
+		gm.query = ""
+		gm.cursor = 0
+	case tea.KeyBackspace:
+		if r := []rune(gm.query); len(r) > 0 {
+			gm.query = string(r[:len(r)-1])
+			gm.cursor = 0
+		}
+	case tea.KeyRunes, tea.KeySpace:
+		// Strip ANSI / C0 from pasted batches (sanitizeFilterInput).
+		gm.query += sanitizeFilterInput(string(km.Runes))
+		gm.cursor = 0
+	}
+	return gm
+}
+
+// filterGists matches the query against what the user can actually see:
+// the label the list renders, plus every filename. Matching the raw
+// description alone would make an untitled gist unfindable by the name
+// shown on its own row.
+func filterGists(gists []github.Gist, query string) []github.Gist {
+	if query == "" {
+		return gists
+	}
+	needle := strings.ToLower(query)
+	out := make([]github.Gist, 0, len(gists))
+	for _, g := range gists {
+		if strings.Contains(strings.ToLower(gistLabel(g)), needle) {
+			out = append(out, g)
+			continue
+		}
+		for _, f := range g.Files {
+			if strings.Contains(strings.ToLower(f.Name), needle) {
+				out = append(out, g)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func sortGists(gists []github.Gist, mode GistsSort) []github.Gist {
+	out := make([]github.Gist, len(gists))
+	copy(out, gists)
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		switch mode {
+		case GistsSortStars:
+			if a.Stars != b.Stars {
+				return a.Stars > b.Stars
+			}
+			return a.UpdatedAt.After(b.UpdatedAt)
+		case GistsSortName:
+			return strings.ToLower(gistLabel(a)) < strings.ToLower(gistLabel(b))
+		default: // GistsSortUpdated
+			return a.UpdatedAt.After(b.UpdatedAt)
+		}
+	})
+	return out
+}
+
+// visibleGists is the single source of truth for the row pipeline. The
+// cursor, the renderer and the action menu all consume this, which is
+// the lesson from the v0.11.0 filtered-stats bug — two callers deriving
+// the same list separately is how a highlighted row stops matching the
+// selected one.
+func visibleGists(gists []github.Gist, query string, mode GistsSort) []github.Gist {
+	return sortGists(filterGists(gists, query), mode)
+}
+
+func (gm GistsModel) renderGistsTab(stats *github.Stats, available, availableHeight int) string {
+	if stats == nil {
+		return mutedStyle.Render("(no gist data yet — waiting for first refresh)")
+	}
+	if len(stats.Gists) == 0 {
+		// Silent on *why* it is empty, on purpose. The fetch is
+		// best-effort, so this reads the same whether the account has no
+		// gists or the query failed — and claiming "you have none" when
+		// the fetch errored would be the kind of confident wrong answer
+		// the scan's disclosures exist to avoid.
+		return mutedStyle.Render("(no gists to show)")
+	}
+
+	rows := visibleGists(stats.Gists, gm.query, gm.sort)
+	if len(rows) == 0 {
+		return mutedStyle.Render(fmt.Sprintf("(no gists match %q — esc to clear)", gm.query))
+	}
+
+	cursor := gm.cursor
+	if cursor >= len(rows) {
+		cursor = len(rows) - 1
+	}
+	if cursor < 0 {
+		cursor = 0
+	}
+
+	overhead := 6
+	if gm.searchActive || gm.query != "" {
+		overhead++
+	}
+	expandedRows := 0
+	if gm.expanded {
+		expandedRows = len(rows[cursor].Files) + 1
+		overhead += expandedRows
+	}
+	rowsVisible := len(rows)
+	if availableHeight > 0 {
+		rowsVisible = availableHeight - overhead
+		if rowsVisible < 3 {
+			rowsVisible = 3
+		}
+		if rowsVisible > len(rows) {
+			rowsVisible = len(rows)
+		}
+	}
+
+	offset := 0
+	if len(rows) > rowsVisible {
+		offset = cursor - rowsVisible/2
+		if offset < 0 {
+			offset = 0
+		}
+		if offset > len(rows)-rowsVisible {
+			offset = len(rows) - rowsVisible
+		}
+	}
+	end := offset + rowsVisible
+	if end > len(rows) {
+		end = len(rows)
+	}
+
+	parts := []string{gm.renderHeaderLine(len(rows), len(stats.Gists), stats.GistsTotal, offset, end)}
+
+	switch {
+	case gm.searchActive:
+		parts = append(parts, mutedStyle.Render("search: ")+
+			gm.query+boldStyle.Foreground(colAccent).Render("█")+
+			mutedStyle.Render("   (enter confirm · esc cancel)"))
+	case gm.query != "":
+		parts = append(parts, mutedStyle.Render("filter: ")+gm.query+
+			mutedStyle.Render("   (esc to clear)"))
+	}
+
+	parts = append(parts, "", renderGistsTable(rows[offset:end], cursor-offset, gm.sort))
+
+	if gm.expanded {
+		parts = append(parts, "", renderGistFiles(rows[cursor]))
+	}
+
+	parts = append(parts, "", keyHints(
+		"↑↓", "move",
+		"g/G", "top/bottom",
+		"s", "sort",
+		"/", "search",
+		"enter", "files",
+		"o", "github",
+		"c", "copy",
+	))
+	return strings.Join(parts, "\n")
+}
+
+// renderHeaderLine names the count, and says so when the list is a
+// window rather than everything. total is what GitHub reported for the
+// same query, so "showing 100 of 240" is honest about the page cap
+// instead of letting a truncated list look complete.
+func (gm GistsModel) renderHeaderLine(visible, fetched, total int, offset, end int) string {
+	countLabel := fmt.Sprintf("%d gist", visible)
+	if visible != 1 {
+		countLabel = fmt.Sprintf("%d gists", visible)
+	}
+	if gm.query != "" && visible != fetched {
+		countLabel = fmt.Sprintf("%d of %d gists", visible, fetched)
+	} else if total > fetched {
+		countLabel = fmt.Sprintf("%d of %d gists", fetched, total)
+	}
+
+	sortLabel := mutedStyle.Render("  sort: ") +
+		valueStyle.Render(gistsSortLabels[gm.sort]+gistsSortChevron[gm.sort])
+
+	window := ""
+	if end-offset < visible {
+		window = mutedStyle.Render(fmt.Sprintf("  rows %d-%d", offset+1, end))
+	}
+	return sectionTitleStyle.Render(countLabel) + sortLabel + window
+}
+
+func renderGistsTable(gists []github.Gist, cursorRow int, sortMode GistsSort) string {
+	const (
+		cursorW  = 2
+		visW     = 7
+		nameW    = 52
+		filesW   = 6
+		starsW   = 6
+		updatedW = 10
+	)
+
+	decorate := func(label string, s GistsSort, width int) string {
+		if s == sortMode {
+			return padRightRaw(activeTabStyle.Render(label+" "+gistsSortChevron[sortMode]), width)
+		}
+		return mutedStyle.Render(padRight(label, width))
+	}
+
+	headerCells := []string{
+		strings.Repeat(" ", cursorW),
+		mutedStyle.Render(padRight("Vis", visW)),
+		decorate("Gist", GistsSortName, nameW),
+		mutedStyle.Render(padRight("Files", filesW)),
+		decorate("Stars", GistsSortStars, starsW),
+		decorate("Updated", GistsSortUpdated, updatedW),
+	}
+	header := strings.Join(headerCells, "  ")
+	rule := tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header)))
+
+	out := []string{header, rule}
+	for i, g := range gists {
+		active := i == cursorRow
+
+		marker := "  "
+		if active {
+			marker = activeTabStyle.Render("▸ ")
+		}
+
+		// "secret" rather than "private": that is GitHub's own word for
+		// it, and a gist that is not public is not access-controlled —
+		// anyone with the link can read it. Calling it private would
+		// overstate what it protects.
+		vis := "public"
+		if !g.IsPublic {
+			vis = "secret"
+		}
+		visCell := padRight(vis, visW)
+
+		name := padRight(truncate(gistLabel(g), nameW), nameW)
+		if active {
+			name = boldStyle.Foreground(colAccent).Render(name)
+		}
+		files := padRight(fmt.Sprintf("%d", len(g.Files)), filesW)
+		stars := padRight(fmt.Sprintf("%d", g.Stars), starsW)
+		updated := padRight(formatRelativeAgo(g.UpdatedAt), updatedW)
+
+		if !active {
+			visCell = mutedStyle.Render(visCell)
+			files = mutedStyle.Render(files)
+			stars = mutedStyle.Render(stars)
+			updated = mutedStyle.Render(updated)
+		}
+
+		out = append(out, marker+visCell+"  "+name+"  "+files+"  "+stars+"  "+updated)
+	}
+	return strings.Join(out, "\n")
+}
+
+// renderGistFiles is the expanded view: the files already carried by the
+// row, so opening it costs nothing and cannot fail.
+func renderGistFiles(g github.Gist) string {
+	if len(g.Files) == 0 {
+		return mutedStyle.Render("  (no files)")
+	}
+	var b strings.Builder
+	b.WriteString(mutedStyle.Render("  files in ") + valueStyle.Render(gistLabel(g)))
+	for _, f := range g.Files {
+		lang := f.Language
+		if lang == "" {
+			lang = "—"
+		}
+		b.WriteString("\n  " + valueStyle.Render(f.Name) +
+			mutedStyle.Render(fmt.Sprintf("  %s  %s", lang, humanBytes(f.Size))))
+	}
+	return b.String()
+}
+
+// humanBytes renders a file size the way a person reads one. Sizes here
+// are gist files, so kilobytes is the interesting scale.
+func humanBytes(n int) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f kB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/ui/gists.go
+++ b/internal/ui/gists.go
@@ -41,12 +41,6 @@ type GistsModel struct {
 	sort         GistsSort
 	query        string
 	searchActive bool
-	// expanded shows the selected gist's files inline. Deliberately not
-	// a drill-in sub-model: the canonical pattern has loading / error /
-	// loaded states because it fetches, and there is nothing to fetch
-	// here — the file list already arrived with the row. Inventing a
-	// loading state for data in hand would be theatre.
-	expanded bool
 }
 
 // IsInputMode reports whether the sub-model is absorbing keystrokes as
@@ -118,30 +112,27 @@ func (gm GistsModel) Update(msg tea.Msg, stats *github.Stats) (GistsModel, tea.C
 	case "up", "k":
 		if gm.cursor > 0 {
 			gm.cursor--
-			gm.expanded = false
 		}
 	case "down", "j":
 		if gm.cursor < n-1 {
 			gm.cursor++
-			gm.expanded = false
 		}
 	case "home", "g":
-		gm.cursor, gm.expanded = 0, false
+		gm.cursor = 0
 	case "end", "G":
 		if n > 0 {
-			gm.cursor, gm.expanded = n-1, false
+			gm.cursor = n - 1
 		}
 	case "s":
 		gm.sort = (gm.sort + 1) % GistsSort(len(gistsSortLabels))
-		gm.cursor, gm.expanded = 0, false
+		gm.cursor = 0
 	case "/":
 		gm.searchActive = true
-		gm.expanded = false
 	case "enter", "d":
 		if n == 0 || gm.cursor >= n {
 			return gm, nil
 		}
-		gm.expanded = !gm.expanded
+		return gm, viewGistDetailCmd(rows[gm.cursor])
 	case "o":
 		if n == 0 || gm.cursor >= n {
 			return gm, nil
@@ -153,10 +144,7 @@ func (gm GistsModel) Update(msg tea.Msg, stats *github.Stats) (GistsModel, tea.C
 		}
 		return gm, copyURLCmd(rows[gm.cursor].URL)
 	case "esc":
-		switch {
-		case gm.expanded:
-			gm.expanded = false
-		case gm.query != "":
+		if gm.query != "" {
 			gm.query = ""
 			gm.cursor = 0
 		}
@@ -185,10 +173,6 @@ func (gm GistsModel) updateSearch(km tea.KeyMsg) GistsModel {
 		gm.query += sanitizeFilterInput(string(km.Runes))
 		gm.cursor = 0
 	}
-	// Any of the above can move the cursor onto a different gist, and an
-	// expansion that survives that is showing one gist's files under
-	// another's name — nobody asked for it and it looks like a bug.
-	gm.expanded = false
 	return gm
 }
 
@@ -275,45 +259,21 @@ func (gm GistsModel) renderGistsTab(stats *github.Stats, available, availableHei
 	// Chrome is measured, not estimated: the tab always renders a title
 	// line, the blank around the table, the table's own header and rule, a
 	// trailing blank and the hint line — eight rows before a single gist.
-	// An earlier guess of six is what let a tall expansion push the pinned
-	// footer off a short terminal.
 	const gistsChrome = 8
 	chrome := gistsChrome
 	if gm.searchActive || gm.query != "" {
 		chrome++
 	}
 
-	content := availableHeight
-	if content > 0 {
-		content -= chrome
-		if content < 4 {
-			content = 4
-		}
-	}
-
-	// When the expansion is open the two compete for the same rows, so
-	// they split the budget rather than the expansion taking whatever it
-	// wants and the list absorbing the overflow.
-	listBudget, expandedFiles := content, 0
-	if gm.expanded && availableHeight > 0 {
-		expandedFiles = content/2 - 1
-		if expandedFiles < 1 {
-			expandedFiles = 1
-		}
-		if n := len(rows[cursor].Files); expandedFiles > n {
-			expandedFiles = n
-		}
-		listBudget = content - expandedFiles - 1
-		if listBudget < 1 {
-			listBudget = 1
-		}
-	} else if gm.expanded {
-		expandedFiles = len(rows[cursor].Files)
-	}
-
 	rowsVisible := len(rows)
-	if availableHeight > 0 && listBudget < rowsVisible {
-		rowsVisible = listBudget
+	if availableHeight > 0 {
+		rowsVisible = availableHeight - chrome
+		if rowsVisible < 3 {
+			rowsVisible = 3
+		}
+		if rowsVisible > len(rows) {
+			rowsVisible = len(rows)
+		}
 	}
 
 	offset := 0
@@ -345,16 +305,12 @@ func (gm GistsModel) renderGistsTab(stats *github.Stats, available, availableHei
 
 	parts = append(parts, "", renderGistsTable(rows[offset:end], cursor-offset, gm.sort))
 
-	if gm.expanded {
-		parts = append(parts, "", renderGistFiles(rows[cursor], expandedFiles))
-	}
-
 	parts = append(parts, "", keyHints(
 		"↑↓", "move",
 		"g/G", "top/bottom",
 		"s", "sort",
 		"/", "search",
-		"enter", "files",
+		"enter", "details",
 		"o", "github",
 		"c", "copy",
 	))
@@ -465,39 +421,6 @@ func renderGistsTable(gists []github.Gist, cursorRow int, sortMode GistsSort) st
 		out = append(out, marker+visCell+"  "+name+"  "+files+"  "+stars+"  "+updated)
 	}
 	return strings.Join(out, "\n")
-}
-
-// renderGistFiles is the expanded view: the files already carried by the
-// row, so opening it costs nothing and cannot fail.
-func renderGistFiles(g github.Gist, max int) string {
-	if len(g.Files) == 0 {
-		return mutedStyle.Render("  (no files)")
-	}
-	shown := g.Files
-	if max > 0 && max < len(shown) {
-		shown = shown[:max]
-	}
-	var b strings.Builder
-	header := "  files in " + gistLabel(g)
-	switch {
-	case len(shown) < len(g.Files):
-		// Cut by the terminal, not by the fetch — a different limit from
-		// GistFilesLimit and worth wording differently, so the reader can
-		// tell "your window is short" from "GitHub gave us no more".
-		header = fmt.Sprintf("  %d of %d files in %s", len(shown), len(g.Files), gistLabel(g))
-	case len(g.Files) >= github.GistFilesLimit:
-		header = fmt.Sprintf("  first %d files in %s", github.GistFilesLimit, gistLabel(g))
-	}
-	b.WriteString(mutedStyle.Render(header))
-	for _, f := range shown {
-		lang := f.Language
-		if lang == "" {
-			lang = "—"
-		}
-		b.WriteString("\n  " + valueStyle.Render(f.Name) +
-			mutedStyle.Render(fmt.Sprintf("  %s  %s", lang, humanBytes(f.Size))))
-	}
-	return b.String()
 }
 
 // humanBytes renders a file size the way a person reads one. Sizes here

--- a/internal/ui/gists_test.go
+++ b/internal/ui/gists_test.go
@@ -1,10 +1,12 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/gfazioli/octoscope/internal/github"
 )
@@ -205,11 +207,93 @@ func TestHumanBytes(t *testing.T) {
 	}{
 		{0, "0 B"},
 		{812, "812 B"},
-		{2048, "2.0 kB"},
-		{3 * 1024 * 1024, "3.0 MB"},
+		// Binary divisors, so binary labels. 1<<10 is a kibibyte; calling
+		// it a kB was wrong by a factor that grows with the size, and
+		// Copilot caught it on #123.
+		{2048, "2.0 KiB"},
+		{3 * 1024 * 1024, "3.0 MiB"},
 	} {
 		if got := humanBytes(tt.in); got != tt.want {
 			t.Errorf("humanBytes(%d) = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+// At the fetch cap the true file count is unknowable — GitHub's Gist.files
+// is a plain list with no totalCount — so the row must not print a number
+// it cannot stand behind. Both reviewers found this independently on #123.
+func TestGistsTableDisclosesTheFileCap(t *testing.T) {
+	names := make([]string, github.GistFilesLimit)
+	for i := range names {
+		names[i] = fmt.Sprintf("f%02d.go", i)
+	}
+	capped := gist("big", names, 0, true, time.Hour)
+	small := gist("small", []string{"a.go", "b.go"}, 0, true, time.Hour)
+
+	out := ansi.Strip(renderGistsTable([]github.Gist{capped, small}, 0, GistsSortUpdated))
+	if !strings.Contains(out, fmt.Sprintf("%d+", github.GistFilesLimit)) {
+		t.Errorf("a gist at the fetch cap printed an exact count:\n%s", out)
+	}
+	if !strings.Contains(out, " 2 ") && !strings.Contains(out, "2  ") {
+		t.Errorf("a gist below the cap should print its real count:\n%s", out)
+	}
+}
+
+// A filter and a truncated fetch are independent facts. They used to be an
+// if/else, so filtering a truncated list silently dropped the truncation —
+// the one of the two a reader cannot otherwise discover. Copilot, #123.
+func TestGistsHeaderKeepsBothTheFilterAndTheTruncation(t *testing.T) {
+	stats := &github.Stats{
+		Gists: []github.Gist{
+			gist("alpha", []string{"a.go"}, 0, true, time.Hour),
+			gist("beta", []string{"b.go"}, 0, true, 2*time.Hour),
+		},
+		GistsTotal: 240,
+	}
+	gm := GistsModel{query: "alpha"}
+	out := ansi.Strip(gm.renderGistsTab(stats, 140, 20))
+	if !strings.Contains(out, "240") {
+		t.Errorf("filtering a truncated list hid the total:\n%s", out)
+	}
+	if !strings.Contains(out, "1 of 2") {
+		t.Errorf("the filter count went missing:\n%s", out)
+	}
+}
+
+// Typing in the filter can move the cursor onto a different gist, and an
+// expansion that survives shows one gist's files under another's name.
+// CodeRabbit, #123.
+func TestGistsFilterClosesAnOpenExpansion(t *testing.T) {
+	gm := GistsModel{expanded: true, searchActive: true}
+	got := gm.updateSearch(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	if got.expanded {
+		t.Error("typing in the filter left the previous gist's files expanded")
+	}
+
+	gm = GistsModel{expanded: true}
+	stats := &github.Stats{Gists: []github.Gist{gist("x", []string{"a.go"}, 0, true, time.Hour)}}
+	got, _ = gm.Update(key("/"), stats)
+	if got.expanded {
+		t.Error("opening the search box left the expansion open underneath it")
+	}
+}
+
+// The expansion competes with the list for the same rows. Unbounded, a
+// 20-file gist on a short terminal pushed the pinned footer off screen —
+// the list clamps at three rows, the expansion did not clamp at all.
+func TestGistsExpansionIsBoundedByHeight(t *testing.T) {
+	names := make([]string, 20)
+	for i := range names {
+		names[i] = fmt.Sprintf("file%02d.go", i)
+	}
+	stats := &github.Stats{Gists: []github.Gist{gist("big", names, 0, true, time.Hour)}}
+	gm := GistsModel{expanded: true}
+
+	out := ansi.Strip(gm.renderGistsTab(stats, 140, 16))
+	if lines := strings.Count(out, "\n") + 1; lines > 16 {
+		t.Errorf("rendered %d lines into a %d-line budget:\n%s", lines, 16, out)
+	}
+	if !strings.Contains(out, "of 20 files") {
+		t.Errorf("the expansion was cut without saying so:\n%s", out)
 	}
 }

--- a/internal/ui/gists_test.go
+++ b/internal/ui/gists_test.go
@@ -297,3 +297,46 @@ func TestGistsExpansionIsBoundedByHeight(t *testing.T) {
 		t.Errorf("the expansion was cut without saying so:\n%s", out)
 	}
 }
+
+// The action menu has to actually open on the Gists tab.
+//
+// This test exists because it did not. The `case TabGists` was added to
+// the action-menu switch during review, but the *guard* around that switch
+// still listed only Repos / PRs / Issues — so the branch was unreachable
+// and `space` fell through to the tab's own Update. Both the commit message
+// and the README claimed the feature worked. Nothing failed, because
+// nothing tested it; CodeRabbit read the guard.
+func TestGistsActionMenuOpens(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token-not-used")
+	client, err := github.New("octocat", github.Options{})
+	if err != nil {
+		t.Fatalf("github.New: %v", err)
+	}
+	m := NewModel(client, "0.29.0", Options{})
+	m.stats = &github.Stats{Gists: []github.Gist{
+		gist("Sample list", []string{"a.json"}, 3, true, time.Hour),
+	}}
+	m.activeTab = TabGists
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	m = updated.(Model)
+
+	if !m.actionMenu.IsOpen() {
+		t.Fatal("space on the Gists tab did not open the action menu — the guard " +
+			"around the switch excludes TabGists again")
+	}
+	view := ansi.Strip(m.actionMenu.View(80))
+	if !strings.Contains(view, "Sample list") {
+		t.Errorf("the menu is not titled for the selected gist:\n%s", view)
+	}
+	for _, want := range []string{"Open in GitHub", "Copy URL"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("action %q missing:\n%s", want, view)
+		}
+	}
+	// No "View details": the files expand on the row, so there is no
+	// detail view to open and offering one would dead-end.
+	if strings.Contains(view, "View details") {
+		t.Errorf("the menu offers a detail view the Gists tab does not have:\n%s", view)
+	}
+}

--- a/internal/ui/gists_test.go
+++ b/internal/ui/gists_test.go
@@ -185,21 +185,6 @@ func TestGistsTableCallsThemSecretNotPrivate(t *testing.T) {
 	}
 }
 
-// Enter expands the files already carried by the row. There is no fetch,
-// so there is no loading state to render and none to wait for.
-func TestGistsExpandShowsFilesWithoutFetching(t *testing.T) {
-	stats := &github.Stats{Gists: []github.Gist{
-		gist("settings sync", []string{"cloudSettings", "extensions.json"}, 0, false, time.Hour),
-	}}
-	gm := GistsModel{expanded: true}
-	out := ansi.Strip(gm.renderGistsTab(stats, 120, 30))
-	for _, want := range []string{"cloudSettings", "extensions.json"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("expanded view is missing %q:\n%s", want, out)
-		}
-	}
-}
-
 func TestHumanBytes(t *testing.T) {
 	for _, tt := range []struct {
 		in   int
@@ -260,44 +245,6 @@ func TestGistsHeaderKeepsBothTheFilterAndTheTruncation(t *testing.T) {
 	}
 }
 
-// Typing in the filter can move the cursor onto a different gist, and an
-// expansion that survives shows one gist's files under another's name.
-// CodeRabbit, #123.
-func TestGistsFilterClosesAnOpenExpansion(t *testing.T) {
-	gm := GistsModel{expanded: true, searchActive: true}
-	got := gm.updateSearch(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
-	if got.expanded {
-		t.Error("typing in the filter left the previous gist's files expanded")
-	}
-
-	gm = GistsModel{expanded: true}
-	stats := &github.Stats{Gists: []github.Gist{gist("x", []string{"a.go"}, 0, true, time.Hour)}}
-	got, _ = gm.Update(key("/"), stats)
-	if got.expanded {
-		t.Error("opening the search box left the expansion open underneath it")
-	}
-}
-
-// The expansion competes with the list for the same rows. Unbounded, a
-// 20-file gist on a short terminal pushed the pinned footer off screen —
-// the list clamps at three rows, the expansion did not clamp at all.
-func TestGistsExpansionIsBoundedByHeight(t *testing.T) {
-	names := make([]string, 20)
-	for i := range names {
-		names[i] = fmt.Sprintf("file%02d.go", i)
-	}
-	stats := &github.Stats{Gists: []github.Gist{gist("big", names, 0, true, time.Hour)}}
-	gm := GistsModel{expanded: true}
-
-	out := ansi.Strip(gm.renderGistsTab(stats, 140, 16))
-	if lines := strings.Count(out, "\n") + 1; lines > 16 {
-		t.Errorf("rendered %d lines into a %d-line budget:\n%s", lines, 16, out)
-	}
-	if !strings.Contains(out, "of 20 files") {
-		t.Errorf("the expansion was cut without saying so:\n%s", out)
-	}
-}
-
 // The action menu has to actually open on the Gists tab.
 //
 // This test exists because it did not. The `case TabGists` was added to
@@ -329,14 +276,15 @@ func TestGistsActionMenuOpens(t *testing.T) {
 	if !strings.Contains(view, "Sample list") {
 		t.Errorf("the menu is not titled for the selected gist:\n%s", view)
 	}
-	for _, want := range []string{"Open in GitHub", "Copy URL"} {
+	for _, want := range []string{"Open in GitHub", "View details", "Copy URL"} {
 		if !strings.Contains(view, want) {
 			t.Errorf("action %q missing:\n%s", want, view)
 		}
 	}
-	// No "View details": the files expand on the row, so there is no
-	// detail view to open and offering one would dead-end.
-	if strings.Contains(view, "View details") {
-		t.Errorf("the menu offers a detail view the Gists tab does not have:\n%s", view)
+	// "View details" is offered again since v0.29.0: the drill-in exists,
+	// so the entry leads somewhere. It was absent in the first cut only
+	// because the files expanded on the row.
+	if !strings.Contains(view, "View details") {
+		t.Errorf("the menu does not offer the drill-in:\n%s", view)
 	}
 }

--- a/internal/ui/gists_test.go
+++ b/internal/ui/gists_test.go
@@ -1,0 +1,215 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+func gist(desc string, files []string, stars int, public bool, ago time.Duration) github.Gist {
+	g := github.Gist{
+		Name:        "hash-" + desc + strings.Join(files, ""),
+		Description: desc,
+		URL:         "https://gist.github.com/u/abc",
+		IsPublic:    public,
+		Stars:       stars,
+		UpdatedAt:   time.Now().Add(-ago),
+	}
+	for _, f := range files {
+		g.Files = append(g.Files, github.GistFile{Name: f, Size: 100})
+	}
+	return g
+}
+
+// GitHub's gist "name" is a hash, so the description is the only
+// human-readable handle — and it is routinely absent (2 of 16 on a real
+// account). Every fallback step has to land on something a person can
+// recognise, because the alternative is a row that reads as a hash.
+func TestGistLabelFallsBackThroughFilenameToHash(t *testing.T) {
+	tests := []struct {
+		name string
+		in   github.Gist
+		want string
+	}{
+		{
+			name: "description wins",
+			in:   gist("Sample of product list", []string{"products.json"}, 0, true, time.Hour),
+			want: "Sample of product list",
+		},
+		{
+			name: "no description falls back to the first filename",
+			in:   github.Gist{Name: "7ac536c", Files: []github.GistFile{{Name: "about.json"}}},
+			want: "about.json",
+		},
+		{
+			name: "whitespace-only description is not a description",
+			in:   github.Gist{Name: "7ac536c", Description: "   ", Files: []github.GistFile{{Name: "about.json"}}},
+			want: "about.json",
+		},
+		{
+			name: "nothing at all falls back to the hash",
+			in:   github.Gist{Name: "7ac536c"},
+			want: "7ac536c",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gistLabel(tt.in); got != tt.want {
+				t.Errorf("gistLabel = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisibleGistsSortsAndFilters(t *testing.T) {
+	in := []github.Gist{
+		gist("beta", []string{"b.go"}, 1, true, 3*time.Hour),
+		gist("alpha", []string{"a.rb"}, 9, false, 1*time.Hour),
+		gist("gamma", []string{"c.py"}, 5, true, 2*time.Hour),
+	}
+
+	labels := func(gs []github.Gist) []string {
+		out := make([]string, 0, len(gs))
+		for _, g := range gs {
+			out = append(out, gistLabel(g))
+		}
+		return out
+	}
+
+	t.Run("updated is newest first", func(t *testing.T) {
+		got := labels(visibleGists(in, "", GistsSortUpdated))
+		want := []string{"alpha", "gamma", "beta"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("stars is highest first", func(t *testing.T) {
+		got := labels(visibleGists(in, "", GistsSortStars))
+		want := []string{"alpha", "gamma", "beta"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("name is alphabetical by the label, not the hash", func(t *testing.T) {
+		got := labels(visibleGists(in, "", GistsSortName))
+		want := []string{"alpha", "beta", "gamma"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+// The filter has to match what the user can *see*. An untitled gist shows
+// its first filename on the row, so matching the raw description alone
+// would make it unfindable by the only name it displays.
+func TestFilterGistsMatchesTheVisibleLabelAndFilenames(t *testing.T) {
+	untitled := github.Gist{Name: "7ac536c", Files: []github.GistFile{{Name: "about.json"}}}
+	titled := gist("WordPress hooks", []string{"hooks.php"}, 0, true, time.Hour)
+	in := []github.Gist{untitled, titled}
+
+	if got := filterGists(in, "about"); len(got) != 1 || got[0].Name != "7ac536c" {
+		t.Errorf("filtering by the displayed filename found %d rows, want the untitled gist", len(got))
+	}
+	if got := filterGists(in, "wordpress"); len(got) != 1 || gistLabel(got[0]) != "WordPress hooks" {
+		t.Errorf("filtering by description found %d rows", len(got))
+	}
+	if got := filterGists(in, "hooks.php"); len(got) != 1 {
+		t.Errorf("filtering by a filename of a *titled* gist found %d rows, want 1", len(got))
+	}
+	if got := filterGists(in, "zzz"); len(got) != 0 {
+		t.Errorf("no-match query returned %d rows", len(got))
+	}
+
+	// The case only the label check can satisfy, and the reason this test
+	// is worth its length: with no description and no files, the row
+	// displays the hash, so the hash is the only string a user can type to
+	// find it. Matching the raw description here finds nothing, and the
+	// filename loop has nothing to walk — caught by mutation, because
+	// every other case in this test passes through the filename loop too
+	// and so proved nothing about the label.
+	bare := github.Gist{Name: "0d2c0a0530448ad1af7e46"}
+	if got := filterGists([]github.Gist{bare, titled}, "0d2c0a"); len(got) != 1 || got[0].Name != bare.Name {
+		t.Errorf("a gist with only a hash is unfindable by that hash: got %d rows", len(got))
+	}
+}
+
+// The empty tab must not claim the account has no gists: the fetch is
+// best-effort, so empty means "nothing to show" and could equally be a
+// failed query. Asserting the stronger sentence would be the confident
+// wrong answer the rest of the app is built to avoid.
+func TestGistsTabDoesNotClaimTheAccountHasNone(t *testing.T) {
+	var gm GistsModel
+	out := ansi.Strip(gm.renderGistsTab(&github.Stats{}, 100, 20))
+	if strings.Contains(strings.ToLower(out), "you have no") ||
+		strings.Contains(strings.ToLower(out), "no gists yet") {
+		t.Errorf("empty state asserts something the best-effort fetch cannot know: %q", out)
+	}
+	if !strings.Contains(out, "no gists to show") {
+		t.Errorf("empty state should still say something: %q", out)
+	}
+}
+
+// A truncated list has to say so. gistsPageSize caps one refresh, and
+// GitHub reports the real total alongside — without the "of N" the window
+// would look like the whole thing.
+func TestGistsTabSaysWhenItIsShowingAWindow(t *testing.T) {
+	stats := &github.Stats{
+		Gists:      []github.Gist{gist("only one", []string{"a.go"}, 0, true, time.Hour)},
+		GistsTotal: 240,
+	}
+	var gm GistsModel
+	out := ansi.Strip(gm.renderGistsTab(stats, 120, 20))
+	if !strings.Contains(out, "1 of 240 gists") {
+		t.Errorf("a truncated list did not disclose the total:\n%s", out)
+	}
+}
+
+// "secret" is GitHub's own word, and the accurate one: a non-public gist
+// is readable by anyone holding the link. Calling it "private" would
+// overstate what it protects.
+func TestGistsTableCallsThemSecretNotPrivate(t *testing.T) {
+	rows := []github.Gist{gist("hidden", []string{"a.go"}, 0, false, time.Hour)}
+	out := ansi.Strip(renderGistsTable(rows, 0, GistsSortUpdated))
+	if !strings.Contains(out, "secret") {
+		t.Errorf("a non-public gist is not labelled secret:\n%s", out)
+	}
+	if strings.Contains(out, "private") {
+		t.Errorf("labelled private, which overstates what a secret gist protects:\n%s", out)
+	}
+}
+
+// Enter expands the files already carried by the row. There is no fetch,
+// so there is no loading state to render and none to wait for.
+func TestGistsExpandShowsFilesWithoutFetching(t *testing.T) {
+	stats := &github.Stats{Gists: []github.Gist{
+		gist("settings sync", []string{"cloudSettings", "extensions.json"}, 0, false, time.Hour),
+	}}
+	gm := GistsModel{expanded: true}
+	out := ansi.Strip(gm.renderGistsTab(stats, 120, 30))
+	for _, want := range []string{"cloudSettings", "extensions.json"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expanded view is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	for _, tt := range []struct {
+		in   int
+		want string
+	}{
+		{0, "0 B"},
+		{812, "812 B"},
+		{2048, "2.0 kB"},
+		{3 * 1024 * 1024, "3.0 MB"},
+	} {
+		if got := humanBytes(tt.in); got != tt.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -43,7 +43,7 @@ var helpGroups = []struct {
 	bindings []helpBinding
 }{
 	{"Navigate", []helpBinding{
-		{"1-6", "jump to tab"},
+		{"1-7", "jump to tab"},
 		{"tab / shift+tab", "cycle tabs"},
 		{"up / down", "move cursor"},
 		{"g / G", "top / bottom"},

--- a/internal/ui/hyperlink.go
+++ b/internal/ui/hyperlink.go
@@ -62,6 +62,34 @@ func githubHyperlink(rawURL, label string) string {
 //     targets we don't want to make one-click from a row that looks
 //     like it belongs to GitHub. They render as plain text instead.
 func isGitHubURL(rawURL string) bool {
+	if !isSafeOpenURL(rawURL) {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "github.com" || strings.HasSuffix(host, ".github.com")
+}
+
+// isSafeOpenURL is the host-agnostic half of the check above: length,
+// escape-sequence breakout, control characters, and **https only**.
+//
+// It exists because the browser-open path needs the scheme gate but must
+// not have the host gate. openURLCmd hands the string to the OS opener,
+// which will cheerfully act on `file:`, `data:` or a custom scheme — that
+// is the danger, and it is the same on every tab. But the destinations are
+// not all GitHub: the support links deliberately point at a payment page,
+// so requiring github.com there would break a working feature rather than
+// protect anything.
+//
+// Raised on #123 against the Gists tab specifically. Gists turned out not
+// to be special — every tab shares openURLCmd and every URL comes from the
+// same GitHub API — so gating one tab would have been inconsistent and
+// left the same exposure on four others. Splitting the check fixes the
+// class instead, and keeps the payment link working.
+func isSafeOpenURL(rawURL string) bool {
 	if rawURL == "" || len(rawURL) > 2048 {
 		return false
 	}
@@ -76,11 +104,6 @@ func isGitHubURL(rawURL string) bool {
 			return false
 		}
 	}
-
 	u, err := url.Parse(rawURL)
-	if err != nil || u.Scheme != "https" {
-		return false
-	}
-	host := strings.ToLower(u.Hostname())
-	return host == "github.com" || strings.HasSuffix(host, ".github.com")
+	return err == nil && u.Scheme == "https"
 }

--- a/internal/ui/hyperlink_test.go
+++ b/internal/ui/hyperlink_test.go
@@ -148,3 +148,65 @@ func TestGitHubHyperlink(t *testing.T) {
 		}
 	}
 }
+
+// isSafeOpenURL is the browser-open gate: the scheme and control-character
+// half of isGitHubURL, deliberately **without** the host check.
+//
+// The two halves exist separately because openURLCmd hands its argument to
+// the OS opener, which will act on `file:` or a custom scheme — that is the
+// hazard, and it is identical on every tab. But the destinations are not
+// all GitHub: the support link points at a payment page on purpose, so a
+// host check at that choke point would break a working feature rather than
+// protect anything. Split on #123.
+func TestIsSafeOpenURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"a GitHub URL", "https://github.com/gfazioli/octoscope", true},
+		{"a gist URL", "https://gist.github.com/gfazioli/abc123", true},
+		// The case that must keep working: off-GitHub and intended.
+		{"the payment link", "https://donate.stripe.com/xyz", true},
+		{"plain http is not enough", "http://github.com/x", false},
+		{"file scheme", "file:///etc/passwd", false},
+		{"data scheme", "data:text/html,<script>alert(1)</script>", false},
+		{"javascript scheme", "javascript:alert(1)", false},
+		{"custom scheme the OS opener would act on", "x-devonthink-item://abc", false},
+		{"escape-sequence breakout", "https://github.com/\x1b]8;;x\x07", false},
+		{"a bare control character", "https://github.com/a\x01b", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSafeOpenURL(tt.in); got != tt.want {
+				t.Errorf("isSafeOpenURL(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// The gate has to be *at* openURLCmd, not at each call site, or the next
+// tab added forgets it. And it must not be the host check: the support
+// link is the regression this pins.
+func TestOpenURLCmdGatesTheScheme(t *testing.T) {
+	if cmd := openURLCmd("file:///etc/passwd"); cmd != nil {
+		t.Error("openURLCmd accepted a file: URL; the OS opener would act on it")
+	}
+	if cmd := openURLCmd("javascript:alert(1)"); cmd != nil {
+		t.Error("openURLCmd accepted a javascript: URL")
+	}
+	if cmd := openURLCmd(""); cmd != nil {
+		t.Error("openURLCmd accepted an empty URL")
+	}
+	if cmd := openURLCmd("https://github.com/gfazioli/octoscope"); cmd == nil {
+		t.Error("openURLCmd rejected an ordinary GitHub URL")
+	}
+	if cmd := openURLCmd(coffeeURL); cmd == nil {
+		t.Errorf("openURLCmd rejected the support link (%s) — a host check here "+
+			"would break it, which is why the scheme half was split out", coffeeURL)
+	}
+	if cmd := openURLCmd(sponsorURL); cmd == nil {
+		t.Error("openURLCmd rejected the sponsor link")
+	}
+}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -93,6 +93,13 @@ type viewIssueDetailMsg struct {
 	issue github.Issue
 }
 
+// viewGistDetailMsg is the Gists-side counterpart. It carries the whole
+// row rather than just the hash so the drill-in can title itself while the
+// fetch is still in flight.
+type viewGistDetailMsg struct {
+	gist github.Gist
+}
+
 // urlCopiedMsg fires after a copy-to-clipboard action — `err` is
 // nil on success, non-nil when the clipboard helper failed
 // (missing xclip/xsel on minimal Linux, headless X session, etc.).
@@ -135,6 +142,13 @@ func viewPRDetailCmd(p github.PullRequest) tea.Cmd {
 func viewIssueDetailCmd(it github.Issue) tea.Cmd {
 	return func() tea.Msg {
 		return viewIssueDetailMsg{issue: it}
+	}
+}
+
+// viewGistDetailCmd captures a Gists row for the drill-in.
+func viewGistDetailCmd(g github.Gist) tea.Cmd {
+	return func() tea.Msg {
+		return viewGistDetailMsg{gist: g}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -17,8 +17,15 @@ import (
 	"github.com/gfazioli/octoscope/internal/update"
 )
 
-// Tab identifies one of the top-level views. Values are stable so the
-// key bindings ("1".."6") map cleanly to positions.
+// Tab identifies one of the top-level views. Values map to the key
+// bindings ("1".."7") by position.
+//
+// Gists landed at position 6 in v0.29.0 rather than at the end, which
+// moved What's new from "6" to "7". That was the deliberate half of the
+// choice: Gists is a *content* tab and belongs beside the others, while
+// What's new is a meta tab whose meaningful stable position is last —
+// keeping it there costs one digit of muscle memory and keeps the row
+// readable. Nothing persists the active tab, so no stored value breaks.
 type Tab int
 
 const (
@@ -27,11 +34,12 @@ const (
 	TabPRs
 	TabIssues
 	TabActivity
+	TabGists
 	TabWhatsNew
 )
 
 // tabCount is the number of tabs. Keep in sync with the Tab constants.
-const tabCount = 6
+const tabCount = 7
 
 // tabLabels is the visible name for each tab, indexed by Tab value.
 var tabLabels = [tabCount]string{
@@ -40,6 +48,7 @@ var tabLabels = [tabCount]string{
 	"PRs",
 	"Issues",
 	"Activity",
+	"Gists",
 	"What's new",
 }
 
@@ -149,7 +158,7 @@ type Model struct {
 	pulseMap map[string]time.Time
 
 	// activeTab is the currently visible tab (0 = Overview). Switched
-	// via number keys "1".."6" or Tab/Shift+Tab.
+	// via number keys "1".."7" or Tab/Shift+Tab.
 	activeTab Tab
 
 	// repos, prs, issues hold per-tab state (cursor / sort / search).
@@ -160,6 +169,7 @@ type Model struct {
 	repos  ReposModel
 	prs    PRsModel
 	issues IssuesModel
+	gists  GistsModel
 
 	// starModeDefault seeds RepoDetailModel.starMode on every
 	// drill-in Open (config key default_star_history, #35). The
@@ -686,6 +696,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				var cmd tea.Cmd
 				m.prs, cmd = m.prs.Update(msg, eff)
 				return m, cmd
+			case m.activeTab == TabGists && m.gists.IsInputMode():
+				var cmd tea.Cmd
+				m.gists, cmd = m.gists.Update(msg, eff)
+				return m, cmd
 			case m.activeTab == TabIssues && m.issues.IsInputMode():
 				var cmd tea.Cmd
 				m.issues, cmd = m.issues.Update(msg, eff, m.pinnedIssues)
@@ -827,8 +841,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.activeTab = (m.activeTab - 1 + tabCount) % tabCount
 			}
 			return m, nil
-		case "1", "2", "3", "4", "5", "6":
-			// Digit → zero-based tab index. Safe because len("1"..."6") == 1
+		case "1", "2", "3", "4", "5", "6", "7":
+			// Digit → zero-based tab index. Safe because len("1"..."7") == 1
 			// and the range is bounded by tabCount via the case list.
 			m.activeTab = Tab(msg.String()[0] - '1')
 			return m, nil
@@ -856,6 +870,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case TabIssues:
 				var cmd tea.Cmd
 				m.issues, cmd = m.issues.Update(msg, eff, m.pinnedIssues)
+				return m, cmd
+			case TabGists:
+				var cmd tea.Cmd
+				m.gists, cmd = m.gists.Update(msg, eff)
 				return m, cmd
 			case TabOverview:
 				// Static tab content — let the viewport handle scroll

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -216,6 +216,7 @@ type Model struct {
 	// internal/ui/issue_detail.go and CLAUDE.md's drill-in
 	// pattern note.
 	issueDetail IssueDetailModel
+	gistDetail  GistDetailModel
 
 	// scan is the supply-chain integrity-scan drill-in opened from
 	// the Repos action menu ("Security scan", `s`). Same drill-in
@@ -661,6 +662,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 
+		// Gists drill-in — same dispatch shape. Its Update reports
+		// whether it consumed the key so a close can fall through in one
+		// pass rather than swallowing the keystroke that closed it.
+		if msg.String() != "ctrl+c" && m.gistDetail.IsOpen() {
+			width := computeAvailable(m.width)
+			height := computeTabHeight(m)
+			newDetail, cmd, consumed := m.gistDetail.Update(msg, width, height)
+			m.gistDetail = newDetail
+			if consumed {
+				return m, cmd
+			}
+		}
+
 		// Integrity-scan drill-in — same dispatch shape as the detail
 		// views. Routed before the per-tab dispatch so its keys
 		// (esc / r / o / y / scroll) win while open.
@@ -780,12 +794,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 			case TabGists:
-				// No "View details": the files expand inline on the row,
-				// since they arrived with it and there is nothing to fetch.
 				if g, ok := m.gists.selectedGist(s); ok {
 					title = "Actions for " + gistLabel(g)
 					actions = []Action{
 						{Label: "Open in GitHub", Shortcut: 'o', Cmd: openURLCmd(g.URL)},
+						{Label: "View details", Shortcut: 'd', Cmd: viewGistDetailCmd(g)},
 						{Label: "Copy URL", Shortcut: 'c', Cmd: copyURLCmd(g.URL)},
 					}
 				}
@@ -1171,6 +1184,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.issueDetail = m.issueDetail.applyFetched(msg.detail, msg.err)
+		return m, nil
+
+	case viewGistDetailMsg:
+		// Mutual exclusion — one drill-in at a time, same as the others.
+		m.repoDetail = m.repoDetail.Close()
+		m.prDetail = m.prDetail.Close()
+		m.issueDetail = m.issueDetail.Close()
+		m.scan = m.scan.Close()
+		m.gistDetail = m.gistDetail.Open(msg.gist)
+		return m, fetchGistDetailCmd(m.client, msg.gist.Name)
+
+	case gistDetailFetchedMsg:
+		// The gist hash is the correlation key: a response for one the user
+		// has already navigated away from is dropped, not painted.
+		if !m.gistDetail.IsOpen() || m.gistDetail.gist.Name != msg.name {
+			return m, nil
+		}
+		m.gistDetail = m.gistDetail.applyFetched(msg.detail, msg.err)
 		return m, nil
 
 	case viewRepoScanMsg:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -653,6 +653,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 
+		// Placed before the Issue drill-in so this order matches
+		// View()'s modal switch exactly. They diverged once: View
+		// painted the gist while Update fed the issue, so keys went
+		// to a view nobody could see.
+		// Gists drill-in — same dispatch shape. Its Update reports
+		// whether it consumed the key so a close can fall through in one
+		// pass rather than swallowing the keystroke that closed it.
+		if msg.String() != "ctrl+c" && m.gistDetail.IsOpen() {
+			width := computeAvailable(m.width)
+			height := computeTabHeight(m)
+			newDetail, cmd, consumed := m.gistDetail.Update(msg, m.client, width, height-4)
+			m.gistDetail = newDetail
+			if consumed {
+				return m, cmd
+			}
+		}
+
 		// Issue-detail drill-in — same dispatch shape.
 		if msg.String() != "ctrl+c" && m.issueDetail.IsOpen() {
 			width := computeAvailable(m.width)
@@ -660,19 +677,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			newDetail, cmd := m.issueDetail.Update(msg, m.client, width, height)
 			m.issueDetail = newDetail
 			return m, cmd
-		}
-
-		// Gists drill-in — same dispatch shape. Its Update reports
-		// whether it consumed the key so a close can fall through in one
-		// pass rather than swallowing the keystroke that closed it.
-		if msg.String() != "ctrl+c" && m.gistDetail.IsOpen() {
-			width := computeAvailable(m.width)
-			height := computeTabHeight(m)
-			newDetail, cmd, consumed := m.gistDetail.Update(msg, width, height)
-			m.gistDetail = newDetail
-			if consumed {
-				return m, cmd
-			}
 		}
 
 		// Integrity-scan drill-in — same dispatch shape as the detail
@@ -1107,6 +1111,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.prDetail = m.prDetail.Close()
 		m.issueDetail = m.issueDetail.Close()
 		m.scan = m.scan.Close()
+		m.gistDetail = m.gistDetail.Close()
 		// Every fresh drill-in starts from the configured star-history
 		// default (#35); the `v` cycle inside the detail stays a
 		// per-visit choice.
@@ -1151,6 +1156,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repoDetail = m.repoDetail.Close()
 		m.issueDetail = m.issueDetail.Close()
 		m.scan = m.scan.Close()
+		m.gistDetail = m.gistDetail.Close()
 		m.prDetail = m.prDetail.Open(msg.pr)
 		return m, fetchPRDetailCmd(m.client, owner, name, num, msg.pr.URL)
 
@@ -1176,6 +1182,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repoDetail = m.repoDetail.Close()
 		m.prDetail = m.prDetail.Close()
 		m.scan = m.scan.Close()
+		m.gistDetail = m.gistDetail.Close()
 		m.issueDetail = m.issueDetail.Open(msg.issue)
 		return m, fetchIssueDetailCmd(m.client, owner, name, num, msg.issue.URL)
 
@@ -1219,6 +1226,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repoDetail = m.repoDetail.Close()
 		m.prDetail = m.prDetail.Close()
 		m.issueDetail = m.issueDetail.Close()
+		m.gistDetail = m.gistDetail.Close()
 		// Hand the scan the repo list for its push-burst context, via
 		// effectiveStats() rather than m.stats: public-only mode is
 		// documented as screenshot-safe, and a burst derived from

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -563,6 +563,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// keystroke. No-op when stats haven't arrived yet.
 		syncOverviewViewport(&m)
 		syncActivityViewport(&m)
+		// Same reason for the gist drill-in: its viewport is sized in
+		// Update, and View works on a copy, so without this a resized
+		// terminal renders the file at the old dimensions until the next
+		// scroll key.
+		if m.gistDetail.IsOpen() {
+			m.gistDetail = m.gistDetail.SyncSize(computeAvailable(m.width), computeTabHeight(m)-4)
+		}
 		return m, nil
 
 	case tea.KeyMsg:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -777,6 +777,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						{Label: "Copy URL", Shortcut: 'c', Cmd: copyURLCmd(it.URL)},
 					}
 				}
+			case TabGists:
+				// No "View details": the files expand inline on the row,
+				// since they arrived with it and there is nothing to fetch.
+				if g, ok := m.gists.selectedGist(s); ok {
+					title = "Actions for " + gistLabel(g)
+					actions = []Action{
+						{Label: "Open in GitHub", Shortcut: 'o', Cmd: openURLCmd(g.URL)},
+						{Label: "Copy URL", Shortcut: 'c', Cmd: copyURLCmd(g.URL)},
+					}
+				}
 			}
 			if len(actions) > 0 {
 				m.actionMenu = m.actionMenu.Open(title, actions)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -708,7 +708,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Open action menu on a list-tab row. Handled here (before
-		// the global key switch) and ONLY for Repos / PRs / Issues,
+		// the global key switch) and ONLY for Repos / PRs / Issues /
+		// Gists,
 		// so on Overview / Activity the same key falls through to
 		// the default branch and reaches the viewport — which uses
 		// space as a page-down. Without this guard the action-menu
@@ -725,7 +726,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// as the out-of-the-box action-menu gesture, ctrl+enter as a
 		// power-user alternative for terminals that pass the modifier.
 		if (msg.String() == " " || msg.String() == "ctrl+@" || msg.String() == "ctrl+enter") &&
-			(m.activeTab == TabRepos || m.activeTab == TabPRs || m.activeTab == TabIssues) {
+			(m.activeTab == TabRepos || m.activeTab == TabPRs || m.activeTab == TabIssues ||
+				m.activeTab == TabGists) {
 			s := m.stats
 			if s != nil && m.client.PublicOnly() {
 				s = s.Public()

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -1113,7 +1113,11 @@ func formatRelativeAgo(t time.Time) string {
 // platform launcher is missing, the worst case is "Enter does nothing"
 // rather than a crash or an obtrusive error toast.
 func openURLCmd(url string) tea.Cmd {
-	if url == "" {
+	// Gate the scheme, not the host — see isSafeOpenURL. browse.OpenURL
+	// hands this to the OS opener, so a non-https scheme is the real
+	// hazard; the host cannot be constrained here because the support
+	// links point off GitHub on purpose.
+	if !isSafeOpenURL(url) {
 		return nil
 	}
 	return func() tea.Msg {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -76,7 +76,7 @@ type SettingsModel struct {
 
 // IsOpen reports whether the panel is currently visible. The root
 // Update uses this to route keystrokes (settings absorbs everything
-// while open, including digits 1-6 and "q").
+// while open, including digits 1-7 and "q").
 func (sm SettingsModel) IsOpen() bool {
 	return sm.open
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -157,6 +157,8 @@ func (m Model) View() string {
 		b.WriteString(m.repoDetail.View(available, tabHeight))
 	case m.prDetail.IsOpen():
 		b.WriteString(m.prDetail.View(available, tabHeight))
+	case m.gistDetail.IsOpen():
+		b.WriteString(m.gistDetail.View(available, tabHeight))
 	case m.issueDetail.IsOpen():
 		b.WriteString(m.issueDetail.View(available, tabHeight))
 	case m.scan.IsOpen():
@@ -1005,7 +1007,7 @@ func formatThousands(n int) string {
 // the View() modal switch; keep the two aligned.
 func (m Model) drillInOpen() bool {
 	return m.repoDetail.IsOpen() || m.prDetail.IsOpen() ||
-		m.issueDetail.IsOpen() || m.scan.IsOpen()
+		m.gistDetail.IsOpen() || m.issueDetail.IsOpen() || m.scan.IsOpen()
 }
 
 // overlayOpen reports whether any overlay — a modal (sponsor splash,

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -171,6 +171,8 @@ func (m Model) View() string {
 			b.WriteString(m.prs.renderPRsTab(s, available, tabHeight))
 		case TabIssues:
 			b.WriteString(m.issues.renderIssuesTab(s, available, tabHeight, m.pinnedIssues))
+		case TabGists:
+			b.WriteString(m.gists.renderGistsTab(s, available, tabHeight))
 		case TabActivity:
 			b.WriteString(m.renderActivityScrolled(s, available, tabHeight))
 		case TabWhatsNew:
@@ -1020,7 +1022,7 @@ func (m Model) overlayOpen() bool {
 // listInputMode reports whether the active list tab is capturing filter
 // text (the `/` search box). While it is, model.go's Update forwards
 // every keystroke to the sub-model as a literal filter character, so the
-// global hotkeys (1-6, p, comma, ?, q, tab) don't fire — the footer must
+// global hotkeys (1-7, p, comma, ?, q, tab) don't fire — the footer must
 // not advertise them, exactly as for an open overlay.
 func (m Model) listInputMode() bool {
 	switch m.activeTab {
@@ -1030,6 +1032,8 @@ func (m Model) listInputMode() bool {
 		return m.prs.IsInputMode()
 	case TabIssues:
 		return m.issues.IsInputMode()
+	case TabGists:
+		return m.gists.IsInputMode()
 	}
 	return false
 }
@@ -1068,7 +1072,7 @@ func footerKeys(m Model) string {
 	default:
 		return keyHints(
 			"r", "refresh",
-			"1-6/tab", "switch",
+			"1-7/tab", "switch",
 			"p", "public",
 			",", "settings",
 			"?", "help",

--- a/internal/ui/whatsnew_test.go
+++ b/internal/ui/whatsnew_test.go
@@ -51,8 +51,11 @@ func TestRenderWhatsNewTab(t *testing.T) {
 }
 
 func TestWhatsNewTabWiring(t *testing.T) {
-	if tabCount != 6 {
-		t.Fatalf("tabCount = %d, want 6", tabCount)
+	// 7 since v0.29.0: Gists took position 6 and What's new moved to 7,
+	// on purpose — Gists is a content tab and belongs beside the others,
+	// What's new is meta and belongs last.
+	if tabCount != 7 {
+		t.Fatalf("tabCount = %d, want 7", tabCount)
 	}
 	if tabLabels[TabWhatsNew] != "What's new" {
 		t.Errorf("tabLabels[TabWhatsNew] = %q, want \"What's new\"", tabLabels[TabWhatsNew])
@@ -65,11 +68,11 @@ func TestWhatsNewTabWiring(t *testing.T) {
 	}
 	m := NewModel(client, "0.16.0", Options{}) // splash off (ShowSponsor false)
 
-	// Key "6" jumps to the What's new tab.
-	updated, _ := m.Update(key("6"))
+	// Key "7" jumps to the What's new tab.
+	updated, _ := m.Update(key("7"))
 	m = updated.(Model)
 	if m.activeTab != TabWhatsNew {
-		t.Fatalf("after '6', activeTab = %d, want TabWhatsNew (%d)", m.activeTab, TabWhatsNew)
+		t.Fatalf("after '7', activeTab = %d, want TabWhatsNew (%d)", m.activeTab, TabWhatsNew)
 	}
 
 	// On the What's new tab, o / b / c act on the support links; other keys no-op.


### PR DESCRIPTION
Closes #76.

Gists were the one account-centric surface the dashboard did not represent — repos, PRs, issues, activity and stars were all there. The issue calls that *"a gap rather than an expansion"*, and this treats it as one: a list tab reusing the cursor, sort and filter the other list tabs share, introducing no mental model of its own.

## Three things the live API decided, not me

I probed before writing Go, per the repo's first rung, and each answer changed the design.

**Privacy is a query argument, not a filter.** Under `--public-only` the query asks for `PUBLIC`, so secret gists are never fetched. That also keeps the *count* honest, which filtering afterwards would not: measured on a real account, `ALL` returns 16 with 6 secret and `PUBLIC` returns `totalCount: 10` — **not** 16. Had it fetched everything and hidden them, a "10 of 16" line would itself have disclosed that six secret gists exist. Only the request body can prove which was asked for, hence a test that captures it.

**It is best-effort, and that is not generic caution.** Of everything `FetchStats` pulls, this is the one query GitHub answers with data *and* an error attached — asking a foreign account for `SECRET` returns `totalCount: 0` alongside *"You don't have permission to see gists."* That is the shape that aborts a decode, so sharing a branch with anything mandatory would take the whole dashboard down with it. Its error is dropped deliberately, and a test pins that the error is real so the drop reads as load-bearing rather than sloppy.

**An empty description is preserved, not filled in.** Two of sixteen real gists have none. Choosing a display string is presentation; inventing one in the fetch layer would put a value into `--json` that GitHub never returned. So the label fallback (description → first filename → hash) lives in the UI, and the filter matches *that* label plus every filename — a gist has to be findable by the name it actually displays.

## Placement, and what it costs

Gists sits at position **6**, which moves What's new to **7**. Deliberate: Gists is a content tab and belongs beside the others, while What's new is meta and its meaningful stable position is last. Nothing persists the active tab, so no stored value breaks — the cost is one digit of muscle memory. The existing wiring test caught the change and was updated rather than silenced.

## Two departures from the neighbouring tabs

- **No drill-in sub-model.** The canonical pattern carries loading / error / loaded states because it fetches. The file list already arrived with the row, so `enter` expands inline — a loading state for data in hand is theatre.
- **No pinned section.** The sticky-partition machinery earns its complexity where there is something to stick, and a gist is not a repo you keep at the top.

## Verified live, which is what caught the loose ends

Rendered against the real account before committing:

- 10 gists under `--public-only`, the six secret ones absent — the fetch-side privacy choice showing through end to end;
- the second row reads `about.json`, which *is* the label fallback firing on a real untitled gist;
- and the footer, help screen and a settings comment were all still advertising **"1-6"**. Found by looking at the thing, not by reading the diff.

## Mutation-tested

Fetch side: dropping `Sanitize` on the description, dropping it on filenames, and removing the public-only privacy switch each fail the test that names them. UI side: removing the filename fallback, matching the raw description instead of the label, relabelling secret as "private", and dropping the truncation disclosure likewise.

One assertion was **inert on the first pass** — the label-filter test, because every case in it also matched through the filename loop and so proved nothing about the label. It now pins the one case only the label can satisfy: a gist with no description and no files, findable solely by its hash. That is the fifth inert assertion this discipline has caught, and this one was in a test I wrote specifically to cover the behaviour it failed to cover.

A note on the fixture: its control characters are JSON escapes because they have to be — `encoding/json` rejects a raw one outright, which also means the escaped form is what GitHub actually sends and the raw byte only exists after the decode, exactly where `Sanitize` is waiting. A comment claiming the opposite was written and corrected by the decoder.

Also corrects the parallel-branch count in `CLAUDE.md`, which said five.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Gists tab with visibility, file counts, stars, update dates, and file details.
  * Search, sort, filter, expand files, open or copy links, and browse gist details and file contents.
  * Added Gists to reports and keyboard navigation for seven dashboard tabs.

* **Bug Fixes**
  * Gist fetch failures no longer prevent the dashboard from loading.
  * Unsafe or invalid links are now blocked from opening.

* **Documentation**
  * Updated tab, shortcut, help, and settings documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->