### PR TITLE
fix(deps): go 1.25.13 for five stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gfazioli/octoscope
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
`main` is red on govulncheck and has been since `c6cc26d` (the merge of #124). **Pre-existing** — every branch cut from main inherits it, which is how PR #129 turned up red without touching anything related.

All five are stdlib, and all five name the same fix:

| Advisory | Package | Fixed in |
|---|---|---|
| GO-2026-6218 | `net/url` | go1.25.13 |
| GO-2026-6090 | `crypto/tls` | go1.25.13 |
| GO-2026-6088 | `encoding/xml` | go1.25.13 |
| GO-2026-5972 | `encoding/asn1` | go1.25.13 |
| GO-2026-5026 | `net/http` | go1.25.13 |

So the `go` directive is the fix, per the CI supply-chain note in `CLAUDE.md`: stdlib advisories move the directive, dependency ones move the module. One line.

**Standalone rather than folded into the feature branch in flight**, which is the documented precedent — GO-2026-5856 and GO-2026-5970 each landed as their own `fix(deps):` PR and then shipped inside the following cycle. It also unblocks `main` rather than only the branch that happened to notice.

## Verification, and what it does not prove

`govulncheck@v1.4.0` locally, the same pin CI uses: **No vulnerabilities found.**

Worth being precise about that, because a measurement taken with the wrong configuration is worse than none: the local toolchain is **1.26.6**, so the run demonstrates that a modern stdlib is clean, not that **1.25.13 specifically** is enough. The advisories' own `Fixed in:` lines are what say 1.25.13 suffices, and CI — which builds from `go-version-file: go.mod` — is what confirms it. If this PR goes green, that is the proof.

Full suite and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)