### PR TITLE
feat(activity): a feed of what happened, beside the heatmap of how much

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
   list by a muted rule, ordered most-recently-updated first.
 - **Issues** — every open issue you've authored, wherever it lives. Same
   shape as PRs minus the state column.
-- **Activity** — 52-week contribution heatmap, plus total / current streak /
-  longest streak / busiest day computed from the same cells.
+- **Activity** — two halves, switched with `←` / `→`. **Heatmap** is the
+  52-week contribution calendar, plus total / current streak / longest
+  streak / busiest day computed from the same cells. **Feed** (v0.29.0+) is
+  the timeline underneath it: what you actually did, most recent first.
 - **Gists** (v0.29.0+) — your gists, newest first, with visibility, file
   count and stars. `enter` drills in and shows the **file contents**,
   syntax-highlighted, and `c` there copies the *code* rather than the link
@@ -286,15 +288,54 @@ filtered.
 
 ### Activity tab
 
-The **Activity** tab renders the last ~52 weeks of your public contribution
-calendar as a heatmap, shaded on an accent-pink gradient that adapts to
-your own distribution (the busiest day always hits the full neon pink, the
-quiet days sit on the surface grey). Underneath:
+The **Activity** tab has two halves at different zoom levels, switched with
+`←` / `→` (or `h` / `l`): the heatmap answers *how much*, the feed answers
+*what*.
+
+#### Heatmap
+
+The last ~52 weeks of your contribution calendar, shaded on an accent-pink
+gradient that adapts to your own distribution (the busiest day always hits
+the full neon pink, the quiet days sit on the surface grey). Underneath:
 
 - **Total contributions** for the window
 - **Current streak** (how many consecutive days you've pushed)
 - **Longest streak** in the window
 - **Busiest day** with its date, so you know when you shipped the most
+
+#### Feed (v0.29.0+)
+
+A timeline of your recent events — pushes, pull requests opened and merged,
+reviews, issues, releases, branches created and deleted — newest first,
+across every repository at once. `enter` opens the row's subject on GitHub,
+`c` copies its link, `/` filters on anything the row shows (a repo name, a
+verb like `merged`, part of a title), and `r` reloads.
+
+Four things are worth knowing, because they are properties of GitHub's
+events API rather than choices:
+
+- **It is genuinely recent, not a history.** GitHub keeps a limited window
+  and octoscope reads one page of 100 events from it. On a busy account
+  that page can cover as little as two days. The line under the table always
+  names the span it actually got, and says when it is at the cap.
+- **Review and comment traffic on the same subject is folded into one row**
+  with a `×N` count, so a heavily-reviewed pull request does not bury
+  everything else. Only *adjacent* events on the *same* subject fold —
+  nothing is reordered — and anything that changed state (opened, merged,
+  closed, pushed, released, **approved**, changes requested) always keeps
+  its own line.
+- **Pull-request rows show a title when one can be found.** GitHub sends a
+  truncated pull-request object with no title in it; where the same page
+  contains a comment on that pull request, the title comes from there. When
+  it does not, the row shows the bare number rather than inventing a label.
+- **It loads when you open it**, not on every dashboard refresh — GitHub
+  asks callers to poll this endpoint no more than once a minute, and
+  `--refresh` goes as low as 5s.
+
+Under `--public-only` the feed asks GitHub's public-events endpoint, so
+events in private repositories are never fetched at all; toggling the mode
+with `p` mid-session drops them from what is already on screen. The
+visibility column only appears when there is a mix to distinguish.
 
 ### Live feedback
 
@@ -641,9 +682,10 @@ Key bindings while running:
 |-----|--------|
 | `1`-`7` | Jump to tab (Overview, Repos, PRs, Issues, Activity, Gists, What's new) |
 | `tab` / `shift+tab` | Cycle tabs forward / backward |
-| `↑` / `↓`, `j` / `k` | Move cursor in list tabs · scroll Overview / Activity when the body overflows the window |
+| `↑` / `↓`, `j` / `k` | Move cursor in list tabs and the Activity feed · scroll Overview / Activity heatmap when the body overflows the window |
 | `pgup` / `pgdn`, `u` / `d` | Page up / down on Overview & Activity (vertical scrolling) |
 | `space` | On Repos / PRs / Issues / Gists: open the action menu for the selected row · on Overview / Activity: page down |
+| `enter` (Activity feed) | Open the event's subject on GitHub — the pull request, issue, comment, release or compare view |
 | `g` / `G` | Jump to top / bottom |
 | `s` | Cycle sort column |
 | `/` | Filter by substring |
@@ -661,6 +703,7 @@ Key bindings while running:
 | `p` | Toggle public-only mode (saves to config) |
 | `,` | Open the in-app settings panel |
 | `?` | Open the keyboard-shortcut overlay (any key to dismiss) |
+| `←` / `→`, `h` / `l` | On the Activity tab: switch between the heatmap and the feed |
 | `←` / `→` | Cycle theme (when the Theme row is focused in the settings panel) |
 | `q` | Quit |
 | `ctrl+c` | Quit |

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -53,7 +53,7 @@
           <li><kbd>1</kbd> <b>Overview</b> — the dashboard above.</li>
           <li><kbd>2</kbd> <b>Repos</b> — every repository with its CI health, stars and last release.</li>
           <li><kbd>3</kbd> <b>PRs</b> and <kbd>4</kbd> <b>Issues</b> — what you've opened, plus review requests.</li>
-          <li><kbd>5</kbd> <b>Activity</b> — a 12-month contribution heatmap.</li>
+          <li><kbd>5</kbd> <b>Activity</b> — a 12-month contribution heatmap, and a feed of what you actually did.</li>
           <li><kbd>6</kbd> <b>What's new</b> — the running version's highlights, bundled offline.</li>
         </ul>
 

--- a/docs/guide/keybinds.html
+++ b/docs/guide/keybinds.html
@@ -72,11 +72,22 @@
         </table>
 
         <table class="keys">
-          <caption>Scrolling — Overview · Activity · drill-in body</caption>
+          <caption>Scrolling — Overview · Activity heatmap · drill-in body</caption>
           <tbody>
             <tr><td class="k"><kbd>↑</kbd><kbd>↓</kbd></td><td>Line up / down</td></tr>
             <tr><td class="k"><kbd>pgup</kbd> <kbd>pgdn</kbd> · <kbd>space</kbd></td><td>Page up / down</td></tr>
             <tr><td class="k"><kbd>u</kbd> · <kbd>d</kbd></td><td>Half-page up / down</td></tr>
+          </tbody>
+        </table>
+
+        <table class="keys">
+          <caption>Activity — heatmap and feed</caption>
+          <tbody>
+            <tr><td class="k"><kbd>←</kbd><kbd>→</kbd> · <kbd>h</kbd><kbd>l</kbd></td><td>Switch between the heatmap and the feed</td></tr>
+            <tr><td class="k"><kbd>↑</kbd><kbd>↓</kbd> · <kbd>g</kbd><kbd>G</kbd></td><td>Move the cursor in the feed · top / bottom</td></tr>
+            <tr><td class="k"><kbd>/</kbd></td><td>Filter the feed on anything a row shows</td></tr>
+            <tr><td class="k"><kbd>enter</kbd> · <kbd>c</kbd></td><td>Open the event on GitHub · copy its link</td></tr>
+            <tr><td class="k"><kbd>r</kbd></td><td>Reload the feed (it does not ride the dashboard refresh)</td></tr>
           </tbody>
         </table>
 

--- a/docs/guide/tabs.html
+++ b/docs/guide/tabs.html
@@ -64,13 +64,18 @@
         </div>
 
         <h2><kbd>5</kbd> Activity</h2>
-        <p>A 12-month contribution heatmap — the GitHub graph, in your terminal — plus the totals it implies: contributions, current streak, longest streak and busiest day. It honours the active theme (a pink gradient, or shades of the theme's own palette under a monochromatic one).</p>
+        <p>Two halves at different zoom levels, switched with <kbd>&larr;</kbd> / <kbd>&rarr;</kbd>. The <b>heatmap</b> answers <i>how much</i>; the <b>feed</b> answers <i>what</i>.</p>
+        <p><b>Heatmap</b> — a 12-month contribution graph, in your terminal, plus the totals it implies: contributions, current streak, longest streak and busiest day. It honours the active theme (a pink gradient, or shades of the theme's own palette under a monochromatic one).</p>
         <figure class="shot">
           <div class="frame">
             <div class="bar"><i></i><i></i><i></i><span class="ttl">octoscope — Activity</span></div>
             <img src="../screenshots/activity.png" alt="octoscope Activity tab: a 12-month contribution heatmap" loading="lazy" />
           </div>
         </figure>
+        <p><b>Feed</b> — the timeline underneath the graph: pushes, pull requests opened and merged, reviews, issues, releases, branches created and deleted, newest first, across every repository at once. <kbd>enter</kbd> opens the row's subject on GitHub, <kbd>c</kbd> copies its link, <kbd>/</kbd> filters on anything the row shows.</p>
+        <p>It is <b>recent, not a history</b>, and says so: GitHub keeps a limited window of events and octoscope reads one page of 100 from it — on a busy account that can be two days. The line under the table names the span it actually got.</p>
+        <p>Review and comment traffic on one subject is <b>folded into a single row</b> with a <code>&times;N</code> count, so a heavily-reviewed pull request does not bury the rest of the week. Only adjacent events on the same subject fold, nothing is reordered, and anything that changed state — including an <b>approval</b> — always keeps its own line. Pull-request rows carry a title when the same page contains a comment naming it; GitHub's own pull-request payload here has no title field at all, so where none can be found the row shows the bare number instead of inventing one.</p>
+        <p>The feed loads when you open it rather than on every refresh: GitHub asks callers to poll this endpoint no more than once a minute, and <code>--refresh</code> goes as low as 5s. Under <code>--public-only</code> it asks the public-events endpoint, so private-repository activity is never fetched at all.</p>
 
         <h2><kbd>6</kbd> Gists</h2>
         <p>Your gists, newest first — visibility, file count, stars and when each last changed. <kbd>enter</kbd> drills in: a multi-file gist shows its files, and <kbd>enter</kbd> again opens one; a <b>one-file gist opens straight into it</b>, because that is the only thing there was to see.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1316,7 +1316,7 @@
                 </div>
                 <div class="theme-carousel-slide">
                     <img src="screenshots/activity.png" alt="octoscope Activity tab: a 12-month contribution heatmap" />
-                    <div class="theme-carousel-caption"><strong>Activity</strong> — a 12-month contribution heatmap</div>
+                    <div class="theme-carousel-caption"><strong>Activity</strong> — a 12-month contribution heatmap, and a feed of what you actually did</div>
                 </div>
                 <div class="theme-carousel-slide">
                     <img src="screenshots/drill-in/screenshot-repo-detail.png" alt="octoscope repository drill-in with checks and a star-history sparkline" />

--- a/internal/github/events.go
+++ b/internal/github/events.go
@@ -245,7 +245,7 @@ func (c *Client) FetchEvents(ctx context.Context, login string) ([]Event, error)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, &FetchError{
-			Reason: classifyStatus(resp.StatusCode),
+			Reason: classifyStatus(resp.StatusCode, resp.Header),
 			Err:    fmt.Errorf("GitHub answered %d for the events feed", resp.StatusCode),
 		}
 	}
@@ -261,24 +261,41 @@ func (c *Client) FetchEvents(ctx context.Context, login string) ([]Event, error)
 // already speaks. Kept separate from classifyErr, which reads error strings
 // off the GraphQL transport and never has a status code to work with.
 //
-// 401 and 403 are split deliberately. They are the two a minimal token
-// actually hits, and the footer's advice differs: a rejected token is
-// re-authenticate, a scope gap is grant-the-scope. Collapsing them would
-// send half the affected users to the wrong fix.
-func classifyStatus(code int) FetchErrorReason {
+// **403 is the whole reason this takes headers.** GitHub overloads it for
+// three unrelated conditions — the token lacks a scope, the hourly budget
+// is spent, or a secondary throttle fired — and the advice for each is
+// different enough that guessing sends people to the wrong fix. The headers
+// separate them exactly, and unlike matching on the body's wording they are
+// machine-readable and stable:
+//
+//   - `Retry-After` is only sent for a secondary throttle, and it says how
+//     long to wait, so it is checked first.
+//   - `X-RateLimit-Remaining: 0` on a 403 means the hourly budget is gone.
+//     Measured live against this endpoint, which sends the full
+//     X-RateLimit-* set on every response.
+//   - Neither present on a 403 is a permission problem, which is the
+//     likeliest one for a read-only feed.
+//
+// 401 stays separate from all of them: a rejected token is
+// re-authenticate, not grant-a-scope.
+func classifyStatus(code int, h http.Header) FetchErrorReason {
 	switch code {
 	case http.StatusUnauthorized:
 		return ReasonAuth
-	case http.StatusForbidden:
-		// Also what GitHub returns when the REST budget is spent. The two
-		// are distinguishable only by the body, and the secondary-throttle
-		// message is the wrong advice for a scope gap, so this stays on
-		// the scope reading — the far likelier one for a read-only feed.
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		if h.Get("Retry-After") != "" {
+			return ReasonRateLimitSecondary
+		}
+		if h.Get("X-RateLimit-Remaining") == "0" {
+			return ReasonRateLimitPrimary
+		}
+		if code == http.StatusTooManyRequests {
+			// 429 is never a permission problem, whatever the headers say.
+			return ReasonRateLimitSecondary
+		}
 		return ReasonAuthScope
 	case http.StatusNotFound:
 		return ReasonNotFound
-	case http.StatusTooManyRequests:
-		return ReasonRateLimitSecondary
 	}
 	if code >= 500 {
 		return ReasonServer

--- a/internal/github/events.go
+++ b/internal/github/events.go
@@ -1,0 +1,485 @@
+package github
+
+// Events — the "what happened" half of Activity (#71). The heatmap
+// answers *how much*; this answers *what*, as a timeline of the account's
+// last N public/private events.
+//
+// **This is REST, and it is the only list in the dashboard that is.**
+// There is no GraphQL equivalent — the v4 schema exposes contribution
+// *counts*, not the event stream — so the endpoint is
+// `/users/{login}/events`, and everything below is shaped by what that
+// endpoint actually returns rather than by what its documentation says.
+// Three measured facts drove the design (all against the live API on
+// 2026-08-08):
+//
+//  1. **`payload.pull_request` is truncated to `{base, head, id, number,
+//     url}`.** No `title`, no `html_url`, no `merged`. GitHub's reference
+//     still documents the full pull-request object; the feed does not send
+//     it. So a PR line can name the number and not the title, and its HTML
+//     URL has to be *derived*. `payload.issue`, by contrast, arrives whole
+//     — title included. That asymmetry is GitHub's, and the UI states it
+//     rather than papering over it with a fetched-later title.
+//
+//  2. **`PushEvent.payload` carries no `commits` and no `size`** — only
+//     `before`, `head`, `push_id`, `ref`, `repository_id`. Again, still
+//     documented, not sent. A push row therefore names the branch and
+//     links to the compare view; it cannot show a commit message, and it
+//     must not pretend to know how many commits there were.
+//
+//  3. **Pagination hard-stops at 3 pages.** `page=4` is an HTTP 422, not an
+//     empty list. Irrelevant to us — one page is what we ask for — but it
+//     is the reason this file never grows a paging loop.
+//
+// The window is short and that is inherent: GitHub keeps roughly 90 days of
+// events, and one page of 100 covered **barely two days** on the account
+// this was measured against. The UI shows the span it actually got rather
+// than implying it is a history.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// eventsPageSize bounds one fetch. Deliberately a single page, for the
+// same reason gists are: paging is unbounded work, and GitHub caps this
+// resource at three pages anyway.
+const eventsPageSize = 100
+
+// EventsPageSize is the cap the UI discloses. Exported so the feed header
+// can say "showing the last 100" without hard-coding a second copy of the
+// number that would drift the moment this one changed.
+const EventsPageSize = eventsPageSize
+
+// Event is one entry in the account's activity feed.
+//
+// The fields are **raw facts, not a rendered sentence**. Phrasing lives in
+// the UI, which is the same rule Gist.Description follows: a display string
+// invented here would end up in machine-readable output as a value GitHub
+// never returned. Type and Action are GitHub's own vocabulary, verbatim.
+type Event struct {
+	// ID is GitHub's event id — unique, and the stable key for a row.
+	ID string
+
+	// Type is the event type verbatim ("PushEvent", "IssuesEvent", ...).
+	// Kept as a string rather than an enum because the set is open: GitHub
+	// adds types, and an unknown one must still render as a dated line in
+	// the right repo instead of vanishing.
+	Type string
+
+	// Repo is "owner/name" as the event reports it. Note this is the repo's
+	// name *at event time* — a later rename is not reflected, and GitHub
+	// redirects the URL, so the link still resolves.
+	Repo string
+
+	// CreatedAt is when GitHub recorded the event, in UTC.
+	CreatedAt time.Time
+
+	// IsPublic mirrors the event's `public` flag, which is false for
+	// anything that happened in a private repository. It is the privacy
+	// signal for screenshot mode — see visibleEvents in the ui package.
+	IsPublic bool
+
+	// Action is payload.action verbatim when the type has one ("opened",
+	// "closed", "merged", "created", "published", "assigned"), otherwise
+	// empty. Worth knowing: PullRequestEvent emits a literal "merged"
+	// action in this feed, which the reference does not list — it
+	// documents "closed" plus a merged flag. Both are handled.
+	//
+	// **One deliberate exception**: for PullRequestReviewEvent this holds
+	// the *review state* ("approved", "changes_requested", "commented")
+	// rather than the action. The action there was "created" on all 20
+	// review events in the measured sample, and it is created-only by
+	// construction — a field with one value carries nothing, while the
+	// difference between an approval and a drive-by comment is the most
+	// significant thing a review row can say.
+	Action string
+
+	// Ref is the short branch or tag name for Push / Create / Delete, and
+	// the tag for a Release. RefType is "branch", "tag" or "repository"
+	// for Create / Delete, and empty elsewhere — a release's ref is a tag
+	// by definition, so the type carries no information there.
+	Ref     string
+	RefType string
+
+	// Number is the issue or pull-request number the event is about, 0 when
+	// the event has no numbered subject (a push, a star, a fork).
+	Number int
+
+	// IsPullRequest distinguishes the two things a number can name.
+	// GitHub files pull-request comments under the *issue* shape, so an
+	// IssueCommentEvent is about a PR as often as an issue and the type
+	// alone cannot tell them apart — `payload.issue.pull_request` is what
+	// separates them, and without it the UI would label half its comment
+	// rows wrong.
+	IsPullRequest bool
+
+	// Title is the subject's title, and it arrives by two routes.
+	//
+	// An issue event carries its own (payload.issue is sent whole). A pull
+	// request event does not — the truncated payload has no title field at
+	// all, see the file comment — so it is **filled in from a sibling event
+	// in the same page** whenever one names the same repo and number.
+	// Comment events on a PR do carry the title, because GitHub files PR
+	// comments under the issue shape, and on any account busy enough to
+	// have PR events there is usually a comment event beside them.
+	//
+	// It is never backfilled with a *request*: one row is not worth a round
+	// trip and a hundred is a rate-limit incident. Empty therefore means
+	// "nothing in this page knew it", and the UI shows the bare number
+	// rather than inventing anything.
+	Title string
+
+	// URL is where the event's subject lives on github.com. Derived when
+	// the payload has no html_url of its own (pushes, PR events), taken
+	// verbatim when it does (issues, comments, reviews, releases).
+	URL string
+}
+
+// eventJSON is the wire shape. Only the fields actually read are declared;
+// the payload is a union across event types, so every sub-object is a
+// pointer and each extractor checks its own.
+type eventJSON struct {
+	ID        string    `json:"id"`
+	Type      string    `json:"type"`
+	Public    bool      `json:"public"`
+	CreatedAt time.Time `json:"created_at"`
+	Repo      struct {
+		Name string `json:"name"`
+	} `json:"repo"`
+	Payload struct {
+		Action  string `json:"action"`
+		Ref     string `json:"ref"`
+		RefType string `json:"ref_type"`
+		Before  string `json:"before"`
+		Head    string `json:"head"`
+		Number  int    `json:"number"`
+
+		PullRequest *struct {
+			Number int `json:"number"`
+		} `json:"pull_request"`
+
+		Issue *struct {
+			Number  int    `json:"number"`
+			Title   string `json:"title"`
+			HTMLURL string `json:"html_url"`
+			// Present only when the "issue" is really a pull request.
+			// A bare presence check — the object inside holds API URLs
+			// this package has no use for.
+			PullRequest *struct{} `json:"pull_request"`
+		} `json:"issue"`
+
+		Comment *struct {
+			HTMLURL string `json:"html_url"`
+		} `json:"comment"`
+
+		Review *struct {
+			State   string `json:"state"`
+			HTMLURL string `json:"html_url"`
+		} `json:"review"`
+
+		Release *struct {
+			TagName string `json:"tag_name"`
+			HTMLURL string `json:"html_url"`
+		} `json:"release"`
+
+		Forkee *struct {
+			FullName string `json:"full_name"`
+			HTMLURL  string `json:"html_url"`
+		} `json:"forkee"`
+	} `json:"payload"`
+}
+
+// FetchEvents returns the account's most recent events, newest first.
+//
+// **Privacy is the endpoint, not a filter** — the same rule gists follow.
+// Under --public-only this asks `/events/public`, so events in private
+// repositories are never fetched at all rather than fetched and dropped.
+// That distinction is the whole point of screenshot mode: measured on a
+// real account, 46 of 100 events on the default endpoint were `public:
+// false`, and the very first one named a private repository in a field the
+// UI would otherwise have to remember not to draw.
+//
+// `login` is required — unlike every GraphQL query in this package there is
+// no `viewer` form of this endpoint, only `/users/{login}/events`. The
+// caller passes the login the dashboard resolved, which is why this is
+// fetched when the feed is opened rather than alongside the profile that
+// discovers it.
+//
+// Fetched on demand, once per open, deliberately: the response carries
+// `X-Poll-Interval: 60`, and octoscope's refresh floor is 5s. Riding the
+// dashboard refresh would let a user who set `--refresh 5s` poll this
+// endpoint twelve times faster than GitHub asks — for a tab they may never
+// open.
+func (c *Client) FetchEvents(ctx context.Context, login string) ([]Event, error) {
+	login = strings.TrimSpace(login)
+	if login == "" {
+		return nil, &FetchError{
+			Reason: ReasonUnknown,
+			Err:    errors.New("events need a login and none was resolved"),
+		}
+	}
+
+	path := "/users/" + login + "/events"
+	if c.publicOnly {
+		path += "/public"
+	}
+	url := fmt.Sprintf("https://api.github.com%s?per_page=%d", path, eventsPageSize)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, &FetchError{Reason: ReasonUnknown, Err: err}
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.rest.Do(req)
+	if err != nil {
+		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &FetchError{
+			Reason: classifyStatus(resp.StatusCode),
+			Err:    fmt.Errorf("GitHub answered %d for the events feed", resp.StatusCode),
+		}
+	}
+
+	var raw []eventJSON
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, &FetchError{Reason: ReasonUnknown, Err: err}
+	}
+	return extractEvents(raw), nil
+}
+
+// classifyStatus maps a REST status onto the reason vocabulary the footer
+// already speaks. Kept separate from classifyErr, which reads error strings
+// off the GraphQL transport and never has a status code to work with.
+//
+// 401 and 403 are split deliberately. They are the two a minimal token
+// actually hits, and the footer's advice differs: a rejected token is
+// re-authenticate, a scope gap is grant-the-scope. Collapsing them would
+// send half the affected users to the wrong fix.
+func classifyStatus(code int) FetchErrorReason {
+	switch code {
+	case http.StatusUnauthorized:
+		return ReasonAuth
+	case http.StatusForbidden:
+		// Also what GitHub returns when the REST budget is spent. The two
+		// are distinguishable only by the body, and the secondary-throttle
+		// message is the wrong advice for a scope gap, so this stays on
+		// the scope reading — the far likelier one for a read-only feed.
+		return ReasonAuthScope
+	case http.StatusNotFound:
+		return ReasonNotFound
+	case http.StatusTooManyRequests:
+		return ReasonRateLimitSecondary
+	}
+	if code >= 500 {
+		return ReasonServer
+	}
+	return ReasonUnknown
+}
+
+// extractEvents is the pure half, so the per-type mapping is testable
+// against recorded payloads without a transport.
+//
+// Every string crosses Sanitize at this boundary, which is where the
+// package cleans GitHub-sourced text. It is not theoretical here: an issue
+// title is written by whoever opened the issue, in any repository the
+// account touched, and it is about to be drawn into a terminal.
+func extractEvents(raw []eventJSON) []Event {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]Event, 0, len(raw))
+	for _, r := range raw {
+		repo := Sanitize(r.Repo.Name)
+		e := Event{
+			ID:        Sanitize(r.ID),
+			Type:      Sanitize(r.Type),
+			Repo:      repo,
+			CreatedAt: r.CreatedAt.UTC(),
+			IsPublic:  r.Public,
+			Action:    Sanitize(r.Payload.Action),
+			RefType:   Sanitize(r.Payload.RefType),
+			Ref:       shortRef(Sanitize(r.Payload.Ref)),
+		}
+		if r.Payload.Issue != nil {
+			e.Number = r.Payload.Issue.Number
+			e.Title = Sanitize(r.Payload.Issue.Title)
+			e.IsPullRequest = r.Payload.Issue.PullRequest != nil
+		}
+		// A release's identity is its tag, and there is no other field on
+		// Event that means "the thing this is about" for a type with no
+		// number. Ref is that field for Push / Create / Delete already.
+		if r.Payload.Release != nil && e.Ref == "" {
+			e.Ref = Sanitize(r.Payload.Release.TagName)
+		}
+		// Reviews: prefer the state over the always-"created" action. See
+		// the Action doc comment.
+		if r.Type == "PullRequestReviewEvent" && r.Payload.Review != nil {
+			if st := Sanitize(r.Payload.Review.State); st != "" {
+				e.Action = st
+			}
+		}
+		if r.Payload.PullRequest != nil && r.Payload.PullRequest.Number != 0 {
+			e.Number = r.Payload.PullRequest.Number
+			e.IsPullRequest = true
+		}
+		if e.Number == 0 && r.Payload.Number != 0 {
+			e.Number = r.Payload.Number
+		}
+		e.URL = eventURL(r, repo, e.Number)
+		out = append(out, e)
+	}
+	return backfillTitles(out)
+}
+
+// backfillTitles copies each subject's title onto the events about that
+// subject that did not get one.
+//
+// This exists because of the truncation documented at the top of the file:
+// a PullRequestEvent has no title, while an IssueCommentEvent on the very
+// same pull request has one, because GitHub files PR comments under the
+// issue shape. The page already contains the answer — it is just attached
+// to a different row.
+//
+// The join key is repo + number, which is unambiguous: GitHub numbers
+// issues and pull requests from one sequence per repository, so #123 is
+// one object, never two. Nothing is invented and nothing is fetched — a
+// row with no match in the page keeps its empty title.
+func backfillTitles(events []Event) []Event {
+	titles := make(map[string]string)
+	for _, e := range events {
+		if e.Title == "" || e.Number == 0 {
+			continue
+		}
+		key := fmt.Sprintf("%s#%d", e.Repo, e.Number)
+		if _, seen := titles[key]; !seen {
+			titles[key] = e.Title
+		}
+	}
+	if len(titles) == 0 {
+		return events
+	}
+	for i := range events {
+		if events[i].Title != "" || events[i].Number == 0 {
+			continue
+		}
+		if t, ok := titles[fmt.Sprintf("%s#%d", events[i].Repo, events[i].Number)]; ok {
+			events[i].Title = t
+			// A sibling that knew the title also knew what kind of object
+			// it was. Only a pull request reaches this branch: an issue
+			// event already carried its own title and never needs the join.
+			events[i].IsPullRequest = true
+		}
+	}
+	return events
+}
+
+// shortRef strips the `refs/heads/` or `refs/tags/` prefix a PushEvent's
+// ref carries. Create and Delete already send the short form, so this has
+// to be a trim rather than a split: a branch legitimately named
+// `refs/heads/x` would otherwise lose a segment.
+func shortRef(ref string) string {
+	for _, p := range []string{"refs/heads/", "refs/tags/"} {
+		if strings.HasPrefix(ref, p) {
+			return strings.TrimPrefix(ref, p)
+		}
+	}
+	return ref
+}
+
+// repoHTMLURL builds the browser URL for an "owner/name" pair. The events
+// API only ever sends the API URL (api.github.com/repos/...), which is not
+// something to open in a browser.
+func repoHTMLURL(repo string) string {
+	if repo == "" {
+		return ""
+	}
+	return "https://github.com/" + repo
+}
+
+// zeroSHA is what `before` holds when a push created the branch — there is
+// no previous commit to compare against.
+const zeroSHA = "0000000000000000000000000000000000000000"
+
+// eventURL picks the most specific github.com URL the event's payload
+// supports, preferring one GitHub sent over one we construct.
+//
+// Where a URL is constructed it is from GitHub's own identifiers (the repo
+// slug, an integer number, a commit SHA) rather than from free text, which
+// is what keeps the result a github.com URL. The UI gates every open on
+// isSafeOpenURL regardless — this function is not the security boundary,
+// it is the correctness one.
+func eventURL(r eventJSON, repo string, number int) string {
+	base := repoHTMLURL(repo)
+	if base == "" {
+		return ""
+	}
+
+	// Payload-supplied URLs first: these are exact, and cover comments,
+	// reviews, issues, releases and forks.
+	switch {
+	case r.Payload.Comment != nil && r.Payload.Comment.HTMLURL != "":
+		return Sanitize(r.Payload.Comment.HTMLURL)
+	case r.Payload.Review != nil && r.Payload.Review.HTMLURL != "":
+		return Sanitize(r.Payload.Review.HTMLURL)
+	case r.Payload.Release != nil && r.Payload.Release.HTMLURL != "":
+		return Sanitize(r.Payload.Release.HTMLURL)
+	case r.Payload.Forkee != nil && r.Payload.Forkee.HTMLURL != "":
+		return Sanitize(r.Payload.Forkee.HTMLURL)
+	case r.Type == "IssuesEvent" && r.Payload.Issue != nil && r.Payload.Issue.HTMLURL != "":
+		return Sanitize(r.Payload.Issue.HTMLURL)
+	}
+
+	switch r.Type {
+	case "PushEvent":
+		before, head := Sanitize(r.Payload.Before), Sanitize(r.Payload.Head)
+		if head == "" {
+			return base
+		}
+		// A push that created the branch has no `before` to compare
+		// against, so link at the branch's commit list instead of building
+		// a compare URL against the zero SHA (which 404s).
+		if before == "" || before == zeroSHA {
+			if ref := shortRef(Sanitize(r.Payload.Ref)); ref != "" {
+				return base + "/commits/" + ref
+			}
+			return base + "/commit/" + head
+		}
+		return base + "/compare/" + before + "..." + head
+
+	case "PullRequestEvent", "PullRequestReviewEvent", "PullRequestReviewCommentEvent":
+		// Derived, because the truncated pull_request object has no
+		// html_url — see the file comment.
+		if number > 0 {
+			return fmt.Sprintf("%s/pull/%d", base, number)
+		}
+
+	case "CreateEvent":
+		ref := shortRef(Sanitize(r.Payload.Ref))
+		switch r.Payload.RefType {
+		case "branch":
+			if ref != "" {
+				return base + "/tree/" + ref
+			}
+		case "tag":
+			if ref != "" {
+				return base + "/releases/tag/" + ref
+			}
+		}
+
+	case "DeleteEvent":
+		// The ref is gone, so there is nothing specific left to link to.
+		return base
+	}
+
+	return base
+}

--- a/internal/github/events_test.go
+++ b/internal/github/events_test.go
@@ -1,0 +1,406 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The fixtures below are the *shapes* the live API returned on
+// 2026-08-08, with repository and account names replaced. The shapes are
+// the point — several of them contradict GitHub's published reference,
+// and a test written from the docs instead of the wire would have locked
+// in fields that never arrive.
+
+const pushEventJSON = `{
+  "id":"17119310465","type":"PushEvent","public":true,
+  "created_at":"2026-08-08T10:18:51Z",
+  "repo":{"name":"octocat/hello-world"},
+  "payload":{"before":"c3d9847e7b1c983b2081ecaea63db85ae19a0f54",
+             "head":"9ef24dcdc5ee3a9c984d45002e83c94a77135173",
+             "push_id":39436460914,"ref":"refs/heads/main","repository_id":1}
+}`
+
+// The pull_request object as it actually arrives: five fields, no title,
+// no html_url. This fixture is the executable record of that finding.
+const prEventJSON = `{
+  "id":"17119000001","type":"PullRequestEvent","public":true,
+  "created_at":"2026-08-08T09:52:00Z",
+  "repo":{"name":"octocat/hello-world"},
+  "payload":{"action":"merged","number":123,
+             "pull_request":{"base":{},"head":{},"id":99,"number":123,
+                             "url":"https://api.github.com/repos/octocat/hello-world/pulls/123"}}
+}`
+
+const issuesEventJSON = `{
+  "id":"17118000002","type":"IssuesEvent","public":true,
+  "created_at":"2026-08-08T09:30:00Z",
+  "repo":{"name":"octocat/hello-world"},
+  "payload":{"action":"closed",
+             "issue":{"number":76,"title":"Gists section",
+                      "html_url":"https://github.com/octocat/hello-world/issues/76"}}
+}`
+
+const issueCommentEventJSON = `{
+  "id":"17117000003","type":"IssueCommentEvent","public":true,
+  "created_at":"2026-08-08T08:14:00Z",
+  "repo":{"name":"octocat/hello-world"},
+  "payload":{"action":"created",
+             "issue":{"number":123,"title":"feat(gists): the Gists tab",
+                      "html_url":"https://github.com/octocat/hello-world/pull/123"},
+             "comment":{"html_url":"https://github.com/octocat/hello-world/pull/123#issuecomment-5225673218"}}
+}`
+
+const reviewEventJSON = `{
+  "id":"17116000004","type":"PullRequestReviewEvent","public":true,
+  "created_at":"2026-08-08T08:00:00Z",
+  "repo":{"name":"octocat/hello-world"},
+  "payload":{"action":"created",
+             "pull_request":{"id":99,"number":123,
+                             "url":"https://api.github.com/repos/octocat/hello-world/pulls/123"},
+             "review":{"state":"commented",
+                       "html_url":"https://github.com/octocat/hello-world/pull/123#pullrequestreview-4888623480"}}
+}`
+
+const releaseEventJSON = `{
+  "id":"17115000005","type":"ReleaseEvent","public":false,
+  "created_at":"2026-08-07T18:00:00Z",
+  "repo":{"name":"acme/private-thing"},
+  "payload":{"action":"published",
+             "release":{"tag_name":"v26.4.0-rc.0","name":"v26.4.0-rc.0",
+                        "html_url":"https://github.com/acme/private-thing/releases/tag/v26.4.0-rc.0"}}
+}`
+
+const createBranchEventJSON = `{
+  "id":"17114000006","type":"CreateEvent","public":true,
+  "created_at":"2026-08-07T12:00:00Z",
+  "repo":{"name":"octocat/hello-world"},
+  "payload":{"ref":"docs/next-version-script-trap","ref_type":"branch",
+             "master_branch":"main","pusher_type":"user"}
+}`
+
+const deleteBranchEventJSON = `{
+  "id":"17113000007","type":"DeleteEvent","public":true,
+  "created_at":"2026-08-07T11:00:00Z",
+  "repo":{"name":"octocat/hello-world"},
+  "payload":{"ref":"feat/gists-tab","ref_type":"branch","pusher_type":"user"}
+}`
+
+func decodeOne(t *testing.T, body string) Event {
+	t.Helper()
+	events := decodeMany(t, "["+body+"]")
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	return events[0]
+}
+
+// decodeMany drives the real decode path — json into eventJSON, then
+// extractEvents — so a struct tag typo fails the test rather than
+// silently producing a zero value.
+func decodeMany(t *testing.T, body string) []Event {
+	t.Helper()
+	c := newEventsClient(t, http.StatusOK, body, nil)
+	events, err := c.FetchEvents(context.Background(), "octocat")
+	if err != nil {
+		t.Fatalf("FetchEvents: %v", err)
+	}
+	return events
+}
+
+// newEventsClient serves one canned response and records the path it was
+// asked for, which is what the privacy test asserts on.
+func newEventsClient(t *testing.T, code int, body string, gotPath *string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotPath != nil {
+			*gotPath = r.URL.Path
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return &Client{
+		rest:          &http.Client{Transport: &rewriteHost{host: srv.URL}},
+		authenticated: true,
+	}
+}
+
+func TestExtractEventsPerType(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantTyp string
+		wantNum int
+		wantTtl string
+		wantAct string
+		wantRef string
+		wantURL string
+	}{
+		{
+			name: "push links to the compare view and shortens the ref",
+			json: pushEventJSON, wantTyp: "PushEvent", wantRef: "main",
+			wantURL: "https://github.com/octocat/hello-world/compare/" +
+				"c3d9847e7b1c983b2081ecaea63db85ae19a0f54...9ef24dcdc5ee3a9c984d45002e83c94a77135173",
+		},
+		{
+			name: "pull request: number survives, title does not exist, url is derived",
+			json: prEventJSON, wantTyp: "PullRequestEvent", wantNum: 123, wantAct: "merged",
+			wantURL: "https://github.com/octocat/hello-world/pull/123",
+		},
+		{
+			name: "issue carries its own title and html_url",
+			json: issuesEventJSON, wantTyp: "IssuesEvent", wantNum: 76,
+			wantTtl: "Gists section", wantAct: "closed",
+			wantURL: "https://github.com/octocat/hello-world/issues/76",
+		},
+		{
+			name: "issue comment prefers the comment anchor over the issue",
+			json: issueCommentEventJSON, wantTyp: "IssueCommentEvent", wantNum: 123,
+			wantTtl: "feat(gists): the Gists tab", wantAct: "created",
+			wantURL: "https://github.com/octocat/hello-world/pull/123#issuecomment-5225673218",
+		},
+		{
+			name: "review prefers the review anchor and reports its state, not the action",
+			json: reviewEventJSON, wantTyp: "PullRequestReviewEvent", wantNum: 123, wantAct: "commented",
+			wantURL: "https://github.com/octocat/hello-world/pull/123#pullrequestreview-4888623480",
+		},
+		{
+			name: "release uses the release html_url and carries its tag as the ref",
+			json: releaseEventJSON, wantTyp: "ReleaseEvent", wantAct: "published",
+			wantRef: "v26.4.0-rc.0",
+			wantURL: "https://github.com/acme/private-thing/releases/tag/v26.4.0-rc.0",
+		},
+		{
+			name: "created branch links at the tree",
+			json: createBranchEventJSON, wantTyp: "CreateEvent", wantRef: "docs/next-version-script-trap",
+			wantURL: "https://github.com/octocat/hello-world/tree/docs/next-version-script-trap",
+		},
+		{
+			name: "deleted branch has nothing left to link to but the repo",
+			json: deleteBranchEventJSON, wantTyp: "DeleteEvent", wantRef: "feat/gists-tab",
+			wantURL: "https://github.com/octocat/hello-world",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := decodeOne(t, tc.json)
+			if e.Type != tc.wantTyp {
+				t.Errorf("Type = %q, want %q", e.Type, tc.wantTyp)
+			}
+			if e.Number != tc.wantNum {
+				t.Errorf("Number = %d, want %d", e.Number, tc.wantNum)
+			}
+			if e.Title != tc.wantTtl {
+				t.Errorf("Title = %q, want %q", e.Title, tc.wantTtl)
+			}
+			if e.Action != tc.wantAct {
+				t.Errorf("Action = %q, want %q", e.Action, tc.wantAct)
+			}
+			if e.Ref != tc.wantRef {
+				t.Errorf("Ref = %q, want %q", e.Ref, tc.wantRef)
+			}
+			if e.URL != tc.wantURL {
+				t.Errorf("URL  = %q\nwant  = %q", e.URL, tc.wantURL)
+			}
+			if e.ID == "" {
+				t.Error("ID is empty — the row would have no stable key")
+			}
+			if e.CreatedAt.IsZero() {
+				t.Error("CreatedAt is zero — created_at did not decode")
+			}
+		})
+	}
+}
+
+// The measured truncation, locked in. If GitHub ever starts sending the
+// full pull_request object this fails, which is the correct outcome: the
+// UI's "no title for PRs" copy would then be a lie and needs revisiting.
+func TestPullRequestPayloadCarriesNoTitle(t *testing.T) {
+	e := decodeOne(t, prEventJSON)
+	if e.Title != "" {
+		t.Fatalf("PullRequestEvent now carries a title (%q) — GitHub changed the "+
+			"payload; revisit the UI copy that says PR rows have none", e.Title)
+	}
+	if !strings.HasSuffix(e.URL, "/pull/123") {
+		t.Fatalf("URL = %q, want it derived from repo + number", e.URL)
+	}
+}
+
+func TestPushEventOnANewBranchAvoidsTheZeroSHACompare(t *testing.T) {
+	const newBranch = `{
+      "id":"1","type":"PushEvent","public":true,
+      "created_at":"2026-08-08T10:00:00Z",
+      "repo":{"name":"octocat/hello-world"},
+      "payload":{"before":"0000000000000000000000000000000000000000",
+                 "head":"abc123","ref":"refs/heads/feat/new"}
+    }`
+	e := decodeOne(t, newBranch)
+	want := "https://github.com/octocat/hello-world/commits/feat/new"
+	if e.URL != want {
+		t.Errorf("URL = %q, want %q (a compare against the zero SHA 404s)", e.URL, want)
+	}
+}
+
+// An issue title is written by whoever opened the issue, in any repo the
+// account touched, and lands in a terminal. Sanitize is the boundary.
+//
+// The escape arrives as `\u001b`, not as a raw byte, and that is not a
+// convenience for the fixture: JSON forbids raw control characters inside
+// string literals, so encoding/json would reject the response outright.
+// GitHub therefore always sends the \u form and the raw byte only exists
+// after the decode — which is exactly why Sanitize runs here, on the
+// decoded value, rather than over the response body.
+func TestExtractEventsSanitizesGitHubText(t *testing.T) {
+	body := `{"id":"1","type":"IssuesEvent","public":true,
+      "created_at":"2026-08-08T10:00:00Z",
+      "repo":{"name":"octocat/hello-world"},
+      "payload":{"action":"opened",
+                 "issue":{"number":1,"title":"real\u001b]0;pwned\u0007title",
+                          "html_url":"https://github.com/octocat/hello-world/issues/1"}}}`
+	e := decodeOne(t, body)
+	if strings.Contains(e.Title, "\x1b") {
+		t.Errorf("Title kept an escape sequence: %q", e.Title)
+	}
+	// The whole OSC goes, payload included. That is the part that matters:
+	// `ESC ] 0 ; ... BEL` retitles the user's terminal window, so leaving
+	// "pwned" behind while dropping the introducer would still hand an
+	// issue author a line of someone else's screen.
+	if strings.Contains(e.Title, "pwned") {
+		t.Errorf("Title kept the OSC payload: %q", e.Title)
+	}
+	if e.Title != "realtitle" {
+		t.Errorf("Title = %q, want %q", e.Title, "realtitle")
+	}
+}
+
+// The privacy invariant, and the reason it is an endpoint rather than a
+// filter: under public-only the private events are never fetched, so
+// there is nothing in memory to leak on the next paint.
+func TestFetchEventsPublicOnlyAsksTheOtherEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		publicOnly bool
+		wantPath   string
+	}{
+		{false, "/users/octocat/events"},
+		{true, "/users/octocat/events/public"},
+	} {
+		var got string
+		c := newEventsClient(t, http.StatusOK, "[]", &got)
+		c.publicOnly = tc.publicOnly
+		if _, err := c.FetchEvents(context.Background(), "octocat"); err != nil {
+			t.Fatalf("publicOnly=%v: %v", tc.publicOnly, err)
+		}
+		if got != tc.wantPath {
+			t.Errorf("publicOnly=%v asked for %q, want %q", tc.publicOnly, got, tc.wantPath)
+		}
+	}
+}
+
+func TestFetchEventsNeedsALogin(t *testing.T) {
+	c := newEventsClient(t, http.StatusOK, "[]", nil)
+	for _, login := range []string{"", "   "} {
+		if _, err := c.FetchEvents(context.Background(), login); err == nil {
+			t.Errorf("login %q was accepted; the endpoint has no viewer form", login)
+		}
+	}
+}
+
+func TestFetchEventsClassifiesFailures(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want FetchErrorReason
+	}{
+		{http.StatusUnauthorized, ReasonAuth},
+		{http.StatusForbidden, ReasonAuthScope},
+		{http.StatusNotFound, ReasonNotFound},
+		{http.StatusTooManyRequests, ReasonRateLimitSecondary},
+		{http.StatusBadGateway, ReasonServer},
+		{http.StatusTeapot, ReasonUnknown},
+	} {
+		c := newEventsClient(t, tc.code, `{"message":"nope"}`, nil)
+		_, err := c.FetchEvents(context.Background(), "octocat")
+		var fe *FetchError
+		if !errors.As(err, &fe) {
+			t.Fatalf("status %d: want a *FetchError, got %v", tc.code, err)
+		}
+		if fe.Reason != tc.want {
+			t.Errorf("status %d classified as %v, want %v", tc.code, fe.Reason, tc.want)
+		}
+	}
+}
+
+func TestShortRefTrimsOnlyTheRefspecPrefix(t *testing.T) {
+	for in, want := range map[string]string{
+		"refs/heads/main":             "main",
+		"refs/tags/v1.0.0":            "v1.0.0",
+		"main":                        "main",
+		"":                            "",
+		"refs/heads/refs/heads/weird": "refs/heads/weird",
+	} {
+		if got := shortRef(in); got != want {
+			t.Errorf("shortRef(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// An unrecognised type must still produce a usable row — GitHub adds event
+// types, and a feed that dropped them would silently under-report.
+func TestUnknownEventTypeStillLandsOnTheRepo(t *testing.T) {
+	const future = `{"id":"1","type":"SomeFutureEvent","public":true,
+      "created_at":"2026-08-08T10:00:00Z",
+      "repo":{"name":"octocat/hello-world"},"payload":{}}`
+	e := decodeOne(t, future)
+	if e.Type != "SomeFutureEvent" {
+		t.Errorf("Type = %q, want it kept verbatim", e.Type)
+	}
+	if e.URL != "https://github.com/octocat/hello-world" {
+		t.Errorf("URL = %q, want the repo as the fallback", e.URL)
+	}
+}
+
+func TestExtractEventsEmpty(t *testing.T) {
+	if got := extractEvents(nil); got != nil {
+		t.Errorf("extractEvents(nil) = %v, want nil", got)
+	}
+}
+
+// A review's action is "created" on every review event GitHub sends, so
+// the state is the only thing that separates an approval from a comment.
+func TestReviewEventReportsItsState(t *testing.T) {
+	approved := strings.Replace(reviewEventJSON, `"state":"commented"`, `"state":"approved"`, 1)
+	if e := decodeOne(t, approved); e.Action != "approved" {
+		t.Errorf("Action = %q, want %q", e.Action, "approved")
+	}
+}
+
+// The join that turns a bare "PR #123" into a titled row, using only what
+// the page already contains.
+func TestBackfillTitlesFillsPullRequestsFromSiblingComments(t *testing.T) {
+	events := decodeMany(t, "["+prEventJSON+","+issueCommentEventJSON+"]")
+	if len(events) != 2 {
+		t.Fatalf("got %d events", len(events))
+	}
+	const want = "feat(gists): the Gists tab"
+	if events[0].Title != want {
+		t.Errorf("PullRequestEvent title = %q, want it backfilled to %q", events[0].Title, want)
+	}
+	if events[1].Title != want {
+		t.Errorf("IssueCommentEvent lost its own title: %q", events[1].Title)
+	}
+}
+
+// Nothing is invented: without a sibling naming the same repo and number,
+// the title stays empty and the UI shows the bare number.
+func TestBackfillTitlesInventsNothing(t *testing.T) {
+	otherRepo := strings.ReplaceAll(issueCommentEventJSON, "octocat/hello-world", "octocat/elsewhere")
+	events := decodeMany(t, "["+prEventJSON+","+otherRepo+"]")
+	if events[0].Title != "" {
+		t.Errorf("title crossed repositories: %q", events[0].Title)
+	}
+}

--- a/internal/github/events_test.go
+++ b/internal/github/events_test.go
@@ -50,7 +50,8 @@ const issueCommentEventJSON = `{
   "repo":{"name":"octocat/hello-world"},
   "payload":{"action":"created",
              "issue":{"number":123,"title":"feat(gists): the Gists tab",
-                      "html_url":"https://github.com/octocat/hello-world/pull/123"},
+                      "html_url":"https://github.com/octocat/hello-world/pull/123",
+                      "pull_request":{"url":"https://api.github.com/repos/octocat/hello-world/pulls/123"}},
              "comment":{"html_url":"https://github.com/octocat/hello-world/pull/123#issuecomment-5225673218"}}
 }`
 
@@ -113,13 +114,16 @@ func decodeMany(t *testing.T, body string) []Event {
 
 // newEventsClient serves one canned response and records the path it was
 // asked for, which is what the privacy test asserts on.
-func newEventsClient(t *testing.T, code int, body string, gotPath *string) *Client {
+func newEventsClient(t *testing.T, code int, body string, gotPath *string, headers ...[2]string) *Client {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if gotPath != nil {
 			*gotPath = r.URL.Path
 		}
 		w.Header().Set("Content-Type", "application/json")
+		for _, h := range headers {
+			w.Header().Set(h[0], h[1])
+		}
 		w.WriteHeader(code)
 		_, _ = w.Write([]byte(body))
 	}))
@@ -311,27 +315,47 @@ func TestFetchEventsNeedsALogin(t *testing.T) {
 	}
 }
 
+// GitHub overloads 403 across three unrelated conditions and the advice for
+// each differs, so the headers — not the status alone, and not the body's
+// wording — are what separate them.
 func TestFetchEventsClassifiesFailures(t *testing.T) {
 	for _, tc := range []struct {
-		code int
-		want FetchErrorReason
+		name    string
+		code    int
+		headers [][2]string
+		want    FetchErrorReason
 	}{
-		{http.StatusUnauthorized, ReasonAuth},
-		{http.StatusForbidden, ReasonAuthScope},
-		{http.StatusNotFound, ReasonNotFound},
-		{http.StatusTooManyRequests, ReasonRateLimitSecondary},
-		{http.StatusBadGateway, ReasonServer},
-		{http.StatusTeapot, ReasonUnknown},
+		{"401 is a rejected token, not a missing scope",
+			http.StatusUnauthorized, nil, ReasonAuth},
+		{"bare 403 is a permission problem",
+			http.StatusForbidden, nil, ReasonAuthScope},
+		{"403 with the budget at zero is the hourly limit",
+			http.StatusForbidden, [][2]string{{"X-RateLimit-Remaining", "0"}}, ReasonRateLimitPrimary},
+		{"403 with Retry-After is the secondary throttle",
+			http.StatusForbidden, [][2]string{{"Retry-After", "60"}}, ReasonRateLimitSecondary},
+		{"Retry-After wins over a spent budget — it carries the wait",
+			http.StatusForbidden,
+			[][2]string{{"Retry-After", "60"}, {"X-RateLimit-Remaining", "0"}},
+			ReasonRateLimitSecondary},
+		{"403 with budget left is still a permission problem",
+			http.StatusForbidden, [][2]string{{"X-RateLimit-Remaining", "4999"}}, ReasonAuthScope},
+		{"429 is never a permission problem, whatever the headers say",
+			http.StatusTooManyRequests, nil, ReasonRateLimitSecondary},
+		{"404", http.StatusNotFound, nil, ReasonNotFound},
+		{"5xx", http.StatusBadGateway, nil, ReasonServer},
+		{"anything else", http.StatusTeapot, nil, ReasonUnknown},
 	} {
-		c := newEventsClient(t, tc.code, `{"message":"nope"}`, nil)
-		_, err := c.FetchEvents(context.Background(), "octocat")
-		var fe *FetchError
-		if !errors.As(err, &fe) {
-			t.Fatalf("status %d: want a *FetchError, got %v", tc.code, err)
-		}
-		if fe.Reason != tc.want {
-			t.Errorf("status %d classified as %v, want %v", tc.code, fe.Reason, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			c := newEventsClient(t, tc.code, `{"message":"nope"}`, nil, tc.headers...)
+			_, err := c.FetchEvents(context.Background(), "octocat")
+			var fe *FetchError
+			if !errors.As(err, &fe) {
+				t.Fatalf("status %d: want a *FetchError, got %v", tc.code, err)
+			}
+			if fe.Reason != tc.want {
+				t.Errorf("status %d classified as %v, want %v", tc.code, fe.Reason, tc.want)
+			}
+		})
 	}
 }
 
@@ -402,5 +426,25 @@ func TestBackfillTitlesInventsNothing(t *testing.T) {
 	events := decodeMany(t, "["+prEventJSON+","+otherRepo+"]")
 	if events[0].Title != "" {
 		t.Errorf("title crossed repositories: %q", events[0].Title)
+	}
+}
+
+// GitHub files pull-request comments under the issue shape, so the type
+// cannot say which one a comment is about — `payload.issue.pull_request`
+// is the only thing that can, and the UI labels the row from it.
+func TestIsPullRequestSeparatesCommentsOnPRsFromCommentsOnIssues(t *testing.T) {
+	onPR := decodeOne(t, issueCommentEventJSON)
+	if !onPR.IsPullRequest {
+		t.Error("a comment on a pull request was not recognised as one")
+	}
+	onIssue := decodeOne(t, issuesEventJSON)
+	if onIssue.IsPullRequest {
+		t.Error("an issue event was mistaken for a pull request")
+	}
+	// A review event's own payload never says, so it inherits the answer
+	// from the sibling the title came from.
+	both := decodeMany(t, "["+reviewEventJSON+","+issueCommentEventJSON+"]")
+	if !both[0].IsPullRequest {
+		t.Error("the review did not inherit its kind from the sibling comment")
 	}
 }

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -339,3 +339,70 @@ func longestStreak(days []github.ContributionDay) int {
 	}
 	return best
 }
+
+// ActivitySub selects which half of the Activity tab is showing (#71).
+// The heatmap and the feed are the same subject at two zoom levels —
+// aggregate shape versus individual events — which is why the issue asked
+// for a sub-tab here rather than an eighth entry in a tab row that is
+// already six wide.
+type ActivitySub int
+
+const (
+	ActivitySubHeatmap ActivitySub = iota
+	ActivitySubFeed
+)
+
+var activitySubLabels = [...]string{
+	ActivitySubHeatmap: "Heatmap",
+	ActivitySubFeed:    "Feed",
+}
+
+// activitySubCount is the number of sub-views, derived so adding a label
+// is the only edit needed.
+var activitySubCount = ActivitySub(len(activitySubLabels))
+
+// next cycles forward, wrapping. delta is +1 or -1.
+func (a ActivitySub) next(delta int) ActivitySub {
+	return (a + ActivitySub(delta) + activitySubCount) % activitySubCount
+}
+
+// activitySubBarHeight is the vertical cost of the sub-tab bar: the bar
+// itself plus the blank line under it.
+//
+// It exists as a constant because two call sites subtract it — the
+// renderer and syncActivityViewport — and a viewport whose height
+// disagrees with the space it is drawn into scrolls to the wrong maximum
+// without ever looking broken.
+const activitySubBarHeight = 2
+
+// activityBodyHeight is the room left for the sub-view once the bar has
+// taken its share. Returns 0 (meaning "unknown, render inline") when the
+// caller had no height either, preserving the pre-sub-tab behaviour on the
+// first paint.
+func activityBodyHeight(tabHeight int) int {
+	if tabHeight <= 0 {
+		return 0
+	}
+	h := tabHeight - activitySubBarHeight
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+// renderActivitySubTabs draws the sub-tab selector. Deliberately quieter
+// than the main tab bar — no rule underneath, and the inactive entries stay
+// muted — so the eye still reads the top-level row as the primary
+// navigation.
+func renderActivitySubTabs(active ActivitySub, available int) string {
+	parts := make([]string, 0, len(activitySubLabels))
+	for i, label := range activitySubLabels {
+		if ActivitySub(i) == active {
+			parts = append(parts, activeTabStyle.Render("▸ "+label))
+		} else {
+			parts = append(parts, inactiveTabStyle.Render(label))
+		}
+	}
+	bar := strings.Join(parts, inactiveTabStyle.Render("  ·  "))
+	return bar + mutedStyle.Render("   ←/→ switch")
+}

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -404,5 +404,8 @@ func renderActivitySubTabs(active ActivitySub, available int) string {
 		}
 	}
 	bar := strings.Join(parts, inactiveTabStyle.Render("  ·  "))
-	return bar + mutedStyle.Render("   ←/→ switch")
+	// Both bindings are named. The README documents ←/→ *and* h/l, and a
+	// hint that lists only half of what works is the kind of drift that
+	// makes the in-app text stop being trusted.
+	return bar + mutedStyle.Render("   ←/→ · h/l switch")
 }

--- a/internal/ui/feed.go
+++ b/internal/ui/feed.go
@@ -53,6 +53,11 @@ type FeedModel struct {
 	// sub-view, which refreshes on its own schedule (i.e. when asked).
 	fetchedAt time.Time
 
+	// gen counts loads. A reply is only installed if it carries the
+	// current generation, so two `r` presses in a row cannot let the
+	// slower reply overwrite the faster one's newer events.
+	gen int
+
 	cursor       int
 	query        string
 	searchActive bool
@@ -72,7 +77,12 @@ func (fm FeedModel) NeedsLoad() bool { return fm.state == feedIdle }
 // are deliberately kept: a reload should not blank a feed the user is
 // reading, and if the reload fails the previous rows are still the best
 // answer available.
+//
+// It also bumps the generation, which is what makes a second `r` supersede
+// the first rather than race it. The caller stamps the command with the new
+// value; anything stamped with an older one is dropped on arrival.
 func (fm FeedModel) startLoading() FeedModel {
+	fm.gen++
 	fm.state = feedLoading
 	return fm
 }
@@ -561,10 +571,15 @@ func (fm FeedModel) renderFeed(available, availableHeight int, publicOnly bool) 
 
 	rowsVisible := len(rows)
 	if availableHeight > 0 {
+		// One row is the floor, and deliberately not the three the other
+		// list tabs enforce: on a very short window a three-row minimum
+		// pushes the pinned footer off screen, which is the thing the
+		// budget exists to prevent. There is no conditional three-row
+		// branch here because there cannot be a meaningful one —
+		// rowsVisible *is* availableHeight-chrome at this point, so any
+		// test of one against the other is decided before it runs. The
+		// Gists tab carries the same no-op; see TestFeedRowBudget.
 		rowsVisible = availableHeight - chrome
-		if rowsVisible < 3 && availableHeight-chrome >= 3 {
-			rowsVisible = 3
-		}
 		if rowsVisible < 1 {
 			rowsVisible = 1
 		}
@@ -865,11 +880,15 @@ func styleEventVerb(verb string, e github.Event) string {
 
 // feedLoadedMsg carries a FetchEvents round-trip back to Update.
 //
-// It has no discriminator for staleness — unlike the drill-ins, which key
-// theirs by URL. There is only ever one feed and one account, so a second
-// response cannot belong to a different subject; the worst a late reply
-// does is re-install the same rows.
+// gen is what makes two reloads safe. The drill-ins key their staleness by
+// URL, which works because they can be reopened on a different subject;
+// there is only ever one feed and one account, so the earlier version of
+// this comment argued no discriminator was needed and that the worst a late
+// reply could do was re-install the same rows. That was wrong: two `r`
+// presses race, and the *older* request's reply can land second and put
+// older events — and an older fetchedAt — back on screen.
 type feedLoadedMsg struct {
+	gen    int
 	events []github.Event
 	err    error
 	reason github.FetchErrorReason
@@ -880,12 +899,12 @@ type feedLoadedMsg struct {
 // timeout matches the rate-limit panel's: long enough for a slow network,
 // short enough that a hung request does not leave the sub-view saying
 // "loading" forever.
-func fetchEventsCmd(client *github.Client, login string) tea.Cmd {
+func fetchEventsCmd(client *github.Client, login string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		events, err := client.FetchEvents(ctx, login)
-		msg := feedLoadedMsg{events: events, err: err, at: time.Now()}
+		msg := feedLoadedMsg{gen: gen, events: events, err: err, at: time.Now()}
 		if err != nil {
 			var fe *github.FetchError
 			if errors.As(err, &fe) {
@@ -928,7 +947,7 @@ func (m Model) maybeLoadFeed() (Model, tea.Cmd) {
 		return m, nil
 	}
 	m.feed = m.feed.startLoading()
-	return m, fetchEventsCmd(m.client, login)
+	return m, fetchEventsCmd(m.client, login, m.feed.gen)
 }
 
 // switchActivitySub moves between the heatmap and the feed, loading the

--- a/internal/ui/feed.go
+++ b/internal/ui/feed.go
@@ -1,0 +1,939 @@
+package ui
+
+// Feed — the Activity tab's second sub-view (#71). The heatmap says how
+// much; this says what.
+//
+// **Loaded on demand, not with the dashboard.** Every other list in the app
+// rides FetchStats; this one does not, for two reasons that both come off
+// the wire rather than out of taste. GitHub answers the events endpoint
+// with `X-Poll-Interval: 60`, and octoscope's refresh floor is 5s — riding
+// the refresh would poll it twelve times faster than asked, for a sub-tab
+// the user may never open. And the endpoint has no `viewer` form, so it
+// needs a login, which is only known *after* the profile query the fetch
+// would have to run beside.
+//
+// The consequence is a state machine rather than a slice, which is why this
+// file carries one and gists does not.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// feedState tracks the on-demand load. feedIdle is the pre-open state: the
+// distinction from feedReady-with-nothing matters, because "not asked yet"
+// and "asked, and you have done nothing recently" are different sentences
+// and the second one is a claim.
+type feedState int
+
+const (
+	feedIdle feedState = iota
+	feedLoading
+	feedReady
+	feedFailed
+)
+
+// FeedModel is the sub-view state. Cursor + search mirror the list tabs;
+// state + err are what the on-demand load adds.
+type FeedModel struct {
+	state  feedState
+	events []github.Event
+	err    error
+	reason github.FetchErrorReason
+
+	// fetchedAt stamps the load so the header can say how stale the feed
+	// is. The dashboard's own "updated Ns ago" says nothing about this
+	// sub-view, which refreshes on its own schedule (i.e. when asked).
+	fetchedAt time.Time
+
+	cursor       int
+	query        string
+	searchActive bool
+}
+
+// IsInputMode reports whether the sub-model is absorbing keystrokes as
+// text, so the root model can withhold its global hotkeys.
+func (fm FeedModel) IsInputMode() bool { return fm.searchActive }
+
+// NeedsLoad reports whether opening the sub-view should fire a fetch.
+// False once anything has been attempted — a failed load is retried with
+// `r`, not by looking at it again, so a broken token cannot turn tab
+// switching into a request loop.
+func (fm FeedModel) NeedsLoad() bool { return fm.state == feedIdle }
+
+// startLoading is the transition into the in-flight state. Existing rows
+// are deliberately kept: a reload should not blank a feed the user is
+// reading, and if the reload fails the previous rows are still the best
+// answer available.
+func (fm FeedModel) startLoading() FeedModel {
+	fm.state = feedLoading
+	return fm
+}
+
+// loaded installs a successful result.
+func (fm FeedModel) loaded(events []github.Event, at time.Time) FeedModel {
+	fm.state = feedReady
+	fm.events = events
+	fm.err = nil
+	fm.fetchedAt = at
+	if fm.cursor >= len(events) {
+		fm.cursor = 0
+	}
+	return fm
+}
+
+// failed installs an error. Rows from a previous successful load survive —
+// see startLoading — so the view shows the stale feed with the failure
+// stated above it rather than replacing information with an error.
+func (fm FeedModel) failed(err error, reason github.FetchErrorReason) FeedModel {
+	fm.state = feedFailed
+	fm.err = err
+	fm.reason = reason
+	return fm
+}
+
+// visibleEvents is the single source of truth for the row pipeline —
+// cursor, renderer and key actions all consume it, which is the invariant
+// that keeps the highlighted row and the selected row the same row.
+//
+// **publicOnly is applied here, not in Stats.Public().** Events are not
+// part of Stats (see the file comment), so the usual strip-every-private-
+// list pass cannot reach them. The fetch already asks the `/events/public`
+// endpoint when the client starts in public-only mode, but that covers
+// startup and not the `p` toggle: flipping it mid-session has to filter
+// what is already in memory, or a screenshot taken right after the toggle
+// still shows private-repo activity.
+func visibleEvents(events []github.Event, query string, publicOnly bool) []github.Event {
+	out := make([]github.Event, 0, len(events))
+	needle := strings.ToLower(strings.TrimSpace(query))
+	for _, e := range events {
+		if publicOnly && !e.IsPublic {
+			continue
+		}
+		if needle != "" && !eventMatches(e, needle) {
+			continue
+		}
+		out = append(out, e)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// eventMatches matches against what the row actually shows — repo, verb
+// and subject — rather than the raw fields. Filtering on the raw type
+// would make "merged" find nothing while the screen says merged.
+func eventMatches(e github.Event, needle string) bool {
+	verb, subject := eventPhrase(e)
+	for _, hay := range []string{e.Repo, verb, subject} {
+		if strings.Contains(strings.ToLower(hay), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// feedRow is one printed line: an event, plus how many adjacent events it
+// stands for and the verbs folded into it.
+type feedRow struct {
+	event github.Event
+	count int
+	verb  string
+}
+
+// chatterTypes are the event types that a busy pull request produces in
+// bulk. Everything else changes state and stays on its own line.
+var chatterTypes = map[string]bool{
+	"PullRequestReviewEvent":        true,
+	"PullRequestReviewCommentEvent": true,
+	"IssueCommentEvent":             true,
+}
+
+// isChatter reports whether an event is review/comment noise rather than a
+// state change. An approval or a change-request is *not* chatter even
+// though it arrives as a review — folding those into a "×12" is precisely
+// how the one review that mattered disappears.
+func isChatter(e github.Event) bool {
+	if !chatterTypes[e.Type] {
+		return false
+	}
+	if e.Type == "PullRequestReviewEvent" {
+		return e.Action == "" || e.Action == "commented"
+	}
+	return true
+}
+
+// collapseChatter folds runs of review/comment traffic on the same subject
+// into a single row.
+//
+// Without it the feed is a wall: on the account this was built against,
+// twenty of the newest twenty-five events were reviews and comments on one
+// pull request, and the tab answered "what happened recently" with the same
+// line fifteen times. Reading it took longer than opening GitHub, which is
+// the failure the Gists tab already taught this project once.
+//
+// **Only adjacent events merge, and only if they share repo and number.**
+// Nothing is reordered and nothing jumps a row of a different kind, so the
+// timeline the user reads is still the timeline GitHub sent — a run is
+// folded, never a history rewritten. State changes (opened, merged, closed,
+// pushed, released, approved) never fold, so the row that says what
+// actually happened is always its own line.
+func collapseChatter(events []github.Event) []feedRow {
+	out := make([]feedRow, 0, len(events))
+	for _, e := range events {
+		verb, _ := eventPhrase(e)
+		if n := len(out); n > 0 && e.Number != 0 &&
+			isChatter(e) && isChatter(out[n-1].event) &&
+			out[n-1].event.Repo == e.Repo && out[n-1].event.Number == e.Number {
+			out[n-1].count++
+			out[n-1].verb = mergeVerbs(out[n-1].verb, verb)
+			continue
+		}
+		out = append(out, feedRow{event: e, count: 1, verb: verb})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mergeVerbs labels a folded run.
+//
+// A run of one verb keeps it. A mixed run becomes "commented", which is
+// accurate rather than a compromise: everything foldable *is* a comment by
+// construction — an issue comment, a review comment, or a review whose
+// state is "commented". Approvals and change-requests are excluded from
+// folding precisely so this collapse never swallows them.
+//
+// The earlier version joined the verbs with a slash, which produced
+// "commented/reviewed" — eighteen characters that truncated to
+// "commented/r…" in the column and said nothing the single word does not.
+func mergeVerbs(existing, next string) string {
+	if existing == next {
+		return existing
+	}
+	return "commented"
+}
+
+// feedRows is the row pipeline: filter, then fold. Cursor, renderer and key
+// actions all consume it, so the highlighted row and the selected row can
+// never be different rows.
+func feedRows(events []github.Event, query string, publicOnly bool) []feedRow {
+	return collapseChatter(visibleEvents(events, query, publicOnly))
+}
+
+// selectedEvent returns the event under the cursor within the same
+// pipeline the renderer used. For a folded row that is the newest event of
+// the run, whose comment anchor is also the most useful place to land.
+func (fm FeedModel) selectedEvent(publicOnly bool) (github.Event, bool) {
+	rows := feedRows(fm.events, fm.query, publicOnly)
+	if len(rows) == 0 {
+		return github.Event{}, false
+	}
+	idx := fm.cursor
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(rows) {
+		idx = len(rows) - 1
+	}
+	return rows[idx].event, true
+}
+
+// Update handles keys while the feed sub-view is showing.
+func (fm FeedModel) Update(msg tea.KeyMsg, publicOnly bool) (FeedModel, tea.Cmd) {
+	if fm.searchActive {
+		return fm.updateSearch(msg), nil
+	}
+
+	rows := feedRows(fm.events, fm.query, publicOnly)
+	n := len(rows)
+
+	// Clamp before acting, not only when rendering. The row set shrinks
+	// underneath the cursor whenever public-only is toggled or a filter is
+	// typed, and a cursor left past the end would then step *down* from an
+	// index that no longer exists — the renderer's own clamp hides that on
+	// screen while enter opens the wrong row.
+	if fm.cursor >= n {
+		fm.cursor = n - 1
+	}
+	if fm.cursor < 0 {
+		fm.cursor = 0
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if fm.cursor > 0 {
+			fm.cursor--
+		}
+	case "down", "j":
+		if fm.cursor < n-1 {
+			fm.cursor++
+		}
+	case "pgup":
+		fm.cursor -= feedPageJump
+		if fm.cursor < 0 {
+			fm.cursor = 0
+		}
+	case "pgdown", " ":
+		// Space pages down here for the same reason it does on the heatmap
+		// half — the two sub-views share a tab, and a key that scrolls one
+		// and does nothing on the other reads as a bug.
+		fm.cursor += feedPageJump
+		if fm.cursor > n-1 {
+			fm.cursor = n - 1
+		}
+		if fm.cursor < 0 {
+			fm.cursor = 0
+		}
+	case "home", "g":
+		fm.cursor = 0
+	case "end", "G":
+		if n > 0 {
+			fm.cursor = n - 1
+		}
+	case "/":
+		fm.searchActive = true
+	case "enter", "o":
+		if n == 0 || fm.cursor >= n {
+			return fm, nil
+		}
+		return fm, openURLCmd(rows[fm.cursor].event.URL)
+	case "c":
+		if n == 0 || fm.cursor >= n {
+			return fm, nil
+		}
+		return fm, copyURLCmd(rows[fm.cursor].event.URL)
+	case "esc":
+		if fm.query != "" {
+			fm.query = ""
+			fm.cursor = 0
+		}
+	}
+	return fm, nil
+}
+
+// feedPageJump is how far pgup/pgdn move the cursor. A fixed jump rather
+// than a screenful: the row budget is computed inside the renderer from a
+// height this model does not have, and a page key that moves a plausible
+// distance beats one that needs the two to be threaded together.
+const feedPageJump = 10
+
+func (fm FeedModel) updateSearch(km tea.KeyMsg) FeedModel {
+	// Dispatch on km.Type so pasted batches arrive whole — same reason as
+	// ReposModel.updateSearch.
+	switch km.Type {
+	case tea.KeyEnter:
+		fm.searchActive = false
+		fm.cursor = 0
+	case tea.KeyEsc:
+		fm.searchActive = false
+		fm.query = ""
+		fm.cursor = 0
+	case tea.KeyBackspace:
+		if r := []rune(fm.query); len(r) > 0 {
+			fm.query = string(r[:len(r)-1])
+			fm.cursor = 0
+		}
+	case tea.KeyRunes, tea.KeySpace:
+		fm.query += sanitizeFilterInput(string(km.Runes))
+		fm.cursor = 0
+	}
+	return fm
+}
+
+// eventPhrase turns an event's raw facts into the two cells the row shows:
+// a verb and the subject it applies to.
+//
+// Phrasing lives here rather than in the github package on purpose — a
+// display string built at the fetch boundary would end up in machine-
+// readable output as a value GitHub never sent. Same rule Gist.Description
+// follows.
+//
+// The subject for a pull request is a bare "PR #123" with no title, and
+// that is not an omission: the events feed truncates payload.pull_request
+// to five fields and a title is not among them. Issues, which arrive whole,
+// do get theirs. Fetching the missing titles would be one request per row.
+func eventPhrase(e github.Event) (verb, subject string) {
+	switch e.Type {
+	case "PushEvent":
+		return "pushed", e.Ref
+
+	case "PullRequestEvent":
+		v := e.Action
+		if v == "" {
+			v = "updated"
+		}
+		return v, subjectLabel(true, e.Number, e.Title)
+
+	case "PullRequestReviewEvent":
+		// Action carries the review *state* for this type (see the field's
+		// doc comment): an approval is the most significant thing a review
+		// row can say, and it would be invisible under a flat "reviewed".
+		switch e.Action {
+		case "approved":
+			return "approved", subjectLabel(true, e.Number, e.Title)
+		case "changes_requested":
+			return "changes req", subjectLabel(true, e.Number, e.Title)
+		case "dismissed":
+			return "dismissed", subjectLabel(true, e.Number, e.Title)
+		}
+		return "reviewed", subjectLabel(true, e.Number, e.Title)
+
+	case "PullRequestReviewCommentEvent":
+		return "commented", subjectLabel(true, e.Number, e.Title)
+
+	case "IssuesEvent":
+		v := e.Action
+		if v == "" {
+			v = "updated"
+		}
+		return v, subjectLabel(e.IsPullRequest, e.Number, e.Title)
+
+	case "IssueCommentEvent":
+		// GitHub files pull-request comments under this type too, with the
+		// PR in the `issue` field — which is why this one *does* have a
+		// title where PullRequestEvent does not.
+		return "commented", subjectLabel(e.IsPullRequest, e.Number, e.Title)
+
+	case "CommitCommentEvent":
+		return "commented", "on a commit"
+
+	case "CreateEvent":
+		if e.RefType == "repository" {
+			return "created", "the repository"
+		}
+		return "created", strings.TrimSpace(e.RefType + " " + e.Ref)
+
+	case "DeleteEvent":
+		return "deleted", strings.TrimSpace(e.RefType + " " + e.Ref)
+
+	case "ReleaseEvent":
+		v := e.Action
+		if v == "published" || v == "" {
+			v = "released"
+		}
+		return v, e.Ref
+
+	case "WatchEvent":
+		return "starred", ""
+
+	case "ForkEvent":
+		return "forked", ""
+
+	case "PublicEvent":
+		return "made public", ""
+
+	case "MemberEvent":
+		v := e.Action
+		if v == "" {
+			v = "changed"
+		}
+		return v, "a collaborator"
+
+	case "GollumEvent":
+		return "edited", "the wiki"
+
+	case "SponsorshipEvent":
+		v := e.Action
+		if v == "" {
+			v = "changed"
+		}
+		return v, "a sponsorship"
+	}
+
+	// Unknown type. GitHub adds these, and a row that says nothing in the
+	// right repo at the right time is far better than a dropped one.
+	return humanizeEventType(e.Type), strings.TrimSpace(e.Action)
+}
+
+// subjectLabel names the numbered thing an event is about.
+//
+// The "PR" prefix is not decoration: "commented #123" is ambiguous where
+// "commented PR #123" is not, and Event.IsPullRequest is what makes the
+// distinction available at all — GitHub files PR comments under the issue
+// shape, so the event type cannot answer it.
+//
+// The title is appended when there is one. For a pull request that is
+// usually a title borrowed from a sibling event in the same page (see
+// backfillTitles); when the page did not contain one, the bare number is
+// what gets shown, because inventing a label is worse than a short row.
+func subjectLabel(isPR bool, number int, title string) string {
+	prefix := ""
+	if isPR {
+		prefix = "PR "
+	}
+	switch {
+	case number <= 0 && title == "":
+		if isPR {
+			return "a pull request"
+		}
+		return ""
+	case number <= 0:
+		return title
+	case title == "":
+		return fmt.Sprintf("%s#%d", prefix, number)
+	}
+	return fmt.Sprintf("%s#%d %s", prefix, number, title)
+}
+
+// humanizeEventType turns "SomeFutureEvent" into "some future" — GitHub's
+// own noun, split on the camel humps and stripped of the suffix every type
+// shares.
+func humanizeEventType(t string) string {
+	t = strings.TrimSuffix(t, "Event")
+	if t == "" {
+		return "did something"
+	}
+	var b strings.Builder
+	for i, r := range t {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			b.WriteByte(' ')
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(b.String())
+}
+
+// renderFeed draws the whole sub-view: header, optional filter line, the
+// table, and the hint line.
+func (fm FeedModel) renderFeed(available, availableHeight int, publicOnly bool) string {
+	switch fm.state {
+	case feedIdle:
+		return mutedStyle.Render("(loading recent activity…)")
+	case feedLoading:
+		if len(fm.events) == 0 {
+			return mutedStyle.Render("(loading recent activity…)")
+		}
+	case feedFailed:
+		if len(fm.events) == 0 {
+			return strings.Join([]string{
+				errorStyle.Render("Recent activity could not be loaded."),
+				mutedStyle.Render(feedErrorHint(fm.reason)),
+				"",
+				keyHints("r", "retry"),
+			}, "\n")
+		}
+	}
+
+	rows := feedRows(fm.events, fm.query, publicOnly)
+	if len(rows) == 0 {
+		if fm.query != "" {
+			return strings.Join([]string{
+				fm.renderHeaderLine(0, 0, publicOnly),
+				"",
+				mutedStyle.Render(fmt.Sprintf("(nothing matches %q — esc to clear)", fm.query)),
+			}, "\n")
+		}
+		if publicOnly && len(fm.events) > 0 {
+			return mutedStyle.Render("(every recent event happened in a private repository — " +
+				"press p to leave public-only mode)")
+		}
+		return mutedStyle.Render("(no recent activity in the window GitHub keeps)")
+	}
+
+	cursor := fm.cursor
+	if cursor >= len(rows) {
+		cursor = len(rows) - 1
+	}
+	if cursor < 0 {
+		cursor = 0
+	}
+
+	// Chrome measured, not estimated: header, blank, table header, rule,
+	// blank, window note, blank, hints.
+	const feedChrome = 8
+	chrome := feedChrome
+	if fm.searchActive || fm.query != "" {
+		chrome++
+	}
+	if fm.state == feedFailed {
+		chrome++
+	}
+
+	rowsVisible := len(rows)
+	if availableHeight > 0 {
+		rowsVisible = availableHeight - chrome
+		if rowsVisible < 3 && availableHeight-chrome >= 3 {
+			rowsVisible = 3
+		}
+		if rowsVisible < 1 {
+			rowsVisible = 1
+		}
+		if rowsVisible > len(rows) {
+			rowsVisible = len(rows)
+		}
+	}
+
+	offset := 0
+	if len(rows) > rowsVisible {
+		offset = cursor - rowsVisible/2
+		if offset < 0 {
+			offset = 0
+		}
+		if offset > len(rows)-rowsVisible {
+			offset = len(rows) - rowsVisible
+		}
+	}
+	end := offset + rowsVisible
+	if end > len(rows) {
+		end = len(rows)
+	}
+
+	parts := []string{fm.renderHeaderLine(countEvents(rows), len(rows), publicOnly)}
+
+	if fm.state == feedFailed {
+		parts = append(parts, warnStyle.Render("reload failed — showing the previous load. ")+
+			mutedStyle.Render(feedErrorHint(fm.reason)))
+	}
+
+	switch {
+	case fm.searchActive:
+		parts = append(parts, mutedStyle.Render("search: ")+
+			fm.query+boldStyle.Foreground(colAccent).Render("█")+
+			mutedStyle.Render("   (enter confirm · esc cancel)"))
+	case fm.query != "":
+		parts = append(parts, mutedStyle.Render("filter: ")+fm.query+
+			mutedStyle.Render("   (esc to clear)"))
+	}
+
+	parts = append(parts, "", renderFeedTable(rows[offset:end], cursor-offset, available, anyPrivate(rows)))
+
+	if note := fm.windowNote(rows, offset, end); note != "" {
+		parts = append(parts, "", note)
+	}
+
+	parts = append(parts, "", keyHints(
+		"↑↓", "move",
+		"g/G", "top/bottom",
+		"/", "search",
+		"enter", "github",
+		"c", "copy",
+		"r", "reload",
+	))
+	return strings.Join(parts, "\n")
+}
+
+// windowNote states the span the feed actually covers, which is the honest
+// version of what a timeline implies. GitHub keeps a limited window of
+// events and we ask for one page of it — on a busy account that page was
+// **two days**, so a reader who assumed "recent activity" meant weeks would
+// be reading a list that silently stops.
+func (fm FeedModel) windowNote(rows []feedRow, offset, end int) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	newest, oldest := rows[0].event.CreatedAt, rows[len(rows)-1].event.CreatedAt
+
+	var b strings.Builder
+	if end-offset < len(rows) {
+		b.WriteString(mutedStyle.Render(fmt.Sprintf("rows %d-%d of %d   ", offset+1, end, len(rows))))
+	}
+	if !newest.IsZero() && !oldest.IsZero() {
+		b.WriteString(mutedStyle.Render("covering " +
+			oldest.Local().Format("Jan 2 15:04") + " → " +
+			newest.Local().Format("Jan 2 15:04")))
+	}
+	// Only claim the window is capped when it actually is. Below the cap
+	// the feed *is* everything GitHub has, and saying otherwise would be
+	// the same kind of unfounded hedge the scan's disclosures avoid.
+	if len(fm.events) >= github.EventsPageSize {
+		b.WriteString(mutedStyle.Render(fmt.Sprintf(
+			" · the last %d events, not a full history", github.EventsPageSize)))
+	}
+	return b.String()
+}
+
+// renderHeaderLine counts *events*, not rows — folding is a presentation
+// choice and "17 events" after collapsing 100 of them would be a false
+// count. shown is how many survived the filter; rows is how many lines
+// they occupy, named only when the two differ.
+func (fm FeedModel) renderHeaderLine(shown, rows int, publicOnly bool) string {
+	label := fmt.Sprintf("%d event", shown)
+	if shown != 1 {
+		label = fmt.Sprintf("%d events", shown)
+	}
+	if fm.query != "" && shown != len(fm.events) {
+		label = fmt.Sprintf("%d of %d events", shown, len(fm.events))
+	}
+	if rows > 0 && rows < shown {
+		label += fmt.Sprintf(" in %d rows", rows)
+	}
+
+	out := sectionTitleStyle.Render(label)
+	if publicOnly {
+		out += mutedStyle.Render("   public only")
+	}
+	if fm.state == feedLoading {
+		out += mutedStyle.Render("   reloading…")
+	} else if !fm.fetchedAt.IsZero() {
+		out += mutedStyle.Render("   loaded " + formatRelativeAgo(fm.fetchedAt))
+	}
+	return out
+}
+
+// feedErrorHint turns a classified failure into the one sentence that says
+// what to do about it. Same vocabulary the footer uses for the dashboard's
+// own errors, so a token problem reads the same wherever it surfaces.
+func feedErrorHint(reason github.FetchErrorReason) string {
+	switch reason {
+	case github.ReasonAuth:
+		return "GitHub rejected the token — it may be expired or revoked."
+	case github.ReasonAuthScope:
+		return "The token cannot read this account's events."
+	case github.ReasonNotFound:
+		return "GitHub has no events endpoint for that account."
+	case github.ReasonRateLimitPrimary, github.ReasonRateLimitSecondary:
+		return "Rate-limited — try again shortly."
+	case github.ReasonNetwork:
+		return "The request did not reach GitHub."
+	case github.ReasonServer:
+		return "GitHub answered with a server error."
+	}
+	return "Press r to try again."
+}
+
+const (
+	feedCursorW = 2
+	feedWhenW   = 9
+	feedVisW    = 8
+	feedVerbW   = 12
+	feedCountW  = 5
+	feedRepoW   = 32
+	// feedSubjectMin keeps the subject column readable rather than letting
+	// a narrow terminal collapse it to nothing — below this the repo column
+	// gives ground first, since the subject is the part that varies.
+	feedSubjectMin = 16
+)
+
+// countEvents totals the events behind a set of rows, so the header can
+// report events while the table shows folded lines.
+func countEvents(rows []feedRow) int {
+	n := 0
+	for _, r := range rows {
+		n += r.count
+	}
+	return n
+}
+
+// anyPrivate reports whether any visible row happened in a private repo,
+// which is what decides whether the visibility column is worth its width.
+func anyPrivate(rows []feedRow) bool {
+	for _, r := range rows {
+		if !r.event.IsPublic {
+			return true
+		}
+	}
+	return false
+}
+
+// renderFeedTable draws the rows.
+//
+// showVis is passed rather than derived per-row: the column is dropped
+// entirely when every visible row is public, which is always the case under
+// --public-only. A column of identical values is eight characters of noise
+// taken from the subject, which is the one column that always varies.
+func renderFeedTable(rows []feedRow, cursorRow, available int, showVis bool) string {
+	repoW, subjectW := feedColumnWidths(available, showVis)
+
+	headerCells := []string{
+		strings.Repeat(" ", feedCursorW),
+		mutedStyle.Render(padRight("When", feedWhenW)),
+	}
+	if showVis {
+		headerCells = append(headerCells, mutedStyle.Render(padRight("Vis", feedVisW)))
+	}
+	headerCells = append(headerCells,
+		mutedStyle.Render(padRight("What", feedVerbW)),
+		mutedStyle.Render(padRight("", feedCountW)),
+		mutedStyle.Render(padRight("Repository", repoW)),
+		mutedStyle.Render(padRight("Subject", subjectW)),
+	)
+	header := strings.Join(headerCells, "  ")
+	rule := tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header)))
+
+	out := []string{header, rule}
+	for i, r := range rows {
+		active := i == cursorRow
+		e := r.event
+		_, subject := eventPhrase(e)
+
+		marker := "  "
+		if active {
+			marker = activeTabStyle.Render("▸ ")
+		}
+
+		when := padRight(formatRelativeAgo(e.CreatedAt), feedWhenW)
+		verbCell := padRightRaw(styleEventVerb(truncate(r.verb, feedVerbW), e), feedVerbW)
+
+		count := ""
+		if r.count > 1 {
+			count = fmt.Sprintf("×%d", r.count)
+		}
+		countCell := padRight(count, feedCountW)
+
+		repo := padRight(truncate(e.Repo, repoW), repoW)
+		subjectCell := padRight(truncate(subject, subjectW), subjectW)
+
+		if active {
+			repo = boldStyle.Foreground(colAccent).Render(repo)
+		} else {
+			repo = valueStyle.Render(repo)
+			when = mutedStyle.Render(when)
+			subjectCell = mutedStyle.Render(subjectCell)
+		}
+		countCell = mutedStyle.Render(countCell)
+
+		cells := []string{marker + when}
+		if showVis {
+			vis := "public"
+			if !e.IsPublic {
+				vis = "private"
+			}
+			visCell := padRight(vis, feedVisW)
+			if !active {
+				visCell = mutedStyle.Render(visCell)
+			}
+			cells = append(cells, visCell)
+		}
+		cells = append(cells, verbCell, countCell, repo, subjectCell)
+		out = append(out, strings.Join(cells, "  "))
+	}
+	return strings.Join(out, "\n")
+}
+
+// feedColumnWidths splits the leftover width between repo and subject. The
+// fixed columns are known, so this is arithmetic rather than guesswork —
+// and it degrades by shrinking the repo name, which stays recognisable
+// truncated, before the subject, which does not.
+func feedColumnWidths(available int, showVis bool) (repoW, subjectW int) {
+	cols := []int{feedCursorW, feedWhenW, feedVerbW, feedCountW}
+	if showVis {
+		cols = append(cols, feedVisW)
+	}
+	fixed := 0
+	for _, c := range cols {
+		fixed += c
+	}
+	// One two-space separator between every pair of columns, including the
+	// two adaptive ones.
+	fixed += (len(cols) + 1) * 2
+
+	leftover := available - fixed
+	if leftover < feedRepoW+feedSubjectMin {
+		// Too narrow for both at full size: give the subject its floor and
+		// let the repo take what is left, with its own floor so the column
+		// can never come out negative and panic strings.Repeat.
+		repoW = leftover - feedSubjectMin
+		if repoW < 10 {
+			repoW = 10
+		}
+		return repoW, feedSubjectMin
+	}
+	return feedRepoW, leftover - feedRepoW
+}
+
+// styleEventVerb colours the verb by what it means rather than by type, so
+// the column reads as a status at a glance: things that landed are green,
+// a rejection or an unmerged close is a warning, things that went away are
+// muted, and what just opened takes the accent.
+func styleEventVerb(verb string, e github.Event) string {
+	switch {
+	case verb == "merged" || verb == "released" || verb == "approved":
+		return okStyle.Render(verb)
+	case verb == "changes req":
+		return warnStyle.Render(verb)
+	case verb == "closed" && e.Type == "PullRequestEvent":
+		// A closed PR was not merged — that is the whole distinction, and
+		// GitHub sends "merged" as its own action in this feed.
+		return warnStyle.Render(verb)
+	case verb == "deleted":
+		return mutedStyle.Render(verb)
+	case verb == "opened" || verb == "reopened":
+		return accentStyle.Render(verb)
+	}
+	return verb
+}
+
+// feedLoadedMsg carries a FetchEvents round-trip back to Update.
+//
+// It has no discriminator for staleness — unlike the drill-ins, which key
+// theirs by URL. There is only ever one feed and one account, so a second
+// response cannot belong to a different subject; the worst a late reply
+// does is re-install the same rows.
+type feedLoadedMsg struct {
+	events []github.Event
+	err    error
+	reason github.FetchErrorReason
+	at     time.Time
+}
+
+// fetchEventsCmd runs the events request off the UI goroutine. The 10s
+// timeout matches the rate-limit panel's: long enough for a slow network,
+// short enough that a hung request does not leave the sub-view saying
+// "loading" forever.
+func fetchEventsCmd(client *github.Client, login string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		events, err := client.FetchEvents(ctx, login)
+		msg := feedLoadedMsg{events: events, err: err, at: time.Now()}
+		if err != nil {
+			var fe *github.FetchError
+			if errors.As(err, &fe) {
+				msg.reason = fe.Reason
+			}
+		}
+		return msg
+	}
+}
+
+// feedLogin is the account whose events to ask for.
+//
+// The events endpoint has no `viewer` form, so this needs the resolved
+// login — which lives on the fetched profile. Before the first successful
+// FetchStats it is empty, and the caller treats that as "not yet": the load
+// is simply not fired, and the next entry into the sub-tab tries again.
+// Reading it from stats rather than from the client is also what makes the
+// feed follow `--login <someone>` to that person's public events.
+func (m Model) feedLogin() string {
+	if m.stats == nil {
+		return ""
+	}
+	return m.stats.Login
+}
+
+// maybeLoadFeed fires the on-demand fetch when the feed is the visible
+// sub-view and has never been loaded. Safe to call on every tab switch:
+// NeedsLoad goes false the moment a load starts, so repeated switching
+// cannot stack requests, and a failed load waits for `r` rather than
+// retrying on sight.
+func (m Model) maybeLoadFeed() (Model, tea.Cmd) {
+	if m.activeTab != TabActivity || m.activitySub != ActivitySubFeed {
+		return m, nil
+	}
+	if !m.feed.NeedsLoad() {
+		return m, nil
+	}
+	login := m.feedLogin()
+	if login == "" {
+		return m, nil
+	}
+	m.feed = m.feed.startLoading()
+	return m, fetchEventsCmd(m.client, login)
+}
+
+// switchActivitySub moves between the heatmap and the feed, loading the
+// latter the first time it is shown.
+func (m Model) switchActivitySub(to ActivitySub) (Model, tea.Cmd) {
+	m.activitySub = to
+	return m.maybeLoadFeed()
+}

--- a/internal/ui/feed.go
+++ b/internal/ui/feed.go
@@ -856,23 +856,55 @@ func feedColumnWidths(available int, showVis bool) (repoW, subjectW int) {
 	return feedRepoW, leftover - feedRepoW
 }
 
-// styleEventVerb colours the verb by what it means rather than by type, so
-// the column reads as a status at a glance: things that landed are green,
-// a rejection or an unmerged close is a warning, things that went away are
-// muted, and what just opened takes the accent.
+// verbTone is what a verb means, independent of the palette that draws it.
+//
+// Split out from the rendering so the mapping can be asserted: lipgloss
+// resolves to the Ascii profile under `go test` — no TTY — which makes
+// every Render a no-op and any "is it coloured" assertion silently
+// vacuous. A tone is a value, and values can be tested.
+type verbTone int
+
+const (
+	toneNeutral verbTone = iota
+	toneLanded           // it shipped: merged, released, approved
+	toneBlocked          // it did not: changes requested, closed unmerged
+	toneGone             // it was removed
+	toneNew              // it just started
+)
+
+// eventVerbTone classifies a verb by outcome rather than by event type, so
+// the column reads as a status at a glance.
+func eventVerbTone(verb string, e github.Event) verbTone {
+	switch verb {
+	case "merged", "released", "approved":
+		return toneLanded
+	case "changes req":
+		return toneBlocked
+	case "closed":
+		// A closed pull request was *not* merged — that is the whole
+		// distinction, and GitHub sends "merged" as its own action in this
+		// feed. A closed issue is just closed, which is not a setback.
+		if e.Type == "PullRequestEvent" {
+			return toneBlocked
+		}
+	case "deleted":
+		return toneGone
+	case "opened", "reopened":
+		return toneNew
+	}
+	return toneNeutral
+}
+
+// styleEventVerb paints the verb according to its tone.
 func styleEventVerb(verb string, e github.Event) string {
-	switch {
-	case verb == "merged" || verb == "released" || verb == "approved":
+	switch eventVerbTone(verb, e) {
+	case toneLanded:
 		return okStyle.Render(verb)
-	case verb == "changes req":
+	case toneBlocked:
 		return warnStyle.Render(verb)
-	case verb == "closed" && e.Type == "PullRequestEvent":
-		// A closed PR was not merged — that is the whole distinction, and
-		// GitHub sends "merged" as its own action in this feed.
-		return warnStyle.Render(verb)
-	case verb == "deleted":
+	case toneGone:
 		return mutedStyle.Render(verb)
-	case verb == "opened" || verb == "reopened":
+	case toneNew:
 		return accentStyle.Render(verb)
 	}
 	return verb

--- a/internal/ui/feed_test.go
+++ b/internal/ui/feed_test.go
@@ -1,0 +1,481 @@
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+func ev(typ, repo string, number int, title string, public bool, ago time.Duration) github.Event {
+	return github.Event{
+		ID:        typ + repo,
+		Type:      typ,
+		Repo:      repo,
+		Number:    number,
+		Title:     title,
+		IsPublic:  public,
+		CreatedAt: time.Now().Add(-ago),
+		URL:       "https://github.com/" + repo,
+	}
+}
+
+// The privacy invariant for the `p` toggle. The fetch already asks the
+// public endpoint at startup, but toggling mid-session has to filter what
+// is already in memory — and this is the one list Stats.Public() cannot
+// reach, because events are not part of Stats.
+func TestPublicOnlyDropsPrivateEventsAlreadyInMemory(t *testing.T) {
+	events := []github.Event{
+		ev("PushEvent", "acme/secret", 0, "", false, time.Minute),
+		ev("PushEvent", "octocat/open", 0, "", true, 2*time.Minute),
+		ev("IssuesEvent", "acme/secret", 4, "internal thing", false, 3*time.Minute),
+	}
+	rows := visibleEvents(events, "", true)
+	if len(rows) != 1 {
+		t.Fatalf("kept %d rows, want only the public one", len(rows))
+	}
+	if rows[0].Repo != "octocat/open" {
+		t.Errorf("kept %q", rows[0].Repo)
+	}
+	for _, r := range rows {
+		if !r.IsPublic {
+			t.Errorf("a private event survived public-only: %+v", r)
+		}
+	}
+}
+
+// The filter has to match what the row shows. Filtering the raw type would
+// make "merged" find nothing while the screen says merged.
+func TestFeedFilterMatchesTheRenderedRow(t *testing.T) {
+	events := []github.Event{
+		ev("PullRequestEvent", "octocat/one", 7, "", true, time.Minute),
+		ev("IssuesEvent", "octocat/two", 9, "Broken pipe", true, 2*time.Minute),
+	}
+	events[0].Action = "merged"
+
+	for _, tc := range []struct {
+		query    string
+		wantRepo string
+	}{
+		{"merged", "octocat/one"},      // the verb, which is derived not stored
+		{"broken", "octocat/two"},      // the title
+		{"octocat/one", "octocat/one"}, // the repo
+		{"PR #7", "octocat/one"},       // the subject as printed
+	} {
+		rows := visibleEvents(events, tc.query, false)
+		if len(rows) != 1 || rows[0].Repo != tc.wantRepo {
+			t.Errorf("query %q matched %d rows (want 1, %s)", tc.query, len(rows), tc.wantRepo)
+		}
+	}
+}
+
+// The wall of noise this exists to fix: a run of reviews and comments on
+// the same pull request becomes one line.
+func TestCollapseChatterFoldsARunOnOneSubject(t *testing.T) {
+	var events []github.Event
+	events = append(events, ev("PullRequestEvent", "o/r", 123, "the tab", true, time.Minute))
+	events[0].Action = "merged"
+	for i := 0; i < 8; i++ {
+		e := ev("IssueCommentEvent", "o/r", 123, "the tab", true, time.Duration(i+2)*time.Minute)
+		events = append(events, e)
+		r := ev("PullRequestReviewEvent", "o/r", 123, "the tab", true, time.Duration(i+2)*time.Minute)
+		r.Action = "commented"
+		events = append(events, r)
+	}
+
+	rows := collapseChatter(events)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (the merge, then one folded run)", len(rows))
+	}
+	if rows[0].count != 1 || rows[0].verb != "merged" {
+		t.Errorf("the state change was folded away: %+v", rows[0])
+	}
+	if rows[1].count != 16 {
+		t.Errorf("folded run counts %d, want 16", rows[1].count)
+	}
+	// A mixed run of comments and comment-state reviews is labelled by
+	// what they all are. Not a compromise: an approval would never have
+	// reached this row, because approvals do not fold.
+	if rows[1].verb != "commented" {
+		t.Errorf("verb = %q, want %q", rows[1].verb, "commented")
+	}
+	if n := countEvents(rows); n != len(events) {
+		t.Errorf("countEvents = %d, want %d — folding must not lose events", n, len(events))
+	}
+}
+
+// An approval is the one review that matters. Folding it into a "×12" of
+// drive-by comments is exactly how it would disappear.
+func TestApprovalNeverFoldsIntoChatter(t *testing.T) {
+	c1 := ev("IssueCommentEvent", "o/r", 5, "x", true, time.Minute)
+	appr := ev("PullRequestReviewEvent", "o/r", 5, "x", true, 2*time.Minute)
+	appr.Action = "approved"
+	c2 := ev("IssueCommentEvent", "o/r", 5, "x", true, 3*time.Minute)
+
+	rows := collapseChatter([]github.Event{c1, appr, c2})
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3 — the approval must stand alone", len(rows))
+	}
+	if rows[1].verb != "approved" {
+		t.Errorf("middle row verb = %q, want %q", rows[1].verb, "approved")
+	}
+}
+
+// Folding must not reorder or jump a row of a different kind, or the
+// timeline stops being the timeline GitHub sent.
+func TestCollapseChatterOnlyFoldsAdjacentRunsOnTheSameSubject(t *testing.T) {
+	rows := collapseChatter([]github.Event{
+		ev("IssueCommentEvent", "o/r", 1, "a", true, time.Minute),
+		ev("IssueCommentEvent", "o/r", 2, "b", true, 2*time.Minute), // different number
+		ev("IssueCommentEvent", "o/r", 1, "a", true, 3*time.Minute), // same as the first, but not adjacent
+	})
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3 — non-adjacent runs must not merge", len(rows))
+	}
+	for i, r := range rows {
+		if r.count != 1 {
+			t.Errorf("row %d folded %d events", i, r.count)
+		}
+	}
+}
+
+// Numbers are only unique *within* a repository, so #1 over here and #1
+// over there are unrelated. Folding on the number alone would merge two
+// different conversations into one row.
+func TestCollapseChatterDoesNotFoldAcrossRepositories(t *testing.T) {
+	rows := collapseChatter([]github.Event{
+		ev("IssueCommentEvent", "octocat/one", 1, "a", true, time.Minute),
+		ev("IssueCommentEvent", "octocat/two", 1, "b", true, 2*time.Minute),
+	})
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 — same number, different repository", len(rows))
+	}
+}
+
+// The row the cursor highlights and the row enter opens have to be the
+// same row after the set shrinks underneath it.
+func TestFeedCursorSurvivesTheRowSetShrinking(t *testing.T) {
+	// Two public rows survive the toggle, deliberately: with only one left
+	// every cursor value clamps to it at render time and a missing clamp
+	// inside Update would be invisible.
+	fm := FeedModel{state: feedReady, events: []github.Event{
+		ev("PushEvent", "octocat/first", 0, "", true, time.Minute),
+		ev("PushEvent", "acme/secret1", 0, "", false, 2*time.Minute),
+		ev("PushEvent", "acme/secret2", 0, "", false, 3*time.Minute),
+		ev("PushEvent", "octocat/second", 0, "", true, 4*time.Minute),
+		ev("PushEvent", "acme/secret3", 0, "", false, 5*time.Minute),
+	}}
+
+	// Walk to the last row with everything visible.
+	for i := 0; i < 4; i++ {
+		fm, _ = fm.Update(key("down"), false)
+	}
+	if fm.cursor != 4 {
+		t.Fatalf("cursor = %d, want 4", fm.cursor)
+	}
+
+	// Public-only now leaves two rows. The stale index 4 has to be clamped
+	// to the new last row (1) *before* the keystroke is applied, so up
+	// lands on row 0. Without the clamp it goes 4 → 3, the renderer hides
+	// it, and enter opens the last row while the cursor looks elsewhere.
+	fm, _ = fm.Update(key("up"), true)
+	if fm.cursor != 0 {
+		t.Errorf("cursor = %d after up, want 0", fm.cursor)
+	}
+	got, ok := fm.selectedEvent(true)
+	if !ok {
+		t.Fatal("no selection after the set shrank")
+	}
+	if got.Repo != "octocat/first" {
+		t.Errorf("selected %q, want octocat/first", got.Repo)
+	}
+}
+
+// Loading is fired once. A failed load waits for `r` rather than retrying
+// every time the sub-tab is looked at, so a bad token cannot turn tab
+// switching into a request loop.
+func TestFeedLoadsOnceAndDoesNotRetryOnSight(t *testing.T) {
+	fm := FeedModel{}
+	if !fm.NeedsLoad() {
+		t.Fatal("a fresh feed should want a load")
+	}
+	fm = fm.startLoading()
+	if fm.NeedsLoad() {
+		t.Error("an in-flight load should not be fired again")
+	}
+	fm = fm.failed(errors.New("nope"), github.ReasonAuthScope)
+	if fm.NeedsLoad() {
+		t.Error("a failed load should wait for r, not retry on sight")
+	}
+}
+
+// A reload that fails must not blank a feed the user is reading — the
+// previous rows are still the best answer available.
+func TestFailedReloadKeepsThePreviousRows(t *testing.T) {
+	fm := FeedModel{}
+	fm = fm.startLoading()
+	fm = fm.loaded([]github.Event{ev("PushEvent", "o/r", 0, "", true, time.Minute)}, time.Now())
+	fm = fm.startLoading()
+	fm = fm.failed(errors.New("boom"), github.ReasonNetwork)
+
+	if len(fm.events) != 1 {
+		t.Fatalf("kept %d events across a failed reload, want 1", len(fm.events))
+	}
+	out := fm.renderFeed(120, 30, false)
+	if !strings.Contains(out, "reload failed") {
+		t.Error("the failure is not stated above the stale rows")
+	}
+	if !strings.Contains(out, "o/r") {
+		t.Error("the previous rows were replaced by the error")
+	}
+}
+
+// A load that has never been attempted and one that came back empty are
+// different sentences, and only one of them is a claim about the account.
+func TestIdleAndEmptyReadDifferently(t *testing.T) {
+	idle := FeedModel{}.renderFeed(120, 30, false)
+	if !strings.Contains(idle, "loading") {
+		t.Errorf("idle state says %q", idle)
+	}
+	empty := FeedModel{state: feedReady}.renderFeed(120, 30, false)
+	if strings.Contains(empty, "loading") {
+		t.Errorf("an empty result still claims to be loading: %q", empty)
+	}
+}
+
+// Under public-only with nothing public left, the reason has to be the
+// mode rather than the account — otherwise the tab tells an active user
+// they have done nothing.
+func TestPublicOnlyEmptyStateBlamesTheMode(t *testing.T) {
+	fm := FeedModel{state: feedReady, events: []github.Event{
+		ev("PushEvent", "acme/secret", 0, "", false, time.Minute),
+	}}
+	out := fm.renderFeed(120, 30, true)
+	if !strings.Contains(out, "private repository") {
+		t.Errorf("empty-under-public-only reads as %q", out)
+	}
+}
+
+// The truncation notice is a claim, and below the cap it is a false one.
+func TestWindowNoteOnlyClaimsTruncationAtTheCap(t *testing.T) {
+	short := FeedModel{state: feedReady, events: []github.Event{
+		ev("PushEvent", "o/r", 0, "", true, time.Minute),
+	}}
+	if got := short.renderFeed(140, 40, false); strings.Contains(got, "not a full history") {
+		t.Error("a short feed claims to be truncated")
+	}
+
+	full := FeedModel{state: feedReady}
+	for i := 0; i < github.EventsPageSize; i++ {
+		full.events = append(full.events,
+			ev("PushEvent", "o/r", 0, "", true, time.Duration(i)*time.Minute))
+	}
+	if got := full.renderFeed(140, 40, false); !strings.Contains(got, "not a full history") {
+		t.Error("a feed at the page cap does not say so")
+	}
+}
+
+// The visibility column is worth eight characters only when it separates
+// something. Under public-only it never does.
+func TestVisColumnAppearsOnlyWhenItSeparatesSomething(t *testing.T) {
+	mixed := FeedModel{state: feedReady, events: []github.Event{
+		ev("PushEvent", "acme/secret", 0, "", false, time.Minute),
+		ev("PushEvent", "octocat/open", 0, "", true, 2*time.Minute),
+	}}
+	if !strings.Contains(mixed.renderFeed(140, 30, false), "private") {
+		t.Error("a mixed feed hides which rows are private")
+	}
+	if strings.Contains(mixed.renderFeed(140, 30, true), "Vis") {
+		t.Error("public-only still spends a column on a constant value")
+	}
+}
+
+func TestEventPhrase(t *testing.T) {
+	mk := func(typ, action, ref, title string, num int) github.Event {
+		e := github.Event{Type: typ, Action: action, Ref: ref, Title: title, Number: num}
+		if typ == "CreateEvent" || typ == "DeleteEvent" {
+			e.RefType = "branch"
+		}
+		return e
+	}
+	tests := []struct {
+		e          github.Event
+		verb, subj string
+	}{
+		{mk("PushEvent", "", "main", "", 0), "pushed", "main"},
+		{mk("PullRequestEvent", "merged", "", "", 12), "merged", "PR #12"},
+		{mk("PullRequestEvent", "opened", "", "the fix", 12), "opened", "PR #12 the fix"},
+		{mk("PullRequestReviewEvent", "approved", "", "", 12), "approved", "PR #12"},
+		{mk("PullRequestReviewEvent", "changes_requested", "", "", 12), "changes req", "PR #12"},
+		{mk("PullRequestReviewEvent", "commented", "", "", 12), "reviewed", "PR #12"},
+		{mk("IssuesEvent", "closed", "", "Gists section", 76), "closed", "#76 Gists section"},
+		{mk("IssueCommentEvent", "created", "", "the tab", 123), "commented", "#123 the tab"},
+		{mk("CreateEvent", "", "feat/x", "", 0), "created", "branch feat/x"},
+		{mk("DeleteEvent", "", "feat/x", "", 0), "deleted", "branch feat/x"},
+		{mk("ReleaseEvent", "published", "v1.2.0", "", 0), "released", "v1.2.0"},
+		{mk("WatchEvent", "started", "", "", 0), "starred", ""},
+		{mk("ForkEvent", "", "", "", 0), "forked", ""},
+		{mk("SomeFutureEvent", "", "", "", 0), "some future", ""},
+	}
+	for _, tc := range tests {
+		verb, subj := eventPhrase(tc.e)
+		if verb != tc.verb || subj != tc.subj {
+			t.Errorf("%s/%s → (%q, %q), want (%q, %q)",
+				tc.e.Type, tc.e.Action, verb, subj, tc.verb, tc.subj)
+		}
+	}
+}
+
+// A PR with no title anywhere in the page shows the bare number rather
+// than an invented label.
+func TestPullRequestWithoutATitleShowsTheBareNumber(t *testing.T) {
+	_, subj := eventPhrase(github.Event{Type: "PullRequestEvent", Action: "opened", Number: 9})
+	if subj != "PR #9" {
+		t.Errorf("subject = %q, want %q", subj, "PR #9")
+	}
+}
+
+// A CreateEvent for a whole repository has no ref, and "created branch"
+// with an empty name would be worse than saying what happened.
+func TestCreatedRepositoryReadsAsARepository(t *testing.T) {
+	_, subj := eventPhrase(github.Event{Type: "CreateEvent", RefType: "repository"})
+	if subj != "the repository" {
+		t.Errorf("subject = %q", subj)
+	}
+}
+
+// A negative column width panics strings.Repeat, so the narrow case has to
+// be arithmetic rather than optimism.
+func TestFeedColumnWidthsNeverGoNegative(t *testing.T) {
+	for _, showVis := range []bool{false, true} {
+		for w := 0; w < 200; w++ {
+			repoW, subjectW := feedColumnWidths(w, showVis)
+			if repoW < 1 || subjectW < 1 {
+				t.Fatalf("available=%d showVis=%v → repo %d, subject %d", w, showVis, repoW, subjectW)
+			}
+		}
+	}
+}
+
+// Rendering at absurd sizes must not panic — the terminal can be anything.
+func TestRenderFeedSurvivesExtremeGeometry(t *testing.T) {
+	fm := FeedModel{state: feedReady, events: []github.Event{
+		ev("PushEvent", "octocat/very-long-repository-name-that-keeps-going", 0, "", true, time.Minute),
+		ev("IssuesEvent", "o/r", 1, strings.Repeat("long title ", 30), true, 2*time.Minute),
+	}}
+	for _, w := range []int{0, 1, 20, 80, 400} {
+		for _, h := range []int{0, 1, 3, 10, 200} {
+			_ = fm.renderFeed(w, h, false)
+			_ = fm.renderFeed(w, h, true)
+		}
+	}
+}
+
+func TestMergeVerbsCollapsesAMixedRunToWhatTheyAllAre(t *testing.T) {
+	if got := mergeVerbs("reviewed", "reviewed"); got != "reviewed" {
+		t.Errorf("a single-verb run should keep its verb, got %q", got)
+	}
+	if got := mergeVerbs("commented", "reviewed"); got != "commented" {
+		t.Errorf("got %q, want %q", got, "commented")
+	}
+	// Stable once collapsed: a third verb must not push it somewhere else.
+	if got := mergeVerbs("commented", "reviewed"); got != mergeVerbs(mergeVerbs("commented", "reviewed"), "reviewed") {
+		t.Error("the collapsed label is not stable under further folding")
+	}
+}
+
+// The PR prefix is what makes a comment row unambiguous, and the title is
+// what makes it useful. Both come from the join, not from the event.
+func TestSubjectLabelDistinguishesPullRequestsFromIssues(t *testing.T) {
+	for _, tc := range []struct {
+		isPR   bool
+		number int
+		title  string
+		want   string
+	}{
+		{true, 123, "the tab", "PR #123 the tab"},
+		{true, 123, "", "PR #123"},
+		{false, 76, "Gists section", "#76 Gists section"},
+		{false, 76, "", "#76"},
+		{false, 0, "", ""},
+		{true, 0, "", "a pull request"},
+	} {
+		if got := subjectLabel(tc.isPR, tc.number, tc.title); got != tc.want {
+			t.Errorf("subjectLabel(%v, %d, %q) = %q, want %q",
+				tc.isPR, tc.number, tc.title, got, tc.want)
+		}
+	}
+}
+
+func TestHumanizeEventType(t *testing.T) {
+	for in, want := range map[string]string{
+		"PushEvent":        "push",
+		"SomeFutureEvent":  "some future",
+		"WorkflowJobEvent": "workflow job",
+		"Event":            "did something",
+		"":                 "did something",
+	} {
+		if got := humanizeEventType(in); got != want {
+			t.Errorf("humanizeEventType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The sub-tab bar costs rows, and the renderer and the viewport sync both
+// have to subtract the same number or the heatmap stops two lines early.
+func TestActivityBodyHeightSubtractsTheBarExactlyOnce(t *testing.T) {
+	if got := activityBodyHeight(0); got != 0 {
+		t.Errorf("unknown height should stay unknown, got %d", got)
+	}
+	if got := activityBodyHeight(30); got != 30-activitySubBarHeight {
+		t.Errorf("activityBodyHeight(30) = %d, want %d", got, 30-activitySubBarHeight)
+	}
+	for h := 1; h < 5; h++ {
+		if got := activityBodyHeight(h); got < 1 {
+			t.Errorf("activityBodyHeight(%d) = %d, want at least 1", h, got)
+		}
+	}
+}
+
+func TestActivitySubCyclesBothWays(t *testing.T) {
+	if got := ActivitySubHeatmap.next(1); got != ActivitySubFeed {
+		t.Errorf("right from heatmap = %v", got)
+	}
+	if got := ActivitySubFeed.next(1); got != ActivitySubHeatmap {
+		t.Errorf("right from feed should wrap, got %v", got)
+	}
+	if got := ActivitySubHeatmap.next(-1); got != ActivitySubFeed {
+		t.Errorf("left from heatmap should wrap, got %v", got)
+	}
+}
+
+// Typing a filter must not leave the search box on a keystroke the box
+// should have swallowed.
+func TestFeedSearchCapturesKeystrokes(t *testing.T) {
+	fm := FeedModel{state: feedReady, events: []github.Event{
+		ev("PushEvent", "octocat/one", 0, "", true, time.Minute),
+		ev("PushEvent", "acme/two", 0, "", true, 2*time.Minute),
+	}}
+	fm, _ = fm.Update(key("/"), false)
+	if !fm.IsInputMode() {
+		t.Fatal("/ did not open the search box")
+	}
+	for _, r := range "acme" {
+		fm, _ = fm.Update(key(string(r)), false)
+	}
+	fm, _ = fm.Update(key("enter"), false)
+	if fm.IsInputMode() {
+		t.Error("enter did not close the search box")
+	}
+	rows := feedRows(fm.events, fm.query, false)
+	if len(rows) != 1 || rows[0].event.Repo != "acme/two" {
+		t.Errorf("filter %q left %d rows", fm.query, len(rows))
+	}
+
+	fm, _ = fm.Update(key("esc"), false)
+	if fm.query != "" {
+		t.Errorf("esc did not clear the filter, query = %q", fm.query)
+	}
+}

--- a/internal/ui/feed_test.go
+++ b/internal/ui/feed_test.go
@@ -619,11 +619,118 @@ func TestFeedResultIsInstalledEvenIfTheUserNavigatedAway(t *testing.T) {
 	m.activeTab = TabRepos
 
 	next, _ := m.Update(feedLoadedMsg{
+		gen:    m.feed.gen,
 		events: []github.Event{ev("PushEvent", "o/r", 0, "", true, time.Minute)},
 		at:     time.Now(),
 	})
 	if got := next.(Model).feed.events; len(got) != 1 {
 		t.Errorf("the result was dropped: %d events", len(got))
+	}
+}
+
+// Two reloads race. Without a generation the slower one wins whichever
+// order the replies land in, and the feed silently goes backwards — older
+// events, and an older "loaded N ago".
+func TestASupersededReloadCannotOverwriteNewerEvents(t *testing.T) {
+	m := newFeedRoutingModel(t)
+	m.activitySub = ActivitySubFeed
+
+	m.feed = m.feed.startLoading()
+	first := m.feed.gen
+	m.feed = m.feed.startLoading() // the user pressed r again
+	second := m.feed.gen
+
+	if first == second {
+		t.Fatal("a second load did not supersede the first")
+	}
+
+	// The newer request answers first.
+	newer := time.Now()
+	next, _ := m.Update(feedLoadedMsg{
+		gen:    second,
+		events: []github.Event{ev("PushEvent", "o/newer", 0, "", true, time.Minute)},
+		at:     newer,
+	})
+	m = next.(Model)
+
+	// The older one lands afterwards and must be dropped.
+	next, _ = m.Update(feedLoadedMsg{
+		gen:    first,
+		events: []github.Event{ev("PushEvent", "o/older", 0, "", true, time.Hour)},
+		at:     newer.Add(-time.Hour),
+	})
+	m = next.(Model)
+
+	if len(m.feed.events) != 1 || m.feed.events[0].Repo != "o/newer" {
+		t.Errorf("the superseded reply overwrote the newer one: %+v", m.feed.events)
+	}
+	if m.feed.fetchedAt.Before(newer) {
+		t.Error("fetchedAt went backwards")
+	}
+}
+
+// A failure from a superseded request must not knock a newer, successful
+// load into the error state either.
+func TestASupersededFailureDoesNotClobberANewerSuccess(t *testing.T) {
+	m := newFeedRoutingModel(t)
+	m.activitySub = ActivitySubFeed
+	m.feed = m.feed.startLoading()
+	stale := m.feed.gen
+	m.feed = m.feed.startLoading()
+
+	next, _ := m.Update(feedLoadedMsg{
+		gen:    m.feed.gen,
+		events: []github.Event{ev("PushEvent", "o/r", 0, "", true, time.Minute)},
+		at:     time.Now(),
+	})
+	m = next.(Model)
+
+	next, _ = m.Update(feedLoadedMsg{gen: stale, err: errors.New("timeout")})
+	m = next.(Model)
+
+	if m.feed.state != feedReady {
+		t.Errorf("state = %v, want feedReady — a stale failure took over", m.feed.state)
+	}
+}
+
+// The row budget is arithmetic, so it is worth measuring rather than only
+// checking that rendering does not panic. A short window gets fewer rows,
+// never a floor that pushes the pinned footer off screen.
+func TestFeedRowBudget(t *testing.T) {
+	fm := FeedModel{state: feedReady}
+	for i := 0; i < 40; i++ {
+		fm.events = append(fm.events,
+			ev("PushEvent", "octocat/repo", 0, "", true, time.Duration(i)*time.Minute))
+	}
+
+	// Count the drawn event rows: every one carries the repo name, and the
+	// header does not.
+	count := func(height int) int {
+		out := ansi.Strip(fm.renderFeed(140, height, false))
+		n := 0
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, "octocat/repo") {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Eight lines of chrome, so a 30-row window leaves 22.
+	if got, want := count(30), 30-8; got != want {
+		t.Errorf("height 30 drew %d rows, want %d", got, want)
+	}
+	// Below the chrome there is no room at all, and one row is the floor —
+	// three would push the footer off the screen the budget exists to keep.
+	for _, h := range []int{1, 4, 8, 9} {
+		if got := count(h); got != 1 {
+			t.Errorf("height %d drew %d rows, want exactly 1 — three would push "+
+				"the pinned footer off the screen this budget exists to keep", h, got)
+		}
+	}
+	// Zero means "height unknown" (first paint), which draws everything.
+	if got := count(0); got != 40 {
+		t.Errorf("unknown height drew %d rows, want all 40", got)
 	}
 }
 

--- a/internal/ui/feed_test.go
+++ b/internal/ui/feed_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/gfazioli/octoscope/internal/github"
 )
 
@@ -477,5 +478,176 @@ func TestFeedSearchCapturesKeystrokes(t *testing.T) {
 	fm, _ = fm.Update(key("esc"), false)
 	if fm.query != "" {
 		t.Errorf("esc did not clear the filter, query = %q", fm.query)
+	}
+}
+
+// The routing integration, which is the part that breaks silently: the
+// sub-model can be perfect while the root never reaches it.
+func newFeedRoutingModel(t *testing.T) Model {
+	t.Helper()
+	t.Setenv("GITHUB_TOKEN", "test-token-not-used")
+	_ = applyTheme("octoscope", "")
+	client, err := github.New("octocat", github.Options{})
+	if err != nil {
+		t.Fatalf("github.New: %v", err)
+	}
+	m := NewModel(client, "test", Options{})
+	m.activeTab = TabActivity
+	m.stats = &github.Stats{Login: "octocat"}
+	m.width, m.height = 150, 45
+	return m
+}
+
+func TestArrowsSwitchTheActivitySubTab(t *testing.T) {
+	for _, tc := range []struct {
+		keys []string
+		want ActivitySub
+	}{
+		{[]string{"right"}, ActivitySubFeed},
+		{[]string{"l"}, ActivitySubFeed},
+		{[]string{"left"}, ActivitySubFeed}, // wraps
+		{[]string{"h"}, ActivitySubFeed},    // wraps
+		{[]string{"right", "left"}, ActivitySubHeatmap},
+		{[]string{"right", "right"}, ActivitySubHeatmap},
+	} {
+		m := newFeedRoutingModel(t)
+		for _, k := range tc.keys {
+			next, _ := m.Update(key(k))
+			m = next.(Model)
+		}
+		if m.activitySub != tc.want {
+			t.Errorf("%v → sub %v, want %v", tc.keys, m.activitySub, tc.want)
+		}
+	}
+}
+
+// Opening the feed has to fire its load, and looking at it again must not
+// fire a second one.
+func TestOpeningTheFeedLoadsItExactlyOnce(t *testing.T) {
+	m := newFeedRoutingModel(t)
+	next, cmd := m.Update(key("right"))
+	m = next.(Model)
+	if cmd == nil {
+		t.Fatal("switching to the feed did not fire a load")
+	}
+	if m.feed.NeedsLoad() {
+		t.Error("the feed still wants a load after one was fired")
+	}
+
+	// Away and back: no second request.
+	next, _ = m.Update(key("left"))
+	m = next.(Model)
+	next, cmd2 := m.Update(key("right"))
+	if cmd2 != nil {
+		t.Error("re-entering the feed fired a second load")
+	}
+	_ = next
+}
+
+// Reaching Activity by tab or by digit is indistinguishable to the user, so
+// both routes have to load the feed.
+func TestReachingActivityByTabOrDigitAlsoLoadsTheFeed(t *testing.T) {
+	for _, k := range []string{"tab", "5"} {
+		m := newFeedRoutingModel(t)
+		m.activitySub = ActivitySubFeed
+		// Start on Issues: tab moves forward onto Activity, and "5" jumps
+		// there directly. Both routes have to end up in the same state.
+		m.activeTab = TabIssues
+		next, cmd := m.Update(key(k))
+		mm := next.(Model)
+		if mm.activeTab != TabActivity {
+			t.Fatalf("%q landed on %v", k, mm.activeTab)
+		}
+		if cmd == nil {
+			t.Errorf("reaching Activity with %q did not load the feed", k)
+		}
+	}
+}
+
+// Without a resolved login there is no endpoint to call, so the load has to
+// wait rather than fire a request that cannot succeed — and then happen on
+// its own once the profile lands.
+func TestFeedWaitsForTheLoginAndLoadsWhenItArrives(t *testing.T) {
+	m := newFeedRoutingModel(t)
+	m.stats = nil
+	next, cmd := m.Update(key("right"))
+	m = next.(Model)
+	if cmd != nil {
+		t.Error("a load was fired with no login resolved")
+	}
+	if !m.feed.NeedsLoad() {
+		t.Fatal("the feed gave up instead of waiting for the login")
+	}
+
+	next, cmd = m.Update(fetchMsg{
+		stats: &github.Stats{Login: "octocat"},
+		at:    time.Now(),
+	})
+	m = next.(Model)
+	if cmd == nil {
+		t.Error("the feed did not load once the profile resolved")
+	}
+	if m.feed.NeedsLoad() {
+		t.Error("the feed still wants a load after the profile arrived")
+	}
+}
+
+// While a filter is being typed the keystrokes are literal text, so the
+// footer must not advertise global hotkeys that will not fire.
+func TestFooterKnowsTheFeedIsTakingLiteralText(t *testing.T) {
+	m := newFeedRoutingModel(t)
+	m.activitySub = ActivitySubFeed
+	if m.listInputMode() {
+		t.Fatal("precondition: not in input mode yet")
+	}
+	m.feed.searchActive = true
+	if !m.listInputMode() {
+		t.Error("the footer still thinks the global hotkeys are live")
+	}
+	m.activitySub = ActivitySubHeatmap
+	if m.listInputMode() {
+		t.Error("the heatmap half has no search box to be typing into")
+	}
+}
+
+// A feedLoadedMsg that arrives after the user navigated away is still the
+// right data for the next time they look.
+func TestFeedResultIsInstalledEvenIfTheUserNavigatedAway(t *testing.T) {
+	m := newFeedRoutingModel(t)
+	m.activitySub = ActivitySubFeed
+	m.feed = m.feed.startLoading()
+	m.activeTab = TabRepos
+
+	next, _ := m.Update(feedLoadedMsg{
+		events: []github.Event{ev("PushEvent", "o/r", 0, "", true, time.Minute)},
+		at:     time.Now(),
+	})
+	if got := next.(Model).feed.events; len(got) != 1 {
+		t.Errorf("the result was dropped: %d events", len(got))
+	}
+}
+
+// The Activity tab's two halves scroll differently: the heatmap rides a
+// viewport, the feed budgets its own rows and prints its own hints. Reading
+// the viewport regardless would advertise a scroll the visible sub-view
+// does not perform.
+func TestFooterOffersTheScrollHintOnlyForTheHeatmap(t *testing.T) {
+	const hint = "↑/↓ scroll"
+
+	build := func(sub ActivitySub) string {
+		m := newFeedRoutingModel(t)
+		m.activitySub = sub
+		// A heatmap taller than its viewport, which is the precondition
+		// for the hint to be offered at all.
+		m.activityVP.Width, m.activityVP.Height = 120, 5
+		m.activityVP.SetContent(strings.Repeat("row\n", 40))
+		return ansi.Strip(renderFooterBar(m))
+	}
+
+	if got := build(ActivitySubHeatmap); !strings.Contains(got, hint) {
+		t.Errorf("the heatmap overflows but the footer does not offer the scroll hint:\n%s", got)
+	}
+	if got := build(ActivitySubFeed); strings.Contains(got, hint) {
+		t.Errorf("the feed advertises the heatmap's scroll hint:\n%s", got)
 	}
 }

--- a/internal/ui/feed_test.go
+++ b/internal/ui/feed_test.go
@@ -757,4 +757,62 @@ func TestFooterOffersTheScrollHintOnlyForTheHeatmap(t *testing.T) {
 	if got := build(ActivitySubFeed); strings.Contains(got, hint) {
 		t.Errorf("the feed advertises the heatmap's scroll hint:\n%s", got)
 	}
+
+	// The footer is the only place that says the tab has two halves
+	// without the user pressing something first, so it has to say it on
+	// both halves — and nowhere else, where the keys do nothing.
+	const switchHint = "←/→ heatmap/feed"
+	for _, sub := range []ActivitySub{ActivitySubHeatmap, ActivitySubFeed} {
+		if got := build(sub); !strings.Contains(got, switchHint) {
+			t.Errorf("sub %v: the footer does not name the sub-tab switch:\n%s", sub, got)
+		}
+	}
+	other := newFeedRoutingModel(t)
+	other.activeTab = TabRepos
+	if got := ansi.Strip(renderFooterBar(other)); strings.Contains(got, switchHint) {
+		t.Errorf("the Repos tab offers a switch that does nothing there:\n%s", got)
+	}
+}
+
+// The verb column reads as a status at a glance, which is the only reason
+// it is coloured at all. Asserted on the tone rather than the rendered
+// string: lipgloss resolves to the Ascii profile under `go test`, so every
+// Render is a no-op there and "is it coloured" would pass for free.
+func TestVerbToneSeparatesOutcomes(t *testing.T) {
+	pr := github.Event{Type: "PullRequestEvent"}
+	for _, tc := range []struct {
+		verb string
+		e    github.Event
+		want verbTone
+	}{
+		{"merged", pr, toneLanded},
+		{"released", github.Event{Type: "ReleaseEvent"}, toneLanded},
+		{"approved", github.Event{Type: "PullRequestReviewEvent"}, toneLanded},
+		{"changes req", github.Event{Type: "PullRequestReviewEvent"}, toneBlocked},
+		{"deleted", github.Event{Type: "DeleteEvent"}, toneGone},
+		{"opened", pr, toneNew},
+		{"reopened", pr, toneNew},
+		{"pushed", github.Event{Type: "PushEvent"}, toneNeutral},
+		{"commented", github.Event{Type: "IssueCommentEvent"}, toneNeutral},
+
+		// The distinction the colour exists to draw: a closed pull request
+		// was not merged, while a closed issue is simply done.
+		{"closed", pr, toneBlocked},
+		{"closed", github.Event{Type: "IssuesEvent"}, toneNeutral},
+	} {
+		if got := eventVerbTone(tc.verb, tc.e); got != tc.want {
+			t.Errorf("%q on %s → tone %d, want %d", tc.verb, tc.e.Type, got, tc.want)
+		}
+	}
+}
+
+// Whatever the tone, the text has to survive — a style that swallowed its
+// own content would leave a blank column and no test above would notice.
+func TestStyleEventVerbKeepsTheWord(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+	for _, verb := range []string{"merged", "closed", "deleted", "opened", "pushed"} {
+		if got := ansi.Strip(styleEventVerb(verb, github.Event{Type: "PullRequestEvent"})); got != verb {
+			t.Errorf("styleEventVerb(%q) = %q", verb, got)
+		}
+	}
 }

--- a/internal/ui/gists.go
+++ b/internal/ui/gists.go
@@ -267,14 +267,19 @@ func (gm GistsModel) renderGistsTab(stats *github.Stats, available, availableHei
 
 	rowsVisible := len(rows)
 	if availableHeight > 0 {
-		rowsVisible = availableHeight - chrome
-		// Three rows is the floor the other list tabs use, but a floor
-		// that does not fit is not a floor — on a very short terminal it
+		// One row is the floor, and deliberately not the three the other
+		// list tabs enforce: on a very short window a three-row minimum
 		// pushes the pinned footer off screen, which is the thing the
-		// budget exists to prevent. Enforce it only when there is room.
-		if rowsVisible < 3 && availableHeight-chrome >= 3 {
-			rowsVisible = 3
-		}
+		// budget exists to prevent.
+		//
+		// This used to carry a conditional three-row branch as well. It
+		// could never run — rowsVisible *is* availableHeight-chrome here,
+		// so a test of one against the other is decided before it
+		// executes — and it expressed an intent the floor of 1 already
+		// implements. Removed rather than "fixed" into behaviour nobody
+		// wanted. Found by review on #124, which had inherited the same
+		// no-op by copying this block.
+		rowsVisible = availableHeight - chrome
 		if rowsVisible < 1 {
 			rowsVisible = 1
 		}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -58,10 +58,11 @@ var helpGroups = []struct {
 		{"P", "pin repo (Repos)"},
 	}},
 	{"Activity", []helpBinding{
-		{"left / right", "heatmap ⇄ feed"},
-		{"enter", "open the event on GitHub"},
-		{"c", "copy the event's URL"},
-		{"r", "reload the feed"},
+		{"← / →, h / l", "switch heatmap ⇄ feed"},
+		{"enter", "feed: open the event on GitHub"},
+		{"c", "feed: copy the event's URL"},
+		{"/", "feed: filter by substring"},
+		{"r", "feed: reload (it does not ride the refresh)"},
 	}},
 	{"App", []helpBinding{
 		{"r", "refresh now"},

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -48,7 +48,7 @@ var helpGroups = []struct {
 		{"up / down", "move cursor"},
 		{"g / G", "top / bottom"},
 	}},
-	{"Lists (Repos / PRs / Issues)", []helpBinding{
+	{"Lists (Repos / PRs / Issues / Gists)", []helpBinding{
 		{"s", "cycle sort"},
 		{"/", "filter by substring"},
 		{"w", "work filter (Repos)"},
@@ -56,6 +56,12 @@ var helpGroups = []struct {
 		{"o", "open in browser"},
 		{"c", "copy URL"},
 		{"P", "pin repo (Repos)"},
+	}},
+	{"Activity", []helpBinding{
+		{"left / right", "heatmap ⇄ feed"},
+		{"enter", "open the event on GitHub"},
+		{"c", "copy the event's URL"},
+		{"r", "reload the feed"},
 	}},
 	{"App", []helpBinding{
 		{"r", "refresh now"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -889,7 +889,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.activeTab == TabActivity && m.activitySub == ActivitySubFeed {
 				if login := m.feedLogin(); login != "" {
 					m.feed = m.feed.startLoading()
-					feedCmd = fetchEventsCmd(m.client, login)
+					feedCmd = fetchEventsCmd(m.client, login, m.feed.gen)
 				}
 			}
 			if !m.loading {
@@ -1208,6 +1208,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case feedLoadedMsg:
+		// Drop a reply from a superseded load. `r` can be pressed twice
+		// before the first request answers, and without this the slower
+		// of the two wins whichever order they land in.
+		if msg.gen != m.feed.gen {
+			return m, nil
+		}
 		// No open-state guard, unlike the rate-limit panel: the feed is a
 		// sub-view rather than a modal, so a reply that lands after the
 		// user navigated away is still the right data for the next time

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -171,6 +171,18 @@ type Model struct {
 	issues IssuesModel
 	gists  GistsModel
 
+	// activitySub selects the Activity tab's half — heatmap or feed
+	// (#71) — switched with ←/→ while that tab is active.
+	activitySub ActivitySub
+
+	// feed is the events sub-view's state. Unlike every other list in
+	// the app it is NOT fed from Stats: it loads on demand the first
+	// time the sub-tab is opened, because the endpoint is REST-only,
+	// needs a login the profile query has to resolve first, and asks
+	// callers for a 60s poll interval that a 5s --refresh would blow
+	// straight through. See internal/ui/feed.go.
+	feed FeedModel
+
 	// starModeDefault seeds RepoDetailModel.starMode on every
 	// drill-in Open (config key default_star_history, #35). The
 	// in-detail `v` cycle changes the open detail only; the next
@@ -729,6 +741,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				var cmd tea.Cmd
 				m.issues, cmd = m.issues.Update(msg, eff, m.pinnedIssues)
 				return m, cmd
+			case m.activeTab == TabActivity && m.activitySub == ActivitySubFeed && m.feed.IsInputMode():
+				var cmd tea.Cmd
+				m.feed, cmd = m.feed.Update(msg, m.client.PublicOnly())
+				return m, cmd
 			}
 		}
 
@@ -862,13 +878,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.persistConfig()
 			return m, nil
 		case "r":
+			// The feed does not ride the dashboard refresh (see feed.go),
+			// so `r` has to reload it explicitly — otherwise the one key
+			// documented as "refresh" leaves the visible sub-view stale,
+			// which is worse than not offering it. Batched with the
+			// dashboard fetch rather than replacing it: the user asked to
+			// refresh, and the tab bar above is dashboard data too.
+			var feedCmd tea.Cmd
+			if m.activeTab == TabActivity && m.activitySub == ActivitySubFeed {
+				if login := m.feedLogin(); login != "" {
+					m.feed = m.feed.startLoading()
+					feedCmd = fetchEventsCmd(m.client, login)
+				}
+			}
 			if !m.loading {
 				m.loading = true
 				// Restart the spinner tick alongside the fetch so the
 				// animation begins immediately on user-triggered
 				// refreshes too. manual=true: a manual refresh must not
 				// spawn a second auto-refresh chain.
-				return m, tea.Batch(fetchCmd(m.client, true, m.refreshGen), m.spinner.Tick)
+				return m, tea.Batch(fetchCmd(m.client, true, m.refreshGen), m.spinner.Tick, feedCmd)
+			}
+			if feedCmd != nil {
+				return m, feedCmd
 			}
 		case "tab", "shift+tab":
 			if msg.String() == "tab" {
@@ -876,12 +908,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.activeTab = (m.activeTab - 1 + tabCount) % tabCount
 			}
-			return m, nil
+			// Landing on Activity with the feed selected has to fire its
+			// on-demand load, exactly as switching sub-tabs does — the
+			// user cannot tell which route brought them here, so both
+			// have to behave the same.
+			return m.maybeLoadFeed()
 		case "1", "2", "3", "4", "5", "6", "7":
 			// Digit → zero-based tab index. Safe because len("1"..."7") == 1
 			// and the range is bounded by tabCount via the case list.
 			m.activeTab = Tab(msg.String()[0] - '1')
-			return m, nil
+			return m.maybeLoadFeed()
 		default:
 			// Any other key is forwarded to the active tab's sub-model.
 			// Global keys above have already matched by this point.
@@ -921,6 +957,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.overviewVP, cmd = m.overviewVP.Update(msg)
 				return m, cmd
 			case TabActivity:
+				// ←/→ (and h/l) switch between the heatmap and the feed.
+				// Neither the viewport nor the feed binds them, so this
+				// steals nothing.
+				switch msg.String() {
+				case "right", "l":
+					return m.switchActivitySub(m.activitySub.next(1))
+				case "left", "h":
+					return m.switchActivitySub(m.activitySub.next(-1))
+				}
+				if m.activitySub == ActivitySubFeed {
+					var cmd tea.Cmd
+					m.feed, cmd = m.feed.Update(msg, m.client.PublicOnly())
+					return m, cmd
+				}
 				syncActivityViewport(&m)
 				var cmd tea.Cmd
 				m.activityVP, cmd = m.activityVP.Update(msg)
@@ -982,6 +1032,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// (startup paint, `r`, settings save) leaves nextTick nil so it
 		// can't spawn a parallel chain. tea.Batch / a bare return both
 		// tolerate a nil cmd.
+		// The first successful fetch is what resolves the login, and the
+		// feed cannot be loaded without one. A user who opened the feed
+		// sub-tab during the startup paint got a load that silently
+		// declined; fire it now that the name exists, or the sub-view
+		// sits on "loading…" until they navigate away and back.
+		var feedCmd tea.Cmd
+		m, feedCmd = m.maybeLoadFeed()
+
 		var nextTick tea.Cmd
 		if !msg.manual {
 			// Reschedule under the gen that ORIGINATED this fetch, not
@@ -1006,6 +1064,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				cmds := []tea.Cmd{
 					nextTick,
+					feedCmd,
 					tea.Tick(pulseDuration, func(t time.Time) tea.Msg {
 						return pulseExpireMsg{}
 					}),
@@ -1016,7 +1075,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 		}
-		return m, nextTick
+		return m, tea.Batch(nextTick, feedCmd)
 
 	case tickMsg:
 		// Drop ticks from a superseded chain (an interval change bumped
@@ -1145,6 +1204,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.rateLimits = m.rateLimits.applyFetched(msg.limits, msg.err)
+		return m, nil
+
+	case feedLoadedMsg:
+		// No open-state guard, unlike the rate-limit panel: the feed is a
+		// sub-view rather than a modal, so a reply that lands after the
+		// user navigated away is still the right data for the next time
+		// they look. Installing it costs nothing and saves a round trip.
+		if msg.err != nil {
+			m.feed = m.feed.failed(msg.err, msg.reason)
+			return m, nil
+		}
+		m.feed = m.feed.loaded(msg.events, msg.at)
 		return m, nil
 
 	case viewPRDetailMsg:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -750,12 +750,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Open action menu on a list-tab row. Handled here (before
 		// the global key switch) and ONLY for Repos / PRs / Issues /
-		// Gists,
-		// so on Overview / Activity the same key falls through to
-		// the default branch and reaches the viewport — which uses
-		// space as a page-down. Without this guard the action-menu
-		// case would unconditionally `return m, nil` on every tab
-		// and silently regress the documented page-down binding.
+		// Gists, so on Overview / Activity the same key falls through
+		// to the default branch and pages down — through the viewport
+		// on Overview and the Activity heatmap, and through the feed's
+		// own cursor on the Activity feed. Without this guard the
+		// action-menu case would unconditionally `return m, nil` on
+		// every tab and silently regress the documented page-down
+		// binding.
 		//
 		// Ctrl+Enter is also accepted for emulators that deliver
 		// the modifier (kitty, alacritty + xterm modifyOtherKeys,

--- a/internal/ui/scroll.go
+++ b/internal/ui/scroll.go
@@ -102,6 +102,10 @@ func syncActivityViewport(m *Model) {
 	}
 	content := renderActivityTab(m.effectiveStats(), available)
 	m.activityVP.Width = available
-	m.activityVP.Height = tabHeight
+	// The Activity tab spends two rows on its sub-tab bar (#71). Subtract
+	// them here as well as in the renderer, or the viewport believes it
+	// owns two rows it does not and stops two lines short of the end —
+	// a bug that looks exactly like "the heatmap has no more content".
+	m.activityVP.Height = activityBodyHeight(tabHeight)
 	m.activityVP.SetContent(content)
 }

--- a/internal/ui/sponsor_routing_test.go
+++ b/internal/ui/sponsor_routing_test.go
@@ -26,12 +26,25 @@ func newSponsorModel(t *testing.T) Model {
 	return m
 }
 
+// key builds a KeyMsg from its String() name. Shared across the package's
+// tests: the named keys have to be constructed by Type, because a rune
+// message spelling "up" is a three-character paste, not an arrow.
 func key(s string) tea.KeyMsg {
 	switch s {
 	case "ctrl+c":
 		return tea.KeyMsg{Type: tea.KeyCtrlC}
 	case "enter":
 		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
 	default:
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -217,20 +217,35 @@ func (m Model) renderOverviewScrolled(s *github.Stats, available, tabHeight int)
 	return vp.View()
 }
 
-// renderActivityScrolled mirrors renderOverviewScrolled for the
-// Activity tab. The 52-week heatmap + summary line is the other
-// static-content tab vulnerable to vertical clipping on short
-// windows.
+// renderActivityScrolled draws the Activity tab: the sub-tab bar, then
+// whichever half is selected (#71).
+//
+// The bar is outside the viewport on purpose — scrolling the heatmap must
+// not scroll the navigation away from under the user — so the body gets
+// tabHeight minus the bar, via the shared activityBodyHeight so this and
+// syncActivityViewport cannot drift apart.
+//
+// The 52-week heatmap + summary line is the static-content half, and the
+// one vulnerable to vertical clipping on short windows; the feed does its
+// own row budgeting and takes the height as a number rather than a
+// viewport.
 func (m Model) renderActivityScrolled(s *github.Stats, available, tabHeight int) string {
+	bar := renderActivitySubTabs(m.activitySub, available)
+	body := activityBodyHeight(tabHeight)
+
+	if m.activitySub == ActivitySubFeed {
+		return bar + "\n\n" + m.feed.renderFeed(available, body, m.client.PublicOnly())
+	}
+
 	content := renderActivityTab(s, available)
-	if tabHeight <= 0 {
-		return content
+	if body <= 0 {
+		return bar + "\n\n" + content
 	}
 	vp := m.activityVP
 	vp.Width = available
-	vp.Height = tabHeight
+	vp.Height = body
 	vp.SetContent(content)
-	return vp.View()
+	return bar + "\n\n" + vp.View()
 }
 
 // renderOverviewTab is the v0.2.0 dashboard body: Social, Activity,
@@ -1036,6 +1051,8 @@ func (m Model) listInputMode() bool {
 		return m.issues.IsInputMode()
 	case TabGists:
 		return m.gists.IsInputMode()
+	case TabActivity:
+		return m.activitySub == ActivitySubFeed && m.feed.IsInputMode()
 	}
 	return false
 }
@@ -1115,7 +1132,12 @@ func renderFooterBar(m Model) string {
 				scrollHint = keyHint("↑/↓", "scroll")
 			}
 		case TabActivity:
-			if m.activityVP.TotalLineCount() > m.activityVP.VisibleLineCount() {
+			// Only the heatmap half scrolls through the viewport. The feed
+			// budgets its own rows and prints its own hint line, so reading
+			// the viewport here would advertise a scroll that the visible
+			// sub-view does not perform.
+			if m.activitySub == ActivitySubHeatmap &&
+				m.activityVP.TotalLineCount() > m.activityVP.VisibleLineCount() {
 				scrollHint = keyHint("↑/↓", "scroll")
 			}
 		}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1132,13 +1132,16 @@ func renderFooterBar(m Model) string {
 				scrollHint = keyHint("↑/↓", "scroll")
 			}
 		case TabActivity:
+			// The tab has two halves and the footer is the only place that
+			// says so without the user pressing something first.
+			scrollHint = keyHint("←/→", "heatmap/feed")
 			// Only the heatmap half scrolls through the viewport. The feed
 			// budgets its own rows and prints its own hint line, so reading
 			// the viewport here would advertise a scroll that the visible
 			// sub-view does not perform.
 			if m.activitySub == ActivitySubHeatmap &&
 				m.activityVP.TotalLineCount() > m.activityVP.VisibleLineCount() {
-				scrollHint = keyHint("↑/↓", "scroll")
+				scrollHint += mutedStyle.Render(keyHintsSep) + keyHint("↑/↓", "scroll")
 			}
 		}
 		if scrollHint != "" {


### PR DESCRIPTION
Closes #71.

The Activity tab gets a second half, switched with `←`/`→` (or `h`/`l`). The heatmap answers *how much*; the feed answers *what*. A sub-tab rather than an eighth top-level entry, as the issue asked.

## Probed before writing Go

The repo rule paid off here — three measured facts contradict GitHub's own reference, and a design written from the docs would have shipped fields that never arrive:

| Documented | Actually sent |
|---|---|
| `payload.pull_request` — full PR object | `{base, head, id, number, url}`. **No title, no `html_url`.** |
| `PushEvent.payload.commits` / `size` | Absent. Only `before`, `head`, `push_id`, `ref`. |
| Pagination | Hard-stops at 3 pages; `page=4` is an HTTP **422**. |

`payload.issue`, by contrast, arrives whole — title included. That asymmetry drove most of what follows.

## Two decisions worth reviewing

**Loaded on demand, not with the dashboard.** The response carries `X-Poll-Interval: 60` and octoscope's `--refresh` floor is 5s, so riding the refresh would poll this endpoint twelve times faster than GitHub asks — for a sub-tab the user may never open. The endpoint also has no `viewer` form, so it needs a login the profile query has to resolve first. `r` reloads it explicitly.

**The raw stream is unreadable, and fixing that is the feature.** Twenty of the newest twenty-five events on the test account were reviews and comments on one pull request. The first cut answered "what happened recently" with the same line fifteen times — the Gists lesson, again. So:

- Adjacent review/comment traffic on the same subject folds into one row with a `×N` count. Only *adjacent*, only *same repo + number*, nothing reordered.
- **Approvals and change-requests never fold.** Folding the one review that mattered into a `×12` is precisely the failure to avoid. (`Event.Action` carries the review *state* for review events — the action itself was `"created"` on all 20 in the sample, so it carries nothing.)
- PR titles are **backfilled from sibling comment events in the same page** — zero extra requests, because the page already contains the answer attached to a different row. Where no sibling knows it, the row shows the bare number rather than inventing a label.

## Honesty about the window

GitHub keeps a limited window and we read one page of 100. On the test account that covered **two days**. The line under the table always names the span it actually got, and only claims truncation when the page is at the cap.

## Privacy

Follows the gists rule: `--public-only` asks `/events/public`, so private-repo activity is never fetched rather than fetched and hidden. The `p` toggle filters what is already in memory — events are not part of `Stats`, so `Stats.Public()` cannot reach them, and `visibleEvents` is where that lives with a test on it. The visibility column only renders when there is a mix to distinguish.

## Stated gap

**Not in `--json` / `--plain`.** The report is built from `FetchStats`; events are not in `Stats`, so including them means a REST call on every report run for a field most callers do not want. Deliberate, and filed as a follow-up rather than left unsaid.

## Verification

- Full suite green, `go vet` clean, `-race` clean.
- **Mutation-tested**: twelve guards broken one at a time. Two assertions turned out unable to fail — a cursor clamp masked by the renderer's own clamp, and an adjacency check that never saw two repositories sharing a number. Both rewritten to bite.
- **Run against the live API over a real pty**, not only in tests: `←`/`→`/`h`/`l` all switch, the feed renders, the cursor moves, links resolve.
- One thing reviewers may hit: **VHS reports the left arrow as killing the app. It does not** — confirmed against a pty and against the released 0.28.0, which behaves identically. Recorder artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Activity feed alongside the contribution heatmap.
  * Browse recent events with keyboard navigation, search, visibility filtering, event folding, and links to related subjects.
  * Feed loading, retry states, timestamps, empty states, and refresh behavior are now supported.
  * Switch between Heatmap and Feed views directly within the Activity tab.

* **Documentation**
  * Updated the user guide, keybinding reference, help overlay, and Activity descriptions to cover the new feed and controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->