### PR TITLE
docs(guide): close the 0.29.0 coverage gaps, and give the tabs page a sidebar

### DIFF
--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -8,7 +8,22 @@
     { group: "Guide", items: [
       { id: "start",     label: "Getting started",   href: "index.html" },
       { id: "auth",      label: "Authentication",     href: "auth.html" },
-      { id: "tabs",      label: "The tabs",           href: "tabs.html" },
+      // anchors: in-page sub-navigation, rendered only while this page is
+      // the active one. The tabs page is by far the longest in the guide —
+      // eight tabs under one sidebar entry meant a reader after the Inbox
+      // scrolled past six others to reach it. Kept as anchors rather than
+      // split into pages: the pager chain is linear and hand-maintained,
+      // and it has already been broken once by an inserted page.
+      { id: "tabs",      label: "The tabs",           href: "tabs.html",
+        anchors: [
+          { href: "#overview",    label: "1 Overview" },
+          { href: "#repos",       label: "2 Repos" },
+          { href: "#prs-issues",  label: "3 PRs · 4 Issues" },
+          { href: "#activity",    label: "5 Activity" },
+          { href: "#gists",       label: "6 Gists" },
+          { href: "#inbox",       label: "7 Inbox" },
+          { href: "#whats-new",   label: "8 What's new" }
+        ] },
       { id: "drill",     label: "Drill-ins & scan",   href: "drill-ins.html" },
       { id: "live",      label: "Live & reliable",    href: "live.html" },
       { id: "themes",    label: "Themes",             href: "themes.html" },
@@ -34,9 +49,19 @@
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {
-        var on = it.id === page ? " active" : "";
+        var isActive = it.id === page;
+        var on = isActive ? " active" : "";
         html += '<a class="navlink' + on + '" href="' + it.href + '">' +
                 '<span class="dot"></span>' + it.label + '</a>';
+        // Sub-navigation only for the page you are on. Showing every
+        // page's anchors would trade one long page for a long sidebar.
+        if (isActive && it.anchors) {
+          html += '<div class="subnav">';
+          it.anchors.forEach(function (a) {
+            html += '<a class="sublink" href="' + a.href + '">' + a.label + '</a>';
+          });
+          html += '</div>';
+        }
       });
       html += '</div>';
     });
@@ -45,6 +70,49 @@
       '<a href="https://github.com/gfazioli/octoscope">GitHub</a></div>';
     sb.innerHTML = html;
   }
+
+  // ---- sub-navigation: mark the section you are actually reading ----
+  //
+  // Without this the `.here` style would be a rule nothing ever applies, and
+  // an in-page nav that cannot tell you where you are is just a list.
+  //
+  // Observes the headings rather than listening to scroll: nothing to
+  // throttle, and it stays correct when a click jumps straight to an anchor.
+  // The band is pushed down by the sticky topbar, or the heading sitting
+  // under it would read as off-screen while it is the one being read.
+  (function () {
+    var links = [].slice.call(document.querySelectorAll(".sublink"));
+    if (!links.length || !("IntersectionObserver" in window)) return;
+
+    var targets = links
+      .map(function (a) { return document.getElementById(a.getAttribute("href").slice(1)); })
+      .filter(Boolean);
+    if (!targets.length) return;
+
+    var topbar = parseInt(getComputedStyle(document.documentElement)
+      .getPropertyValue("--topbar"), 10) || 56;
+    var band = topbar + 40;
+
+    var passed = {};
+    function paint() {
+      // The last heading whose top has crossed the band is the one being
+      // read; anything below it is still ahead of the reader.
+      var current = null;
+      targets.forEach(function (t) { if (passed[t.id]) current = t.id; });
+      links.forEach(function (a) {
+        a.classList.toggle("here", a.getAttribute("href") === "#" + current);
+      });
+    }
+
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        passed[e.target.id] = e.boundingClientRect.top < band;
+      });
+      paint();
+    }, { threshold: 0, rootMargin: "-" + band + "px 0px 0px 0px" });
+
+    targets.forEach(function (t) { io.observe(t); });
+  })();
 
   // ---- version badge ----
   // Same trick as the landing's hero pill: read the latest published

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -114,6 +114,126 @@
     targets.forEach(function (t) { io.observe(t); });
   })();
 
