### PR TITLE
feat(sponsors): who funds this account, and who it funds

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,15 @@ The dashboard is split into **tabs** (`Overview`, `Repos`, `PRs`, `Issues`,
   (`o` opens the Sponsors page, `c` copies the link). Jump here any time
   with `7`.
 
-The **Overview** tab is organised in five sections:
+The **Overview** tab is organised in six sections:
 
 - **Profile** — name, login, pronouns, bio, company, location, website, and
   how many years you've been on GitHub
 - **Social** — Followers · Following · Stars received (across your non-fork
   repositories) · plus a 4th *Stars + Forks* card when you own forks that
   carry stargazers, so the dashboard reconciles with counters that don't
-  filter forks out
+  filter forks out · plus *Sponsors* and *Sponsoring* cards (v0.29.0+) when
+  there is any sponsorship in that direction
 - **Activity** — lifetime PRs authored and merged, lifetime issues authored,
   and commits in the last 12 months, with a takeaway line ("X% of N PRs
   merged · M still open") summarising the funnel; underneath, a Languages
@@ -122,6 +123,23 @@ The **Overview** tab is organised in five sections:
 - **Operational** — repositories, forks received, open issues *(own)* and
   open PRs *(own)* across your owned repositories — the *(own)* qualifier
   disambiguates from your lifetime authored counts above
+- **Sponsors** (v0.29.0+) — who funds this account and who it funds, by
+  name, with GitHub's own monthly income estimate. **The whole section is
+  absent unless there is something to say**: an account with no sponsorship
+  and no listing never grows an empty row. An open listing with no sponsors
+  yet says so, because "nobody has sponsored me" and "I can't be sponsored"
+  are different statements.
+
+  Two limits are stated rather than papered over. There is **no tier, start
+  date or amount**, and no way to tell a public sponsor from a private one:
+  every one of those fields needs the `read:user` scope, and octoscope is
+  not going to ask you to widen a token so a dashboard can print a tier
+  name. And because the public/private distinction is exactly what can't be
+  read, **`--public-only` drops the section entirely** — names, counts and
+  income — rather than guessing which sponsors are safe to draw. The income
+  figure is your own or it is not shown at all; GitHub answers that field
+  with 0 for anybody else, so it is never read where a zero would be
+  indistinguishable from "not allowed to know".
 - **Network** — the organisations you're a member of plus your verified
   social accounts (X, LinkedIn, Bluesky, Mastodon…)
 
@@ -498,15 +516,28 @@ can iterate unconditionally.
                             "url": "...", "updated_at": "...", "private": false } ],
   "review_requests":    [ /* same shape as open_pull_requests, plus "author" */ ],
   "organizations":  [ { "login": "...", "name": "..." } ],