+  // ---- screenshot gallery ----
+  //
+  // The stills are 1400px or 3400px wide in a ~600px column, so the
+  // terminal text they exist to show is unreadable in place. Click one and
+  // it fills the window; arrow keys walk the page's screenshots as a
+  // gallery.
+  //
+  // Two levels, because one is not enough for both families of capture.
+  // The 1400px tab stills are already at natural size once fitted to the
+  // window. The 3400px drill-in captures are still 2.6x smaller than
+  // natural even fitted, so those also get a 1:1 view with the stage
+  // scrolling. The zoom control is hidden when the fitted size already
+  // equals the natural one — an affordance that does nothing is worse than
+  // none.
+  (function () {
+    var shots = [].slice.call(document.querySelectorAll(".frame img"));
+    if (!shots.length) return;
+
+    // Promoted here rather than in the markup: the behaviour is JS-only,
+    // so static HTML claiming role="button" would promise what a JS-less
+    // page cannot do. Plain HTML still renders the image inline.
+    shots.forEach(function (img, i) {
+      var frame = img.closest(".frame");
+      if (!frame) return;
+      frame.classList.add("zoomable");
+      frame.setAttribute("role", "button");
+      frame.setAttribute("tabindex", "0");
+      frame.setAttribute("aria-label", "Enlarge screenshot: " + (img.alt || "screenshot " + (i + 1)));
+      frame.addEventListener("click", function () { open(i); });
+      frame.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); open(i); }
+      });
+    });
+
+    var lb = document.createElement("div");
+    lb.className = "lb";
+    lb.setAttribute("role", "dialog");
+    lb.setAttribute("aria-modal", "true");
+    lb.setAttribute("aria-label", "Screenshot viewer");
+    lb.innerHTML =
+      '<div class="lb-bar">' +
+        '<span class="lb-count"></span>' +
+        '<span class="lb-cap"></span>' +
+        '<button class="lb-btn lb-prev" aria-label="Previous screenshot">&larr;</button>' +
+        '<button class="lb-btn lb-next" aria-label="Next screenshot">&rarr;</button>' +
+        '<button class="lb-btn lb-zoom"></button>' +
+        '<button class="lb-btn lb-close" aria-label="Close viewer">esc</button>' +
+      '</div><div class="lb-stage"><img alt=""></div>';
+    document.body.appendChild(lb);
+
+    var img   = lb.querySelector(".lb-stage img");
+    var stage = lb.querySelector(".lb-stage");
+    var cap   = lb.querySelector(".lb-cap");
+    var count = lb.querySelector(".lb-count");
+    var zoomB = lb.querySelector(".lb-zoom");
+    var at = 0, opener = null;
+
+    // Whether 1:1 would show more than the fitted view. Measured against
+    // the stage's own box, so it answers the question for this window
+    // rather than in the abstract.
+    function canZoom() {
+      return img.naturalWidth > stage.clientWidth - 36 ||
+             img.naturalHeight > stage.clientHeight - 36;
+    }
+    function paintZoom() {
+      zoomB.hidden = !canZoom();
+      zoomB.textContent = lb.classList.contains("zoomed") ? "fit" : "1:1";
+    }
+
+    function show(i) {
+      at = (i + shots.length) % shots.length;
+      lb.classList.remove("zoomed");
+      img.src = shots[at].currentSrc || shots[at].src;
+      img.alt = shots[at].alt || "";
+      cap.textContent = shots[at].alt || "";
+      count.textContent = (at + 1) + " / " + shots.length;
+      lb.querySelector(".lb-prev").hidden = shots.length < 2;
+      lb.querySelector(".lb-next").hidden = shots.length < 2;
+      // naturalWidth is 0 until decode, so ask again once it lands.
+      if (img.complete) paintZoom(); else img.onload = paintZoom;
+    }
+
+    function open(i) {
+      opener = document.activeElement;
+      show(i);
+      lb.classList.add("open");
+      document.body.classList.add("lb-lock");
+      lb.querySelector(".lb-close").focus();
+    }
+    function close() {
+      lb.classList.remove("open", "zoomed");
+      document.body.classList.remove("lb-lock");
+      // Put focus back where it came from, or the reader is dropped at the
+      // top of the document with no idea where they were.
+      if (opener && opener.focus) opener.focus();
+    }
+
+    lb.querySelector(".lb-close").addEventListener("click", close);
+    lb.querySelector(".lb-prev").addEventListener("click", function () { show(at - 1); });
+    lb.querySelector(".lb-next").addEventListener("click", function () { show(at + 1); });
+    zoomB.addEventListener("click", function () { lb.classList.toggle("zoomed"); paintZoom(); });
+    img.addEventListener("click", function () {
+      if (canZoom()) { lb.classList.toggle("zoomed"); paintZoom(); }
+    });
+    // Backdrop only: a click that lands on the image or the bar is not a
+    // request to leave.
+    lb.addEventListener("click", function (e) { if (e.target === lb || e.target === stage) close(); });
+
+    document.addEventListener("keydown", function (e) {
+      if (!lb.classList.contains("open")) return;
+      if (e.key === "Escape")     { close(); }
+      else if (e.key === "ArrowLeft")  { show(at - 1); }
+      else if (e.key === "ArrowRight") { show(at + 1); }
+      else if (e.key === "Home")  { show(0); }
+      else if (e.key === "End")   { show(shots.length - 1); }
+      else return;
+      e.preventDefault();
+    });
+  })();
+
   // ---- version badge ----
   // Same trick as the landing's hero pill: read the latest published
   // release rather than hardcoding a number that goes stale the moment

--- a/docs/guide/drill-ins.html
+++ b/docs/guide/drill-ins.html
@@ -35,6 +35,7 @@
           <li><b>Repos</b> → description, languages, release, a Checks section (<kbd>c</kbd> expands it past the first eight), and a 12-month star-history sparkline — <kbd>v</kbd> toggles it between density and a cumulative curve.</li>
           <li><b>Pull requests</b> → metadata, reviewers, timeline, and an inline <b>diff viewer</b> (<kbd>f</kbd> → files → <kbd>Enter</kbd>).</li>
           <li><b>Issues</b> → the full body rendered as markdown, labels and timeline.</li>
+          <li><b>Gists</b> → the one that goes two levels deep: <kbd>enter</kbd> opens a multi-file gist's file list, <kbd>enter</kbd> again opens a file — <b>syntax-highlighted and scrollable</b> — and <kbd>c</kbd> there copies the <b>code</b> rather than the link. A one-file gist opens straight into the file, because that was the only thing there was to see. GitHub truncates very large files and a gist can hold a binary; both are said out loud rather than rendered as noise.</li>
         </ul>
 
         <figure class="shot">
@@ -46,7 +47,7 @@
         </figure>
 
         <h2>Reached from the action menu</h2>
-        <p>Press <kbd>space</kbd> on a row for its action menu — open on github.com, copy the URL, view details, and (on a repo) run the integrity scan.</p>
+        <p>Press <kbd>space</kbd> on any list row — Repos, PRs, Issues, Gists or Inbox — for its action menu — open on github.com, copy the URL, view details, and (on a repo) run the integrity scan.</p>
         <figure class="shot">
           <div class="frame">
             <div class="bar"><i></i><i></i><i></i><span class="ttl">octoscope — action menu</span></div>

--- a/docs/guide/keybinds.html
+++ b/docs/guide/keybinds.html
@@ -36,7 +36,7 @@
         </table>
 
         <table class="keys">
-          <caption>In a list — Repos · PRs · Issues</caption>
+          <caption>In a list — Repos · PRs · Issues · Gists</caption>
           <tbody>
             <tr><td class="k"><kbd>↑</kbd><kbd>↓</kbd> · <kbd>j</kbd><kbd>k</kbd></td><td>Move up / down</td></tr>
             <tr><td class="k"><kbd>g</kbd> · <kbd>G</kbd></td><td>Jump to top / bottom</td></tr>

--- a/docs/guide/live.html
+++ b/docs/guide/live.html
@@ -35,6 +35,7 @@
         <h2>Live feedback</h2>
         <p>When a value changes between refreshes — a new star lands, someone follows, a PR merges — the affected card's border <b>flashes accent-pink for two seconds</b>. No diffing numbers with your eyes.</p>
         <p>Changes to your <b>Stars</b> and <b>Followers</b> also fire a <b>native system notification</b> with a short beep, so you catch passive attention even when octoscope is in a background tab. It works on macOS, Linux and Windows and is click-through to the relevant page.</p>