+  "sponsors":       [ { "login": "...", "name": "...", "url": "...", "is_org": false } ],
+  "sponsors_total":   0,
+  "sponsoring":     [ /* same shape as sponsors */ ],
+  "sponsoring_total": 0,
+  "has_sponsors_listing": false,
+  "monthly_sponsors_income_cents": 0,
   "watched_repos":  [ /* same shape as repositories */ ],
   "watched_skipped": [ "owner/renamed" ],
   "rate_limit": { "cost": 0, "limit": 5000, "remaining": 0, "reset_at": "..." }
 }
 ```
 
-`ci_state`, `latest_release` and `rate_limit` are omitted when empty /
-unavailable. Lists follow the same caps as the TUI (repositories up to
-100, PRs / issues up to 50).
+`ci_state`, `latest_release`, `rate_limit` and
+`monthly_sponsors_income_cents` are omitted when empty / unavailable. Lists
+follow the same caps as the TUI (repositories up to 100, PRs / issues up to
+50, sponsors up to 20 per direction).
+
+The sponsor totals are separate from the lists on purpose: both lists are
+capped, so comparing `len(sponsors)` against "how many sponsors do I have"
+is wrong on a busy account — read `sponsors_total`. And
+`monthly_sponsors_income_cents` is only ever present for the account the
+token belongs to.
 
 ## Themes
 

--- a/docs/guide/tabs.html
+++ b/docs/guide/tabs.html
@@ -29,7 +29,7 @@
           <li><b>Social</b> — followers, following, and total stars received across your non-fork repositories.</li>
           <li><b>Activity</b> — lifetime PRs authored and merged, issues opened, commits in the last year, and a languages bar in GitHub's own hex colours.</li>
           <li><b>Operational</b> — repositories, forks received, and the open issues / open PRs you own.</li>
-          <li><b>Sponsors</b> — who funds this account and who it funds, by name, with GitHub's own monthly income estimate. Absent entirely unless there is something to say. There is no tier, date or amount, and no way to tell a public sponsor from a private one — all of that needs the <code>read:user</code> scope — which is also why <code>--public-only</code> drops the section rather than guessing which names are safe to draw.</li>
+          <li><b>Sponsors</b> — who funds this account and who it funds, by name, plus GitHub's own monthly income estimate <b>for your own account only</b> (GitHub answers that field with 0 for anybody else, so it is never shown where a zero could be mistaken for a measurement). Absent entirely unless there is something to say. There is no tier, date or amount, and no way to tell a public sponsor from a private one — all of that needs the <code>read:user</code> scope — which is also why <code>--public-only</code> drops the section rather than guessing which names are safe to draw.</li>
           <li><b>Network</b> — organisations you belong to and your verified social accounts.</li>
         </ul>
         <p>plus a <b>Top repositories</b> list. Counters tagged <code>(own)</code> are your account's; the rest are lifetime totals.</p>

--- a/docs/guide/tabs.html
+++ b/docs/guide/tabs.html
@@ -29,6 +29,7 @@
           <li><b>Social</b> — followers, following, and total stars received across your non-fork repositories.</li>
           <li><b>Activity</b> — lifetime PRs authored and merged, issues opened, commits in the last year, and a languages bar in GitHub's own hex colours.</li>
           <li><b>Operational</b> — repositories, forks received, and the open issues / open PRs you own.</li>
+          <li><b>Sponsors</b> — who funds this account and who it funds, by name, with GitHub's own monthly income estimate. Absent entirely unless there is something to say. There is no tier, date or amount, and no way to tell a public sponsor from a private one — all of that needs the <code>read:user</code> scope — which is also why <code>--public-only</code> drops the section rather than guessing which names are safe to draw.</li>
           <li><b>Network</b> — organisations you belong to and your verified social accounts.</li>
         </ul>
         <p>plus a <b>Top repositories</b> list. Counters tagged <code>(own)</code> are your account's; the rest are lifetime totals.</p>

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -559,12 +559,23 @@ func (s *Stats) Public() *Stats {
 	// sponsors" over a list of one is its own disclosure — and the income
 	// is the single most screenshot-sensitive number the dashboard holds.
 	//
-	// HasSponsorsListing stays: it is on the public profile page already,
-	// and it is what lets the UI say "nobody yet" rather than vanish.
+	// HasSponsorsListing goes too, and the first version of this kept it —
+	// on the reasoning that the listing is already on the public profile
+	// page, so exposing it leaks nothing. That reasoning answered the wrong
+	// question. The leak was never the problem; the **claim** was.
+	//
+	// With the flag kept and the names stripped, renderSponsors falls to its
+	// "nobody yet — the listing is open" line. On an account that does have
+	// sponsors, screenshot mode was therefore *asserting it has none* —
+	// hiding and none wearing one appearance, which is the exact failure the
+	// scan's disclosures exist to prevent, arriving here instead. An absent
+	// section says "this mode does not show sponsorship"; a present one
+	// saying "nobody yet" says something false.
 	out.Sponsors = nil
 	out.SponsorsTotal = 0
 	out.Sponsoring = nil
 	out.SponsoringTotal = 0
+	out.HasSponsorsListing = false
 	out.MonthlySponsorsIncomeCents = 0
 
 	// WatchedSkipped names watch_repos refs that failed to resolve —

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -383,6 +383,29 @@ type Stats struct {
 	Gists      []Gist
 	GistsTotal int
 
+	// Sponsorship (#72). Sponsors is who funds this account, Sponsoring is
+	// who it funds; the totals are what GitHub reports for the same query,
+	// so a list capped at SponsorsPageSize can say it is a window.
+	//
+	// HasSponsorsListing is carried separately because it is the one fact
+	// that distinguishes "nobody sponsors this account" from "this account
+	// cannot be sponsored at all", and those read very differently.
+	//
+	// **No tier, no date, no amount, and no way to tell a public sponsor
+	// from a private one** — all of that needs `read:user`, which octoscope
+	// does not ask for. See internal/github/sponsors.go.
+	Sponsors           []Sponsor
+	SponsorsTotal      int
+	Sponsoring         []Sponsor
+	SponsoringTotal    int
+	HasSponsorsListing bool
+
+	// MonthlySponsorsIncomeCents is GitHub's own estimate, in cents USD.
+	// Zero unless these stats belong to the authenticated viewer: the
+	// field answers 0 for anyone else, so a non-zero value here always
+	// means "this is your own income" and never "their income is 0".
+	MonthlySponsorsIncomeCents int
+
 	// Meta
 	Authenticated bool
 	// IsViewer is true when the stats belong to the authenticated
@@ -526,6 +549,24 @@ func (s *Stats) Public() *Stats {
 		out.GistsTotal = len(out.Gists)
 	}
 
+	// Sponsorship (#72) goes entirely, names and counts and income alike.
+	//
+	// Not caution for its own sake: the one field that separates a public
+	// sponsor from a private one is `privacyLevel`, and reading it needs a
+	// scope octoscope does not ask for. So every name in this list is of
+	// *unknown* visibility, and a screenshot mode that cannot tell them
+	// apart has no business drawing any of them. The counts go too — "3
+	// sponsors" over a list of one is its own disclosure — and the income
+	// is the single most screenshot-sensitive number the dashboard holds.
+	//
+	// HasSponsorsListing stays: it is on the public profile page already,
+	// and it is what lets the UI say "nobody yet" rather than vanish.
+	out.Sponsors = nil
+	out.SponsorsTotal = 0
+	out.Sponsoring = nil
+	out.SponsoringTotal = 0
+	out.MonthlySponsorsIncomeCents = 0
+
 	// WatchedSkipped names watch_repos refs that failed to resolve —
 	// one may reference a repo that just went private, so screenshot
 	// mode drops the notice entirely rather than leak the name.
@@ -662,6 +703,21 @@ type profileFields struct {
 	Following struct {
 		TotalCount githubv4.Int
 	}
+
+	// Sponsorship (#72). Both connections ride inside this query rather
+	// than taking a branch of their own: measured at cost 1 for the whole
+	// profile query with the contribution calendar included, so they are
+	// free by the standard this repo judges additions against.
+	//
+	// Keep `first: 20` in step with sponsorsPageSize — a struct tag cannot
+	// interpolate a constant, and TestSponsorsPageSizeMatchesQuery fails if
+	// the two drift.
+	HasSponsorsListing githubv4.Boolean
+	// Only meaningful for the viewer; GitHub answers 0 for anyone else,
+	// which is why extractStats reads it only in viewer mode.
+	MonthlySponsorsIncomeCents githubv4.Int      `graphql:"monthlyEstimatedSponsorsIncomeInCents"`
+	Sponsors                   sponsorConnection `graphql:"sponsors(first: 20)"`
+	Sponsoring                 sponsorConnection `graphql:"sponsoring(first: 20)"`
 
 	PullRequests struct {
 		TotalCount githubv4.Int
@@ -1354,6 +1410,11 @@ func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *S
 		CreatedAt:                p.CreatedAt.Time,
 		Followers:                int(p.Followers.TotalCount),
 		Following:                int(p.Following.TotalCount),
+		Sponsors:                 extractSponsors(p.Sponsors),
+		SponsorsTotal:            int(p.Sponsors.TotalCount),
+		Sponsoring:               extractSponsors(p.Sponsoring),
+		SponsoringTotal:          int(p.Sponsoring.TotalCount),
+		HasSponsorsListing:       bool(p.HasSponsorsListing),
 		PRsTotal:                 int(p.PullRequests.TotalCount),
 		PRsMerged:                int(p.MergedPRs.TotalCount),
 		OpenPRsAuthored:          int(p.OpenPRs.TotalCount),
@@ -1363,6 +1424,16 @@ func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *S
 		PublicRepos:              int(r.Repositories.TotalCount),
 		Authenticated:            c.authenticated,
 		IsViewer:                 c.login == "",
+	}
+
+	// Income is read only in viewer mode, and that is a correctness rule
+	// rather than a privacy one. GitHub answers this field with 0 for any
+	// account that is not the caller's, so carrying it for someone else
+	// would put "$0.00 / month" on screen as though it were their income.
+	// Zero is the value that cannot be distinguished from "not allowed to
+	// know", so it is never read where it would be ambiguous.
+	if stats.IsViewer {
+		stats.MonthlySponsorsIncomeCents = int(p.MonthlySponsorsIncomeCents)
 	}
 
 	for _, sa := range p.SocialAccounts.Nodes {

--- a/internal/github/sponsors.go
+++ b/internal/github/sponsors.go
@@ -1,0 +1,136 @@
+package github
+
+// Sponsors — who funds this account, and who it funds (#72).
+//
+// The issue asked for the scope to be settled before anything was built,
+// and settling it is what shaped this file. Measured against the live API
+// on 2026-08-19 with the token octoscope already asks for
+// (`admin:public_key, gist, read:org, repo, workflow`):
+//
+//   - `sponsors` and `sponsoring` answer fine. Both are unions of User and
+//     Organization, so both are discriminated on `__typename`.
+//   - **Everything interesting about a sponsorship needs `read:user`.**
+//     `sponsorshipsAsMaintainer`'s `privacyLevel`, `createdAt`,
+//     `isOneTimePayment` and `tier` all return INSUFFICIENT_SCOPES. So the
+//     tab shows *who*, and cannot show *since when*, *how much* or
+//     *public or private*. Asking users to widen a token so a dashboard
+//     can print a tier name is not a trade this project makes.
+//   - The money fields do answer, and only for the account itself:
+//     `monthlyEstimatedSponsorsIncomeInCents` returned 2500 for the viewer
+//     and **0** for another user. GitHub documents that behaviour for
+//     `totalSponsorshipAmountAsSponsorInCents` — *"Only returns a value
+//     when viewed by the user themselves"* — and the measurement says the
+//     income field behaves the same way. Which makes 0 ambiguous with a
+//     genuine zero, so it is only ever read in viewer mode.
+//
+// **One thing could not be verified, and the design assumes the worst.**
+// Whether `sponsors` includes *private* sponsors is not answerable here:
+// the schema description says only "List of sponsors for this user or
+// organization", and on the account this was built against the public and
+// the include-private counts are both 1, so the two are indistinguishable.
+// Since `privacyLevel` is exactly the field the token cannot read, there is
+// no way to tell one sponsor from another. Screenshot mode therefore drops
+// the whole block rather than guessing — see Stats.Public.
+
+import (
+	"strings"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// Sponsor is one account on either side of a sponsorship.
+//
+// Deliberately thin: it holds what the query can actually answer for. No
+// tier, no start date, no amount — see the file comment for why, and note
+// that adding any of them means asking the user for a wider token.
+type Sponsor struct {
+	Login string
+	Name  string
+	URL   string
+	// IsOrg separates the two members of the union. Kept as a bool rather
+	// than the raw `__typename` because those are the only two GitHub
+	// returns here, and a caller asking "is this an org" should not have
+	// to know the schema's spelling.
+	IsOrg bool
+}
+
+// Label is what the UI shows for a sponsor: the display name when GitHub
+// has one, the login otherwise. Chosen here rather than in the renderer
+// only because both sides of the section want the same rule; it invents
+// nothing, which is the line that matters.
+func (s Sponsor) Label() string {
+	if n := strings.TrimSpace(s.Name); n != "" {
+		return n
+	}
+	return s.Login
+}
+
+// sponsorsPageSize bounds each connection. Twenty is well past what any
+// dashboard section can draw — the counts come back alongside, so a busy
+// account renders "and 156 more" instead of a list that silently stops.
+const sponsorsPageSize = 20
+
+// SponsorsPageSize is the cap the UI discloses, exported so the renderer
+// does not carry a second copy of the number.
+const SponsorsPageSize = sponsorsPageSize
+
+// sponsorConnection is the shared shape of both connections. Both are
+// unions of User and Organization, and both are discriminated on
+// `__typename` rather than on which fragment came back populated —
+// shurcooL/githubv4 resolves shared field names across inline fragments,
+// so "which one looks filled in" is not a discriminator.
+type sponsorConnection struct {
+	TotalCount githubv4.Int
+	Nodes      []struct {
+		Typename string `graphql:"__typename"`
+		User     struct {
+			Login githubv4.String
+			Name  githubv4.String
+			URL   githubv4.String `graphql:"url"`
+		} `graphql:"... on User"`
+		Organization struct {
+			Login githubv4.String
+			Name  githubv4.String
+			URL   githubv4.String `graphql:"url"`
+		} `graphql:"... on Organization"`
+	}
+}
+
+// extractSponsors maps one connection, cleaning every GitHub-sourced
+// string at this boundary like the rest of the package.
+func extractSponsors(c sponsorConnection) []Sponsor {
+	if len(c.Nodes) == 0 {
+		return nil
+	}
+	out := make([]Sponsor, 0, len(c.Nodes))
+	for _, n := range c.Nodes {
+		var s Sponsor
+		switch n.Typename {
+		case "Organization":
+			s = Sponsor{
+				Login: Sanitize(string(n.Organization.Login)),
+				Name:  Sanitize(string(n.Organization.Name)),
+				URL:   Sanitize(string(n.Organization.URL)),
+				IsOrg: true,
+			}
+		case "User":
+			s = Sponsor{
+				Login: Sanitize(string(n.User.Login)),
+				Name:  Sanitize(string(n.User.Name)),
+				URL:   Sanitize(string(n.User.URL)),
+			}
+		default:
+			// A type GitHub adds later. Skipped rather than guessed at:
+			// a row with no login is not a sponsor anyone can read.
+			continue
+		}
+		if s.Login == "" {
+			continue
+		}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/github/sponsors_test.go
+++ b/internal/github/sponsors_test.go
@@ -163,10 +163,13 @@ func TestPublicDropsEverySponsorshipField(t *testing.T) {
 	if got.MonthlySponsorsIncomeCents != 0 {
 		t.Errorf("income survived: %d", got.MonthlySponsorsIncomeCents)
 	}
-	// The listing flag stays: it is on the public profile page already, and
-	// it is what lets the UI say "nobody yet" rather than vanish entirely.
-	if !got.HasSponsorsListing {
-		t.Error("HasSponsorsListing was dropped; it is public and load-bearing")
+	// The listing flag goes as well. Keeping it is not a leak — the listing
+	// is on the public profile page — but it drops renderSponsors onto its
+	// "nobody yet" line, so an account *with* sponsors would have screenshot
+	// mode assert it has none. Hiding and none must not wear one appearance.
+	if got.HasSponsorsListing {
+		t.Error("HasSponsorsListing survived; the section then claims 'nobody yet' " +
+			"for an account that has sponsors")
 	}
 }
 

--- a/internal/github/sponsors_test.go
+++ b/internal/github/sponsors_test.go
@@ -1,0 +1,192 @@
+package github
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// sponsorNode is the anonymous node type of sponsorConnection, named here
+// so the helpers below can build one.
+type sponsorNode = struct {
+	Typename string `graphql:"__typename"`
+	User     struct {
+		Login githubv4.String
+		Name  githubv4.String
+		URL   githubv4.String `graphql:"url"`
+	} `graphql:"... on User"`
+	Organization struct {
+		Login githubv4.String
+		Name  githubv4.String
+		URL   githubv4.String `graphql:"url"`
+	} `graphql:"... on Organization"`
+}
+
+// node builds one node with BOTH fragments populated. That is not a
+// contrived shape: shurcooL/githubv4 resolves shared field names across
+// inline fragments, so a User node really can come back carrying values in
+// the Organization struct. Every test below therefore proves the extractor
+// reads __typename rather than "whichever half looks filled in".
+func node(typename, userLogin, userName, orgLogin, orgName string) sponsorNode {
+	var n sponsorNode
+	n.Typename = typename
+	n.User.Login = githubv4.String(userLogin)
+	n.User.Name = githubv4.String(userName)
+	n.User.URL = githubv4.String("https://github.com/" + userLogin)
+	n.Organization.Login = githubv4.String(orgLogin)
+	n.Organization.Name = githubv4.String(orgName)
+	n.Organization.URL = githubv4.String("https://github.com/" + orgLogin)
+	return n
+}
+
+func conn(total int, nodes ...sponsorNode) sponsorConnection {
+	var c sponsorConnection
+	c.TotalCount = githubv4.Int(total)
+	c.Nodes = append(c.Nodes, nodes...)
+	return c
+}
+
+func TestExtractSponsorsDiscriminatesOnTypename(t *testing.T) {
+	got := extractSponsors(conn(2,
+		node("User", "kastov", "Yury Kastov", "acme", "Acme Inc"),
+		node("Organization", "someone", "Some One", "charmbracelet", "Charm"),
+	))
+	if len(got) != 2 {
+		t.Fatalf("got %d sponsors, want 2", len(got))
+	}
+	if got[0].Login != "kastov" || got[0].IsOrg {
+		t.Errorf("first = %+v, want the User fragment", got[0])
+	}
+	if got[1].Login != "charmbracelet" || !got[1].IsOrg {
+		t.Errorf("second = %+v, want the Organization fragment", got[1])
+	}
+	// Both fragments were populated on both nodes, so reading the wrong one
+	// yields a plausible-looking sponsor with the wrong identity — which is
+	// why this is asserted on the value and not on emptiness.
+	if got[0].Login == "acme" || got[1].Login == "someone" {
+		t.Error("the extractor read the fragment __typename did not name")
+	}
+}
+
+// GitHub adds union members. A row with no login is not a sponsor anyone
+// can read, so it is dropped rather than drawn blank.
+func TestExtractSponsorsSkipsWhatItCannotName(t *testing.T) {
+	got := extractSponsors(conn(3,
+		node("Bot", "", "", "", ""),
+		node("User", "", "No Login", "", ""),
+		node("User", "real", "Real Person", "", ""),
+	))
+	if len(got) != 1 || got[0].Login != "real" {
+		t.Fatalf("got %+v, want only the nameable one", got)
+	}
+}
+
+func TestExtractSponsorsEmpty(t *testing.T) {
+	if got := extractSponsors(conn(0)); got != nil {
+		t.Errorf("extractSponsors(empty) = %v, want nil", got)
+	}
+}
+
+// A sponsor's display name is attacker-controlled in the same way every
+// other GitHub-sourced string is: whoever owns the account picks it, and
+// it is about to be written to a terminal.
+func TestExtractSponsorsSanitizes(t *testing.T) {
+	got := extractSponsors(conn(1, node("User", "someone", "real\x1b]0;pwned\x07name", "", "")))
+	if len(got) != 1 {
+		t.Fatalf("got %d", len(got))
+	}
+	if strings.ContainsAny(got[0].Name, "\x1b\x07") {
+		t.Errorf("Name kept a terminal escape: %q", got[0].Name)
+	}
+	if strings.Contains(got[0].Name, "pwned") {
+		t.Errorf("Name kept the OSC payload: %q", got[0].Name)
+	}
+}
+
+func TestSponsorLabelPrefersTheNameThenTheLogin(t *testing.T) {
+	for _, tc := range []struct{ name, login, want string }{
+		{"Yury Kastov", "kastov", "Yury Kastov"},
+		{"", "kastov", "kastov"},
+		{"   ", "kastov", "kastov"},
+	} {
+		if got := (Sponsor{Name: tc.name, Login: tc.login}).Label(); got != tc.want {
+			t.Errorf("Label(name=%q login=%q) = %q, want %q", tc.name, tc.login, got, tc.want)
+		}
+	}
+}
+
+// The constant and the two struct tags are three copies of one number, and
+// a tag cannot interpolate a constant, so only a test keeps them in step.
+func TestSponsorsPageSizeMatchesQuery(t *testing.T) {
+	if sponsorsPageSize != 20 {
+		t.Fatalf("sponsorsPageSize is %d — update this test and both struct tags",
+			sponsorsPageSize)
+	}
+	src, err := os.ReadFile("client.go")
+	if err != nil {
+		t.Fatalf("read client.go: %v", err)
+	}
+	for _, q := range []string{"sponsors(first: 20)", "sponsoring(first: 20)"} {
+		if !strings.Contains(string(src), q) {
+			t.Errorf("client.go no longer queries %q — it has drifted from sponsorsPageSize", q)
+		}
+	}
+}
+
+// Screenshot mode drops the whole block rather than filtering it, because
+// there is nothing to filter on: `privacyLevel` needs a scope octoscope
+// does not ask for, so every name here is of unknown visibility.
+//
+// There is deliberately no IsPrivate field on Sponsor, which is exactly why
+// TestPublicStripsEveryPrivateList cannot reach this and this test exists.
+func TestPublicDropsEverySponsorshipField(t *testing.T) {
+	s := &Stats{
+		Sponsors:                   []Sponsor{{Login: "kastov"}},
+		SponsorsTotal:              3,
+		Sponsoring:                 []Sponsor{{Login: "fisker"}},
+		SponsoringTotal:            12,
+		HasSponsorsListing:         true,
+		MonthlySponsorsIncomeCents: 2500,
+	}
+	got := s.Public()
+
+	if got.Sponsors != nil || got.Sponsoring != nil {
+		t.Errorf("names survived: %+v / %+v", got.Sponsors, got.Sponsoring)
+	}
+	// The counts go too: "3 sponsors" printed above a list of one is its
+	// own disclosure — the same second-order leak the gists total avoids.
+	if got.SponsorsTotal != 0 || got.SponsoringTotal != 0 {
+		t.Errorf("counts survived: %d / %d", got.SponsorsTotal, got.SponsoringTotal)
+	}
+	if got.MonthlySponsorsIncomeCents != 0 {
+		t.Errorf("income survived: %d", got.MonthlySponsorsIncomeCents)
+	}
+	// The listing flag stays: it is on the public profile page already, and
+	// it is what lets the UI say "nobody yet" rather than vanish entirely.
+	if !got.HasSponsorsListing {
+		t.Error("HasSponsorsListing was dropped; it is public and load-bearing")
+	}
+}
+
+// GitHub answers the income field with 0 for any account that is not the
+// caller's, so reading it outside viewer mode would print someone else's
+// income as $0.00 rather than declining to say.
+func TestIncomeIsReadOnlyForTheViewer(t *testing.T) {
+	var p profileFields
+	p.Login = "octocat"
+	p.MonthlySponsorsIncomeCents = 2500
+
+	viewer := (&Client{login: ""}).extractStats(p, repoFields{}, repoCIFields{})
+	if viewer.MonthlySponsorsIncomeCents != 2500 {
+		t.Errorf("viewer income = %d, want 2500", viewer.MonthlySponsorsIncomeCents)
+	}
+
+	other := (&Client{login: "someone-else"}).extractStats(p, repoFields{}, repoCIFields{})
+	if other.MonthlySponsorsIncomeCents != 0 {
+		t.Errorf("income = %d for another account — GitHub answers 0 there, so any "+
+			"non-zero value could only come from reading it where it means nothing",
+			other.MonthlySponsorsIncomeCents)
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -53,9 +53,25 @@ type Report struct {
 	ReviewRequests   []PullRequest `json:"review_requests"`
 	Organizations    []Org         `json:"organizations"`
 	Gists            []Gist        `json:"gists"`
-	WatchedRepos     []Repo        `json:"watched_repos"`
-	WatchedSkipped   []string      `json:"watched_skipped"`
-	RateLimit        *RateLimit    `json:"rate_limit,omitempty"`
+
+	// Sponsorship (#72). Additive, so no SchemaVersion bump.
+	//
+	// The totals are separate from the lists on purpose: both lists are
+	// capped at github.SponsorsPageSize, so a script that compared
+	// len(sponsors) against "how many sponsors do I have" would quietly be
+	// wrong on a busy account. MonthlySponsorsIncomeCents is only ever
+	// non-zero for the account the token belongs to — GitHub answers 0 for
+	// anybody else, which is why it is omitted rather than printed as a
+	// zero somebody could mistake for a measurement.
+	Sponsors                   []Sponsor  `json:"sponsors"`
+	SponsorsTotal              int        `json:"sponsors_total"`
+	Sponsoring                 []Sponsor  `json:"sponsoring"`
+	SponsoringTotal            int        `json:"sponsoring_total"`
+	HasSponsorsListing         bool       `json:"has_sponsors_listing"`
+	MonthlySponsorsIncomeCents int        `json:"monthly_sponsors_income_cents,omitempty"`
+	WatchedRepos               []Repo     `json:"watched_repos"`
+	WatchedSkipped             []string   `json:"watched_skipped"`
+	RateLimit                  *RateLimit `json:"rate_limit,omitempty"`
 }
 
 // Gist is one gist. Label is what the TUI shows on the row — the
@@ -235,8 +251,15 @@ func FromStats(s *github.Stats, octoscopeVersion string, generatedAt time.Time, 
 		ReviewRequests:   toPRs(s.ReviewRequests),
 		Organizations:    toOrgs(s.Organizations),
 		Gists:            toGists(s.Gists),
-		WatchedRepos:     toRepos(s.WatchedRepos),
-		WatchedSkipped:   nonNilStrings(s.WatchedSkipped),
+
+		Sponsors:                   toSponsors(s.Sponsors),
+		SponsorsTotal:              s.SponsorsTotal,
+		Sponsoring:                 toSponsors(s.Sponsoring),
+		SponsoringTotal:            s.SponsoringTotal,
+		HasSponsorsListing:         s.HasSponsorsListing,
+		MonthlySponsorsIncomeCents: s.MonthlySponsorsIncomeCents,
+		WatchedRepos:               toRepos(s.WatchedRepos),
+		WatchedSkipped:             nonNilStrings(s.WatchedSkipped),
 	}
 	if s.RateLimit != nil {
 		r.RateLimit = &RateLimit{
@@ -430,6 +453,8 @@ func RenderPlain(w io.Writer, r Report) error {
 	writeIssueList(&b, "Open issues", r.OpenIssuesList)
 	writePRList(&b, "Review requests", r.ReviewRequests)
 	writeGistList(&b, "Gists", r.Gists)
+	writeSponsorList(&b, "Sponsors", r.Sponsors, r.SponsorsTotal)
+	writeSponsorList(&b, "Sponsoring", r.Sponsoring, r.SponsoringTotal)
 	writeRepoList(&b, "Watched", r.WatchedRepos)
 	if len(r.WatchedSkipped) > 0 {
 		fmt.Fprintf(&b, "\n%d watched %s skipped: %s\n",
@@ -539,4 +564,54 @@ func plural(n int, one, many string) string {
 		return one
 	}
 	return many
+}
+
+// Sponsor is one account on either side of a sponsorship.
+//
+// Thin because the query is: tier, start date, amount and public-versus-
+// private all need the `read:user` scope octoscope does not ask for, so
+// they are absent from the wire contract rather than present and empty.
+type Sponsor struct {
+	Login string `json:"login"`
+	Name  string `json:"name"`
+	URL   string `json:"url"`
+	IsOrg bool   `json:"is_org"`
+}
+
+func toSponsors(in []github.Sponsor) []Sponsor {
+	out := make([]Sponsor, 0, len(in))
+	for _, s := range in {
+		out = append(out, Sponsor{
+			Login: s.Login,
+			Name:  s.Name,
+			URL:   s.URL,
+			IsOrg: s.IsOrg,
+		})
+	}
+	return out
+}
+
+// writeSponsorList prints one side of the sponsorship. total is stated
+// separately from the list because the list is capped — "showing 20 of
+// 176" is the honest header, and a bare list of twenty is not.
+func writeSponsorList(b *strings.Builder, title string, list []Sponsor, total int) {
+	if total == 0 && len(list) == 0 {
+		return
+	}
+	header := fmt.Sprintf("%d", total)
+	if total > len(list) {
+		header = fmt.Sprintf("showing %d of %d", len(list), total)
+	}
+	fmt.Fprintf(b, "\n%s (%s)\n", title, header)
+	for _, s := range list {
+		kind := "user"
+		if s.IsOrg {
+			kind = "org"
+		}
+		name := s.Name
+		if name == "" {
+			name = s.Login
+		}
+		fmt.Fprintf(b, "  %-24s %-5s %s\n", s.Login, kind, name)
+	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -303,6 +303,8 @@ var diffIDs = []struct {
 	{"forks_received", func(s *github.Stats) int { return s.ForksReceived }},
 	{"open_issues", func(s *github.Stats) int { return s.OpenIssues }},
 	{"open_prs", func(s *github.Stats) int { return s.OpenPRs }},
+	{"sponsors", func(s *github.Stats) int { return s.SponsorsTotal }},
+	{"sponsoring", func(s *github.Stats) int { return s.SponsoringTotal }},
 }
 
 // changedCards returns the subset of card ids whose numeric value

--- a/internal/ui/sponsors.go
+++ b/internal/ui/sponsors.go
@@ -1,0 +1,155 @@
+package ui
+
+// Sponsors — who funds this account and who it funds (#72), on the
+// Overview tab.
+//
+// Two surfaces, deliberately, because they answer different questions with
+// data of different shapes. The **counts** join the Social card row, where
+// a person already looks for followers and stars, and get the pulse-on-
+// change treatment for free — a new sponsor arriving is exactly the kind of
+// passive event the pulse exists for. The **names** get their own section,
+// modelled on Network: a label column with the list packed and wrapped
+// under it, because a name list is not a number and does not belong in a
+// card.
+//
+// Both are absent by default. An account nobody sponsors and that sponsors
+// nobody shows neither the cards nor the section — the same rule the
+// pinned / watched / review-request sections follow, and the reason the
+// tab does not grow a permanently empty row for most users.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// sponsorCards returns the conditional additions to the Social card row.
+// Nothing is added for an account with no sponsorship in either direction,
+// so the row keeps its shape for the overwhelming majority of users.
+func sponsorCards(s *github.Stats) []cardSpec {
+	if s == nil {
+		return nil
+	}
+	var out []cardSpec
+	if s.SponsorsTotal > 0 {
+		out = append(out, cardSpec{
+			id: "sponsors", icon: "♥", label: "Sponsors", short: "Sponsors",
+			value: s.SponsorsTotal,
+		})
+	}
+	if s.SponsoringTotal > 0 {
+		out = append(out, cardSpec{
+			id: "sponsoring", icon: "♡", label: "Sponsoring", short: "Sponsoring",
+			value: s.SponsoringTotal,
+		})
+	}
+	return out
+}
+
+// sponsorLabels turns a capped list into the strings the row prints, and
+// appends the honest remainder when the fetch saw fewer than GitHub has.
+//
+// The remainder is computed from the *total*, not from the page size, so a
+// list that happens to be short does not claim to be truncated — the same
+// distinction the events feed draws about its own window.
+func sponsorLabels(list []github.Sponsor, total int) []string {
+	out := make([]string, 0, len(list)+1)
+	for _, sp := range list {
+		label := sp.Label()
+		if sp.IsOrg {
+			// Organizations and people read differently in a mixed list,
+			// and GitHub's own listing separates them. One glyph is enough
+			// to stop "Acme Inc" looking like somebody's display name.
+			label = "▣ " + label
+		}
+		out = append(out, label)
+	}
+	if rest := total - len(list); rest > 0 {
+		out = append(out, fmt.Sprintf("and %d more", rest))
+	}
+	return out
+}
+
+// formatCents renders a cents amount as US dollars, which is the unit
+// GitHub reports in and the only one it reports in.
+func formatCents(cents int) string {
+	return fmt.Sprintf("$%d.%02d", cents/100, cents%100)
+}
+
+// The row labels deliberately do not repeat the section title. Rendered
+// under a heading of "Sponsors", a row also labelled "Sponsors" reads as a
+// stutter — which is only visible by running it, not by reading it. The
+// issue's own wording ("sponsors received and given") is the fix.
+const (
+	sponsorsLabel   = "Received"
+	sponsoringLabel = "Given   "
+	incomeLabel     = "Income  "
+	sponsorLabelGap = "  "
+)
+
+// renderSponsors draws the section body: who sponsors this account, who it
+// sponsors, and — for the viewer only — GitHub's monthly income estimate.
+//
+// Returns "" when there is nothing worth a section, which is what keeps it
+// off the Overview for accounts with no sponsorship at all.
+func renderSponsors(s *github.Stats, available int) string {
+	if s == nil {
+		return ""
+	}
+
+	valueWidth := available - lipgloss.Width(sponsorsLabel) - lipgloss.Width(sponsorLabelGap)
+	if valueWidth < 20 {
+		valueWidth = 20
+	}
+
+	line := func(label string, items []string) string {
+		packed := packLines(items, " · ", valueWidth)
+		return mutedStyle.Render(label) + sponsorLabelGap +
+			indentContinuation(packed, label, sponsorLabelGap)
+	}
+
+	var lines []string
+
+	switch {
+	case len(s.Sponsors) > 0:
+		lines = append(lines, line(sponsorsLabel, sponsorLabels(s.Sponsors, s.SponsorsTotal)))
+	case s.SponsorsTotal > 0:
+		// A count with no names is what public-only leaves behind on a
+		// different code path, and it is also what a future cap change
+		// could produce. Say the number rather than drawing an empty row.
+		lines = append(lines, mutedStyle.Render(sponsorsLabel)+sponsorLabelGap+
+			valueStyle.Render(fmt.Sprintf("%d", s.SponsorsTotal)))
+	case s.HasSponsorsListing:
+		// The distinction worth drawing: this account *can* be sponsored
+		// and nobody has yet. Saying nothing here would read as "octoscope
+		// does not know", which is a different and wronger claim.
+		lines = append(lines, mutedStyle.Render(sponsorsLabel)+sponsorLabelGap+
+			mutedStyle.Render("nobody yet — the listing is open"))
+	}
+
+	if len(s.Sponsoring) > 0 {
+		lines = append(lines, line(sponsoringLabel, sponsorLabels(s.Sponsoring, s.SponsoringTotal)))
+	} else if s.SponsoringTotal > 0 {
+		lines = append(lines, mutedStyle.Render(sponsoringLabel)+sponsorLabelGap+
+			valueStyle.Render(fmt.Sprintf("%d", s.SponsoringTotal)))
+	}
+
+	// Income is the viewer's own, or it is not shown. GitHub answers this
+	// field with 0 for anyone else, so the github package only carries it
+	// in viewer mode — a zero here means "not ours to say", never "zero".
+	if s.MonthlySponsorsIncomeCents > 0 {
+		lines = append(lines, mutedStyle.Render(incomeLabel)+sponsorLabelGap+
+			valueStyle.Render(formatCents(s.MonthlySponsorsIncomeCents))+
+			mutedStyle.Render(" / month estimated by GitHub"))
+	}
+
+	// No explicit empty check: strings.Join over no lines is already "",
+	// which is the signal the caller tests for. Two earlier guards said the
+	// same thing — an up-front "is there any sponsorship" predicate and a
+	// len(lines)==0 return — and mutating either away changed no behaviour
+	// and failed no test, which is the definition of a second source of
+	// truth. One mechanism, stated once.
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/sponsors_test.go
+++ b/internal/ui/sponsors_test.go
@@ -212,10 +212,15 @@ func TestOverviewDropsTheSponsorsSectionUnderPublicOnly(t *testing.T) {
 			t.Errorf("public-only leaked %q", leak)
 		}
 	}
-	// It degrades to the open-listing line rather than vanishing, because
-	// HasSponsorsListing is public and deliberately survives.
-	if !strings.Contains(public, "nobody yet") {
-		t.Errorf("public-only should still say the listing is open:\n%s", public)
+	// And it must vanish rather than degrade. Falling back to the
+	// open-listing line would have screenshot mode state "nobody yet" over
+	// an account that has a sponsor — an omission turning into a false
+	// claim, which is worse than what the mode exists to prevent.
+	if strings.Contains(public, "nobody yet") {
+		t.Errorf("public-only claims the account has no sponsors:\n%s", public)
+	}
+	if strings.Contains(public, "Sponsors") {
+		t.Errorf("the Sponsors section survived public-only:\n%s", public)
 	}
 }
 

--- a/internal/ui/sponsors_test.go
+++ b/internal/ui/sponsors_test.go
@@ -1,0 +1,233 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+func sp(login, name string, org bool) github.Sponsor {
+	return github.Sponsor{Login: login, Name: name, IsOrg: org, URL: "https://github.com/" + login}
+}
+
+// Section absence is the default UX here, same as pinned / watched /
+// review-requests: an account with no sponsorship in either direction and
+// no listing grows no permanently empty row.
+func TestSponsorSectionAbsentWithoutAnySponsorship(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+	if got := renderSponsors(&github.Stats{}, 120); got != "" {
+		t.Errorf("rendered %q for an account with nothing to say", got)
+	}
+	if got := renderSponsors(nil, 120); got != "" {
+		t.Errorf("rendered %q for nil stats", got)
+	}
+	if cards := sponsorCards(&github.Stats{}); len(cards) != 0 {
+		t.Errorf("added %d cards for an account with no sponsorship", len(cards))
+	}
+}
+
+// The cards are only useful if they are actually appended to the row —
+// testing sponsorCards alone leaves the wiring unasserted, and removing
+// that one line passed the whole suite until this existed.
+func TestSponsorCardsReachTheSocialRow(t *testing.T) {
+	m := newFeedRoutingModel(t)
+
+	with := ansi.Strip(m.renderSocial(&github.Stats{
+		Followers: 1, SponsorsTotal: 3, SponsoringTotal: 2,
+	}, 200))
+	if !strings.Contains(with, "Sponsors") {
+		t.Errorf("the Sponsors card is missing from the Social row:\n%s", with)
+	}
+	if !strings.Contains(with, "Sponsoring") {
+		t.Errorf("the Sponsoring card is missing from the Social row:\n%s", with)
+	}
+
+	without := ansi.Strip(m.renderSocial(&github.Stats{Followers: 1}, 200))
+	if strings.Contains(without, "Sponsor") {
+		t.Errorf("an account with no sponsorship grew a card:\n%s", without)
+	}
+}
+
+// "Nobody sponsors this account" and "this account cannot be sponsored"
+// are different statements, and only one of them is worth drawing.
+func TestSponsorSectionSaysNobodyYetWhenTheListingIsOpen(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+	got := ansi.Strip(renderSponsors(&github.Stats{HasSponsorsListing: true}, 120))
+	if !strings.Contains(got, "nobody yet") {
+		t.Errorf("an open listing with no sponsors rendered as %q", got)
+	}
+	// And the counterpart: no listing at all draws nothing rather than
+	// claiming nobody has sponsored them.
+	if got := renderSponsors(&github.Stats{HasSponsorsListing: false}, 120); got != "" {
+		t.Errorf("an account with no listing rendered %q", got)
+	}
+}
+
+func TestSponsorCardsAppearOnlyForTheSideThatHasAny(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		stats   github.Stats
+		wantIDs []string
+	}{
+		{"neither", github.Stats{}, nil},
+		{"received only", github.Stats{SponsorsTotal: 3}, []string{"sponsors"}},
+		{"given only", github.Stats{SponsoringTotal: 2}, []string{"sponsoring"}},
+		{"both", github.Stats{SponsorsTotal: 3, SponsoringTotal: 2}, []string{"sponsors", "sponsoring"}},
+	} {
+		var ids []string
+		for _, c := range sponsorCards(&tc.stats) {
+			ids = append(ids, c.id)
+		}
+		if strings.Join(ids, ",") != strings.Join(tc.wantIDs, ",") {
+			t.Errorf("%s: cards %v, want %v", tc.name, ids, tc.wantIDs)
+		}
+	}
+}
+
+// The remainder is computed from the total, so a short list never claims
+// to be truncated and a capped one never looks complete.
+func TestSponsorLabelsStateTheRemainderOnlyWhenThereIsOne(t *testing.T) {
+	list := []github.Sponsor{sp("a", "Ada", false), sp("b", "Bob", false)}
+
+	full := strings.Join(sponsorLabels(list, 2), " | ")
+	if strings.Contains(full, "more") {
+		t.Errorf("a complete list claimed truncation: %q", full)
+	}
+
+	capped := strings.Join(sponsorLabels(list, 176), " | ")
+	if !strings.Contains(capped, "and 174 more") {
+		t.Errorf("a capped list did not say so: %q", capped)
+	}
+}
+
+// An organisation in a list of people reads as somebody's display name
+// unless it is marked.
+func TestSponsorLabelsMarkOrganisations(t *testing.T) {
+	got := sponsorLabels([]github.Sponsor{
+		sp("ada", "Ada Lovelace", false),
+		sp("acme", "Acme Inc", true),
+	}, 2)
+	if got[0] != "Ada Lovelace" {
+		t.Errorf("person = %q, want the bare name", got[0])
+	}
+	if !strings.HasPrefix(got[1], "▣ ") || !strings.Contains(got[1], "Acme Inc") {
+		t.Errorf("organisation = %q, want it marked", got[1])
+	}
+}
+
+// Falls back to the login, because a sponsor with no display name is
+// common and a blank row is not a row.
+func TestSponsorLabelsFallBackToTheLogin(t *testing.T) {
+	got := sponsorLabels([]github.Sponsor{sp("kastov", "", false)}, 1)
+	if got[0] != "kastov" {
+		t.Errorf("got %q, want the login", got[0])
+	}
+}
+
+// GitHub answers the income field with 0 for any account that is not the
+// caller's, so a zero must never reach the screen as "$0.00" — it means
+// "not ours to say", and the two are indistinguishable once printed.
+func TestIncomeIsDrawnOnlyWhenItIsOurs(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+
+	other := ansi.Strip(renderSponsors(&github.Stats{
+		Sponsors: []github.Sponsor{sp("ada", "Ada", false)}, SponsorsTotal: 1,
+	}, 120))
+	if strings.Contains(other, "$") || strings.Contains(other, "Income") {
+		t.Errorf("income rendered for an account that reports none: %q", other)
+	}
+
+	ours := ansi.Strip(renderSponsors(&github.Stats{
+		Sponsors: []github.Sponsor{sp("ada", "Ada", false)}, SponsorsTotal: 1,
+		MonthlySponsorsIncomeCents: 2500,
+	}, 120))
+	if !strings.Contains(ours, "$25.00") {
+		t.Errorf("our own income did not render: %q", ours)
+	}
+}
+
+func TestFormatCents(t *testing.T) {
+	for cents, want := range map[int]string{
+		0:      "$0.00",
+		5:      "$0.05",
+		250:    "$2.50",
+		2500:   "$25.00",
+		123456: "$1234.56",
+	} {
+		if got := formatCents(cents); got != want {
+			t.Errorf("formatCents(%d) = %q, want %q", cents, got, want)
+		}
+	}
+}
+
+// The user-visible half of "section absence is the default": an account
+// with no sponsorship must not grow a bare "Sponsors" heading over nothing.
+// Only renderOverviewTab can show that — renderSponsors returning "" is
+// necessary and not sufficient, and the guard that drops the heading went
+// unasserted until this existed.
+func TestOverviewOmitsTheSponsorsHeadingWhenThereIsNothingToSay(t *testing.T) {
+	m := newFeedRoutingModel(t)
+
+	bare := ansi.Strip(m.renderOverviewTab(&github.Stats{Login: "octocat"}, 140))
+	if strings.Contains(bare, "Sponsors") {
+		t.Errorf("an account with no sponsorship grew a Sponsors section:\n%s", bare)
+	}
+	// Network still renders, so this is not "the whole tab collapsed".
+	if !strings.Contains(bare, "Network") {
+		t.Fatalf("precondition: the rest of the Overview should still render:\n%s", bare)
+	}
+
+	with := ansi.Strip(m.renderOverviewTab(&github.Stats{
+		Login: "octocat", HasSponsorsListing: true,
+	}, 140))
+	if !strings.Contains(with, "Sponsors") {
+		t.Errorf("an open listing should still earn the section:\n%s", with)
+	}
+}
+
+// The whole point of screenshot mode here: the section must not survive
+// it, because nothing in the data says which sponsors are private.
+func TestOverviewDropsTheSponsorsSectionUnderPublicOnly(t *testing.T) {
+	m := newFeedRoutingModel(t)
+	s := &github.Stats{
+		Login:                      "octocat",
+		Sponsors:                   []github.Sponsor{sp("kastov", "Yury Kastov", false)},
+		SponsorsTotal:              1,
+		Sponsoring:                 []github.Sponsor{sp("fisker", "Fisker", false)},
+		SponsoringTotal:            1,
+		HasSponsorsListing:         true,
+		MonthlySponsorsIncomeCents: 2500,
+	}
+
+	full := ansi.Strip(m.renderOverviewTab(s, 140))
+	if !strings.Contains(full, "Yury Kastov") || !strings.Contains(full, "$25.00") {
+		t.Fatalf("precondition: the section should render in normal mode:\n%s", full)
+	}
+
+	public := ansi.Strip(m.renderOverviewTab(s.Public(), 140))
+	for _, leak := range []string{"Yury Kastov", "kastov", "Fisker", "fisker", "$25.00"} {
+		if strings.Contains(public, leak) {
+			t.Errorf("public-only leaked %q", leak)
+		}
+	}
+	// It degrades to the open-listing line rather than vanishing, because
+	// HasSponsorsListing is public and deliberately survives.
+	if !strings.Contains(public, "nobody yet") {
+		t.Errorf("public-only should still say the listing is open:\n%s", public)
+	}
+}
+
+// Rendering at absurd sizes must not panic — the terminal can be anything.
+func TestRenderSponsorsSurvivesExtremeGeometry(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+	s := &github.Stats{SponsorsTotal: 200, HasSponsorsListing: true,
+		MonthlySponsorsIncomeCents: 999999}
+	for i := 0; i < 40; i++ {
+		s.Sponsors = append(s.Sponsors, sp("someone-with-a-long-login", strings.Repeat("Name ", 8), i%3 == 0))
+	}
+	for _, w := range []int{0, 1, 12, 40, 120, 400} {
+		_ = renderSponsors(s, w)
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -256,6 +256,9 @@ func (m Model) renderOverviewTab(s *github.Stats, available int) string {
 	b.WriteString(renderSection("Social", m.renderSocial(s, available)) + "\n")
 	b.WriteString(renderSection("Activity", m.renderActivity(s, available)) + "\n")
 	b.WriteString(renderSection("Operational", m.renderOperational(s, available)) + "\n")
+	if sponsors := renderSponsors(s, available); sponsors != "" {
+		b.WriteString(renderSection("Sponsors", sponsors) + "\n")
+	}
 	b.WriteString(renderSection("Network", renderNetwork(s, available)))
 	return b.String()
 }
@@ -587,6 +590,10 @@ func (m Model) renderSocial(s *github.Stats, available int) string {
 			short: "+Forks", value: s.TotalStarsWithForks,
 		})
 	}
+	// Sponsorship counts (#72), added only when there is any — see
+	// sponsorCards. Being cards is what gets them the pulse on a change,
+	// which for a new sponsor is the point.
+	specs = append(specs, sponsorCards(s)...)
 	return renderCardRow(available, m.compact, m.pulseMap, specs)
 }
 


### PR DESCRIPTION
Closes #72.

The issue asked for the scope to be settled **before** anything was built. It was, and it shaped the whole feature.

## What the token can and cannot see

Measured live against the token octoscope already asks for (`admin:public_key, gist, read:org, repo, workflow`):

| | |
|---|---|
| `sponsors`, `sponsoring` | ✅ answer fine — unions of User and Organization, discriminated on `__typename` |
| `hasSponsorsListing` | ✅ |
| `monthlyEstimatedSponsorsIncomeInCents` | ✅ **for the viewer only** — returned `2500` for the viewer, `0` for another user |
| `privacyLevel`, `createdAt`, `isOneTimePayment`, `tier` | ❌ `INSUFFICIENT_SCOPES` — all need `read:user` |

So this shows **who**, and cannot show *since when*, *how much*, or *public versus private*. Asking someone to widen a token so a dashboard can print a tier name is not a trade this project makes, and the limits are stated in the README rather than left to be discovered.

**Cost 1** for the whole profile query with both connections *and* the contribution calendar, so they ride inside `profileFields` rather than taking a branch of their own.

## The one thing that could not be verified

Whether `sponsors` includes **private** sponsors is not answerable here. The schema description says only *"List of sponsors for this user or organization"*, and on the account this was built against the public and include-private counts are both 1 — indistinguishable. And `privacyLevel` is precisely the field the token cannot read.

So `--public-only` **drops the entire block** — names, counts and income — rather than guessing which names are safe to draw. The counts go too: "3 sponsors" printed over a list of one is its own disclosure, the same second-order leak the gists total avoids.

`Sponsor` deliberately has **no `IsPrivate` field**, which is why `TestPublicStripsEveryPrivateList` cannot reach this and a dedicated test exists.

## Two surfaces, because the data has two shapes

- **Counts → Social card row.** That is where a person already looks for followers and stars, and it gets the pulse-on-change for free — a new sponsor arriving is exactly the passive event the pulse exists for.
- **Names → their own Overview section**, modelled on Network: label column, list packed and wrapped underneath. Organisations carry a glyph so "Acme Inc" doesn't read as somebody's display name.

Both absent unless there is something to say. An open listing with no sponsors *says so*, because "nobody has sponsored me" and "I can't be sponsored" are different statements and silence would be a third, wronger one.

## Income is never guessed

GitHub answers the income field with `0` for any account that is not the caller's, so a zero is indistinguishable from "not allowed to know". It is read only in viewer mode and omitted from `--json` when absent — never printed as `$0.00` for someone else.

## In the report, unlike the feed

`--json` / `--plain` carry it, because sponsors are part of `Stats` and there is no extra request to justify (the contrast with #125 is deliberate). Additive → no `SchemaVersion` bump. Totals are separate from the lists because both lists are capped at 20.

## Verification

- Full suite, `go vet`, `-race` all clean. Exercised live: viewer, `--public-only`, another account, `--json`, `--plain`, and the TUI over a real pty.
- **Running it caught what reading it did not**: the section title and the first row label were both "Sponsors" — a stutter invisible on the page. Renamed to the issue's own words, Received / Given.
- **Mutation-tested, fifteen guards.** Three were assertions that could not fail, and two of those were the *same* defect twice: an up-front "is there any sponsorship" predicate and a `len(lines)==0` return, both duplicating what `strings.Join` already does. Deleted rather than dressed up — the same call as the dead row-budget branch on #124, and it would have been inconsistent to defend here what I removed there.

## Unrelated, but worth recording

`octoscope sindresorhus` times out (`context deadline exceeded`). **Pre-existing** — the released 0.28.0 fails identically on that account. Not touched here; say the word and I'll file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Sponsors section to the Overview tab, showing sponsors, sponsoring activity, totals, account types, and listing status.
  * Added optional monthly sponsorship income for the authenticated viewer.
  * Added sponsorship details to JSON and plain-text reports, including capped-list indicators.
  * Added pulse highlights when sponsor or sponsoring counts change.

* **Documentation**
  * Documented sponsorship behavior, data limitations, visibility rules, and `--public-only` handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->