+        <p><b>These are not the same thing as the Inbox tab</b>, and the difference is worth holding onto. What is described here is octoscope <i>noticing a number change between two of its own refreshes</i> — nobody sent it to you. The <a href="tabs.html#inbox">Inbox</a> is GitHub's own notification feed: mentions, review requests, assignments — things somebody actually addressed to you. One is a delta octoscope computed; the other is a message GitHub delivered.</p>
         <div class="note">
           <span class="ic">i</span>
           <p><b>macOS:</b> native notifications use <code>terminal-notifier</code>. Homebrew pulls it in automatically; if you installed octoscope another way, <code>brew install terminal-notifier</code> once and you're set. Without it, the in-app change-pulse still works.</p>

--- a/docs/guide/scripting.html
+++ b/docs/guide/scripting.html
@@ -42,6 +42,8 @@
         <div class="note">
           <span class="ic">↗</span>
           <p>The full field-by-field JSON schema lives in the <a href="https://github.com/gfazioli/octoscope#scripting--plain-and-json">README's Scripting section</a> — this page is the tour, the README is the contract.</p>
+          <p>Two things about the shape that a field list will not warn you about. <b>Counts are separate from lists, because the lists are capped</b> — <code>sponsors</code> holds up to 20 entries while <code>sponsors_total</code> is what GitHub reports, so comparing <code>len(sponsors)</code> against &ldquo;how many sponsors do I have&rdquo; is wrong on a busy account. Same for repositories, PRs and issues, which have caps of their own. And <b><code>monthly_sponsors_income_cents</code> is only ever present for the account the token belongs to</b> — GitHub answers that field with 0 for anybody else, so it is omitted rather than emitted as a zero somebody could read as a measurement.</p>
+          <p>The notification inbox is deliberately <b>not</b> in either output. It is loaded on demand in the TUI rather than on every refresh, so putting it here would mean a REST call on every <code>--json</code> run for a field most callers do not want. Tracked as <a href="https://github.com/gfazioli/octoscope/issues/125">issue #125</a>.</p>
         </div>
 
         <div class="pager">

--- a/docs/guide/style.css
+++ b/docs/guide/style.css
@@ -147,6 +147,51 @@ figure.shot { margin: 0 0 12px; }
 .frame img { display: block; width: 100%; height: auto; }
 figcaption { font-size: 13px; color: var(--faint); margin: 10px 2px 30px; }
 
+/* Zoomable screenshots + lightbox.
+   ------------------------------------------------------------------
+   The stills are 1400px or 3400px wide and sit in a ~600px column, so
+   the terminal text they exist to show is unreadable in place. The
+   affordance is added by docs.js rather than in the markup, because the
+   behaviour is JS-only and a role="button" in static HTML would promise
+   something a JS-less page cannot do. Everything below is var()-driven,
+   so both themes and the toggle come for free. */
+.frame.zoomable { cursor: zoom-in; }
+.frame.zoomable:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+.lb {
+  position: fixed; inset: 0; z-index: 60; display: none;
+  background: color-mix(in srgb, var(--bg) 92%, black);
+  backdrop-filter: blur(6px);
+}
+.lb.open { display: grid; grid-template-rows: auto 1fr; }
+body.lb-lock { overflow: hidden; }
+
+.lb-bar {
+  display: flex; align-items: center; gap: 14px; padding: 12px 18px;
+  border-bottom: 1px solid var(--border); font-family: var(--mono); font-size: 12.5px; color: var(--muted);
+}
+.lb-count { color: var(--faint); }
+.lb-cap { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lb-btn {
+  font-family: var(--mono); font-size: 12.5px; color: var(--muted); background: var(--surface-2);
+  border: 1px solid var(--border); border-radius: 7px; padding: 5px 10px; cursor: pointer;
+}
+.lb-btn:hover, .lb-btn:focus-visible { color: var(--text); border-color: var(--border-strong); }
+.lb-btn[hidden] { display: none; }
+
+/* The stage centres the image and never upscales it: max-width alone
+   means anything narrower than the viewport renders at natural size. */
+.lb-stage { display: grid; place-items: center; overflow: auto; padding: 18px; }
+.lb-stage img {
+  display: block; max-width: 96vw; max-height: calc(100vh - 100px);
+  width: auto; height: auto; border-radius: 10px; border: 1px solid var(--border-strong);
+}
+/* 1:1, for the captures whose natural size beats the fitted one — the
+   stage scrolls rather than the page. */
+.lb.zoomed .lb-stage { place-items: start; }
+.lb.zoomed .lb-stage img { max-width: none; max-height: none; cursor: zoom-out; }
+
+
 /* callout */
 .note { display: flex; gap: 12px; margin: 0 0 22px; border: 1px solid var(--border); border-left: 3px solid var(--accent); background: var(--accent-soft); border-radius: 10px; padding: 14px 16px; }
 .note .ic { color: var(--accent); font-family: var(--mono); font-weight: 700; }

--- a/docs/guide/style.css
+++ b/docs/guide/style.css
@@ -80,6 +80,18 @@ nav.side { padding: 14px 12px 24px; }
 .navlink .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--faint); flex: none; transition: background .15s; }
 .navlink.active { color: var(--text); background: var(--accent-soft); font-weight: 600; }
 .navlink.active .dot { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+/* In-page sub-navigation under the active sidebar entry. Everything is a
+   var(), so both themes and the light/dark toggle are inherited rather than
+   re-declared. Plain anchors, so keyboard reachability comes for free —
+   unlike the landing's cards, which had to be promoted in JS. */
+.subnav { display: flex; flex-direction: column; margin: 2px 0 6px 19px; padding-left: 10px; border-left: 1px solid var(--border); }
+.sublink {
+  color: var(--faint); font-size: 13px; padding: 4px 8px; border-radius: 6px;
+  transition: background .15s ease, color .15s ease;
+}
+.sublink:hover, .sublink:focus-visible { color: var(--text); background: var(--surface-2); text-decoration: none; }
+.sublink.here { color: var(--text); font-weight: 600; }
+
 .sidebar-foot { margin-top: auto; padding: 14px 20px; border-top: 1px solid var(--border); font-family: var(--mono); font-size: 12px; color: var(--faint); display: flex; gap: 14px; }
 .sidebar-foot a { color: var(--muted); }
 

--- a/docs/guide/tabs.html
+++ b/docs/guide/tabs.html
@@ -20,10 +20,10 @@
       <article class="page">
         <p class="eyebrow">Guide</p>
         <h1>The tabs</h1>
-        <p class="lead">octoscope is six views over one account, each a number key away. The banner, profile card, tab bar and footer stay pinned — only the body swaps.</p>
+        <p class="lead">octoscope is eight views over one account, each a number key away. The banner, profile card, tab bar and footer stay pinned — only the body swaps.</p>
 
-        <h2><kbd>1</kbd> Overview</h2>
-        <p>The landing dashboard — your whole account in one paint, grouped into five sub-sections:</p>
+        <h2 id="overview"><kbd>1</kbd> Overview</h2>
+        <p>The landing dashboard — your whole account in one paint, grouped into six sub-sections:</p>
         <ul>
           <li><b>Profile</b> — name, login, pronouns, bio, company, location, website, and how many years you've been on GitHub.</li>
           <li><b>Social</b> — followers, following, and total stars received across your non-fork repositories.</li>
@@ -40,7 +40,7 @@
           </div>
         </figure>
 
-        <h2><kbd>2</kbd> Repos</h2>
+        <h2 id="repos"><kbd>2</kbd> Repos</h2>
         <p>Every repository you own, sortable, with a CI rollup dot, stars, forks, open issues/PRs, last push and latest release. Pinned repos (<kbd>P</kbd>) ride a sticky section at the top; watched repos from your config sit below.</p>
         <p>Three keys shape the list: <kbd>s</kbd> cycles the <b>sort</b>, <kbd>/</kbd> <b>filters</b> by substring, and <kbd>w</kbd> cycles the <b>work filters</b> — <b>PRs&nbsp;open</b>, <b>CI&nbsp;broken</b>, <b>stale&nbsp;90&nbsp;days</b> — to narrow the tab to what actually needs attention.</p>
         <figure class="shot">
@@ -51,7 +51,7 @@
           <figcaption>The Repos tab — a green/red/yellow CI dot per repo; press <kbd>Enter</kbd> to break it down into the individual checks.</figcaption>
         </figure>
 
-        <h2><kbd>3</kbd> PRs &nbsp;·&nbsp; <kbd>4</kbd> Issues</h2>
+        <h2 id="prs-issues"><kbd>3</kbd> PRs &nbsp;·&nbsp; <kbd>4</kbd> Issues</h2>
         <p>The pull requests and issues you've opened, plus — for your own account — a sticky <b>review-requests</b> inbox at the top of the PRs tab, so what's waiting on you surfaces first. Both tabs share the Repos sort (<kbd>s</kbd>) and filter (<kbd>/</kbd>); Issues can be pinned (<kbd>P</kbd>) too.</p>
         <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px;">
           <figure class="shot">
@@ -64,7 +64,7 @@
           </figure>
         </div>
 
-        <h2><kbd>5</kbd> Activity</h2>
+        <h2 id="activity"><kbd>5</kbd> Activity</h2>
         <p>Two halves at different zoom levels, switched with <kbd>&larr;</kbd> / <kbd>&rarr;</kbd>. The <b>heatmap</b> answers <i>how much</i>; the <b>feed</b> answers <i>what</i>.</p>
         <p><b>Heatmap</b> — a 12-month contribution graph, in your terminal, plus the totals it implies: contributions, current streak, longest streak and busiest day. It honours the active theme (a pink gradient, or shades of the theme's own palette under a monochromatic one).</p>
         <figure class="shot">
@@ -78,7 +78,7 @@
         <p>Review and comment traffic on one subject is <b>folded into a single row</b> with a <code>&times;N</code> count, so a heavily-reviewed pull request does not bury the rest of the week. Only adjacent events on the same subject fold, nothing is reordered, and anything that changed state — including an <b>approval</b> — always keeps its own line. Pull-request rows carry a title when the same page contains a comment naming it; GitHub's own pull-request payload here has no title field at all, so where none can be found the row shows the bare number instead of inventing one.</p>
         <p>The feed loads when you open it rather than on every refresh: GitHub asks callers to poll this endpoint no more than once a minute, and <code>--refresh</code> goes as low as 5s. Under <code>--public-only</code> it asks the public-events endpoint, so private-repository activity is never fetched at all.</p>
 
-        <h2><kbd>6</kbd> Gists</h2>
+        <h2 id="gists"><kbd>6</kbd> Gists</h2>
         <p>Your gists, newest first — visibility, file count, stars and when each last changed. <kbd>enter</kbd> drills in: a multi-file gist shows its files, and <kbd>enter</kbd> again opens one; a <b>one-file gist opens straight into it</b>, because that is the only thing there was to see.</p>
         <p>The file view is the point of the tab. A gist is a snippet, so it is shown <b>syntax-highlighted and scrollable</b>, and <kbd>c</kbd> there copies the <b>code</b> rather than the link — the first cut of this tab could only send you to the browser, which is what octoscope exists to avoid. GitHub truncates very large files and a gist can hold a binary; both are said out loud instead of being rendered as noise.</p>
         <p>Two details worth knowing. A gist's real name is a hash, so an <b>untitled</b> one is listed by its first filename instead — and the filter matches that, so you can find it by the name you can actually see. And under <code>--public-only</code> the secret ones are never requested rather than fetched and hidden, which keeps the count honest too: a &ldquo;10 of 16&rdquo; would itself have told anyone watching that six secret gists exist.</p>
@@ -90,7 +90,7 @@
           </div>
         </figure>
 
-        <h2><kbd>7</kbd> Inbox</h2>
+        <h2 id="inbox"><kbd>7</kbd> Inbox</h2>
         <p>Your actual GitHub notification inbox — mentions, review requests, assignments, subscriptions, CI activity — <b>unread only</b>, newest first. That last part has a visible consequence: open a thread and it leaves the tab on the next reload, because GitHub marked it read when you arrived. <kbd>enter</kbd> opens the thread on GitHub, <kbd>c</kbd> copies its link, <kbd>/</kbd> filters, and <kbd>s</kbd> cycles a three-way filter: <b>all</b>, <b>involving you</b>, <b>ci</b>.</p>
         <p>That filter exists because of a measurement: of 104 notifications on a real account, <b>77 were CI activity</b>. The default is still <b>all</b> — an inbox that hides most of itself is worse than a noisy one — and the line under the table always states how many rows the current filter is hiding.</p>
         <p><b>Read-only, like the rest of octoscope.</b> Marking a thread read is a <code>PATCH</code>, so <kbd>enter</kbd> takes you to GitHub and GitHub marks it read. There is deliberately no <code>--allow-mutations</code> flag: that would make this a different product with a different trust model. The tab says so out loud rather than leaving you hunting for a key that does not exist.</p>
@@ -104,7 +104,7 @@
           </div>
         </figure>
 
-        <h2><kbd>8</kbd> What's new</h2>
+        <h2 id="whats-new"><kbd>8</kbd> What's new</h2>
         <p>A bundled, offline changelog of the running version's highlights — shown right after an upgrade, no network needed. It's also where the support links live: <kbd>o</kbd> opens the Sponsors page, <kbd>c</kbd> copies the link.</p>
 
         <div class="pager">


### PR DESCRIPTION
An audit of the guide against what 0.29.0 actually shipped.

**`tabs.html` was complete.** The gaps were on the pages that describe things *across* tabs — which is exactly where a per-tab edit does not land.

## Coverage

| Page | Gap |
|---|---|
| `drill-ins.html` | Listed Repos, PRs, Issues — **not Gists**, the one drill-in that goes two levels deep and the whole point of that tab |
| `drill-ins.html` | "Press space on a row" without naming which tabs have a menu; Gists and Inbox joined it in 0.29.0 |
| `keybinds.html` | A table captioned "Repos · PRs · Issues"; Gists is a list tab too |
| `live.html` | Documented the OS delta notifications and never separated them from the new **Inbox** |
| `scripting.html` | Delegates the field list to the README on purpose, but neither of the two *semantic* traps was written down anywhere |

The `live.html` one is the gap most likely to generate a question. Issue #74 opened by drawing the distinction — one is a number octoscope noticed changing between its own refreshes, the other is a message GitHub delivered — so the project treats it as load-bearing while the docs did not draw it at all.

The scripting traps: sponsor counts are separate from the lists **because the lists are capped**, so `len(sponsors)` is not "how many sponsors do I have"; and `monthly_sponsors_income_cents` exists only for the token's own account. The page now also says the inbox is deliberately absent from both outputs, and links #125.

## Two stale counts a feature-name grep could not find

Caught by **rendering the page and reading it**, not by searching for feature names:

- *"octoscope is **six** views over one account"* → eight
- Overview *"grouped into **five** sub-sections"* → six; Sponsors was added and nobody recounted

Both verified against the source rather than memory: eight `Tab` constants, and the six bullets the page itself lists (`Profile` is the profile card, not a `renderSection`, which is why the code shows five and the list shows six).

## Readability

`tabs.html` is **1295 words against a 340-word median**, seven headings and seven images, under **one** sidebar entry — a reader after the Inbox scrolled past six tabs to reach it.

The sidebar now nests the eight tabs as sub-links under the active page, built from the same `NAV` array as everything else. Anchors rather than eight pages: the pager chain is linear and hand-maintained and has already been broken once by an inserted page, and eight ~160-word pages would make the guide an index instead of something you read.

A scroll-spy marks the section being read — otherwise the `.here` style would be a rule nothing ever applies.

## Verified, and the limit stated

- Sub-nav renders correctly in **both themes** — the light one by forcing `data-theme` on a copy, per the documented trick.
- The sublinks are plain `<a href="#…">`, so keyboard reachability is free rather than promoted in JS.
- The spy's **selection logic** was driven through seven cases in node, including the two a naive "first visible heading" version gets wrong (several headings crossed at once, and scrolling back up).
- **Not verified: the `IntersectionObserver` firing in a real browser.** Two headless attempts failed — once the fragment had not scrolled before the shot, once a copied page could not resolve its own assets. If it never fires, `.here` is never applied and the sub-nav behaves exactly as it does today: working links. Cosmetic failure mode, but saying so rather than implying it was checked.

No pages added or removed, so the pager chain is untouched — all ten still carry exactly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the guide with details on Gists navigation, file viewing, copying code, truncated or binary files, and Inbox actions.
  - Documented keyboard shortcuts, refresh notifications versus GitHub Inbox notifications, and JSON output behavior.
  - Updated the tabs guide to cover all views and Overview subsections with direct links.
- **Navigation**
  - Added contextual sidebar sub-navigation with active-section highlighting as readers scroll.
  - Improved styling for hover, focus, and current-section states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->