### PR TITLE
fix(whatsnew): the tab scrolls, and the entry stops overflowing

### DIFF
--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -45,7 +45,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.30.0</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.30.1</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1251,7 +1251,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.30.0</span>
+                <span class="version-tag" id="version-pill">0.30.1</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -205,6 +205,13 @@ type Model struct {
 	// are refreshed before each scroll keystroke (see scroll.go).
 	overviewVP viewport.Model
 	activityVP viewport.Model
+	// whatsNewVP scrolls the What's new tab. It was the only long
+	// static surface without one, and the omission was invisible until
+	// an entry grew past the terminal: renderWhatsNewTab took a width
+	// and no height, so it could neither clip nor scroll, and the body
+	// pushed the banner, profile card and tab bar off the top with no
+	// way to get them back. Shipped that way in 0.30.0.
+	whatsNewVP viewport.Model
 
 	// actionMenu is the modal action picker shown when the user
 	// presses Ctrl+Enter on a list-tab row. While open it absorbs
@@ -562,6 +569,7 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 		pulseMap:        make(map[string]time.Time),
 		overviewVP:      viewport.New(0, 0),
 		activityVP:      viewport.New(0, 0),
+		whatsNewVP:      viewport.New(0, 0),
 		sponsor:         sponsor,
 		checkForUpdates: opts.CheckForUpdates,
 
@@ -620,6 +628,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// keystroke. No-op when stats haven't arrived yet.
 		syncOverviewViewport(&m)
 		syncActivityViewport(&m)
+		syncWhatsNewViewport(&m)
 		// Same reason for the gist drill-in: its viewport is sized in
 		// Update, and View works on a copy, so without this a resized
 		// terminal renders the file at the old dimensions until the next
@@ -1069,6 +1078,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "c":
 					return m, copyURLCmd(sponsorURL)
 				}
+				// Everything else is a scroll key. Sync content and size
+				// before delegating so the viewport's own maxYOffset is
+				// computed against what is on screen — exactly what the
+				// Overview tab does above.
+				syncWhatsNewViewport(&m)
+				var cmd tea.Cmd
+				m.whatsNewVP, cmd = m.whatsNewVP.Update(msg)
+				return m, cmd
 			}
 		}
 
@@ -1089,6 +1106,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// content is shorter than the previous offset.
 		syncOverviewViewport(&m)
 		syncActivityViewport(&m)
+		syncWhatsNewViewport(&m)
 
 		// Pull a typed reason off the error envelope so the footer
 		// can specialise its message without sniffing the string.

--- a/internal/ui/scroll.go
+++ b/internal/ui/scroll.go
@@ -91,6 +91,20 @@ func syncOverviewViewport(m *Model) {
 
 // syncActivityViewport mirrors syncOverviewViewport for the Activity
 // tab (52-week heatmap + summary). Same shape, different renderer.
+// syncWhatsNewViewport mirrors syncOverviewViewport for the What's new
+// tab. It needs no stats, so unlike the other two it is safe to call
+// before the first fetch returns.
+func syncWhatsNewViewport(m *Model) {
+	available := computeAvailable(m.width)
+	tabHeight := computeTabHeight(*m)
+	if tabHeight <= 0 {
+		tabHeight = 20
+	}
+	m.whatsNewVP.Width = available
+	m.whatsNewVP.Height = tabHeight
+	m.whatsNewVP.SetContent(renderWhatsNewTab(m.version, available))
+}
+
 func syncActivityViewport(m *Model) {
 	if m.stats == nil {
 		return

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -197,7 +197,7 @@ func (m Model) View() string {
 		case TabActivity:
 			b.WriteString(m.renderActivityScrolled(s, available, tabHeight))
 		case TabWhatsNew:
-			b.WriteString(renderWhatsNewTab(m.version, available))
+			b.WriteString(m.renderWhatsNewScrolled(available, tabHeight))
 		default:
 			b.WriteString(renderComingSoonTab(m.activeTab))
 		}
@@ -230,6 +230,30 @@ func (m Model) renderOverviewScrolled(s *github.Stats, available, tabHeight int)
 		return content
 	}
 	vp := m.overviewVP
+	vp.Width = available
+	vp.Height = tabHeight
+	vp.SetContent(content)
+	return vp.View()
+}
+
+// renderWhatsNewScrolled wraps the What's new body in its viewport so a
+// long entry scrolls instead of pushing the banner, profile card and tab
+// bar off the top of the terminal with no way to get them back.
+//
+// That is what 0.30.0 shipped: renderWhatsNewTab took a width and no
+// height, so it could neither clip nor scroll, and its entry rendered 57
+// lines against a tab budget of roughly 24. The entry was also longer
+// than the instruction above the map asks for, which is fixed too — but
+// the shorter entry only makes the overflow less likely, and a short
+// terminal reaches it either way.
+func (m Model) renderWhatsNewScrolled(available, tabHeight int) string {
+	content := renderWhatsNewTab(m.version, available)
+	if tabHeight <= 0 {
+		// Height unknown (first paint before WindowSizeMsg) — render
+		// inline, same as the Overview tab.
+		return content
+	}
+	vp := m.whatsNewVP
 	vp.Width = available
 	vp.Height = tabHeight
 	vp.SetContent(content)
@@ -1157,6 +1181,10 @@ func renderFooterBar(m Model) string {
 		switch m.activeTab {
 		case TabOverview:
 			if m.overviewVP.TotalLineCount() > m.overviewVP.VisibleLineCount() {
+				scrollHint = keyHint("↑/↓", "scroll")
+			}
+		case TabWhatsNew:
+			if m.whatsNewVP.TotalLineCount() > m.whatsNewVP.VisibleLineCount() {
 				scrollHint = keyHint("↑/↓", "scroll")
 			}
 		case TabActivity:

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -26,28 +26,36 @@ type whatsNewEntry struct {
 //
 // RELEASE CHECKLIST: add an entry for each new version here, mirroring
 // the GitHub release notes' headline points. Keep it short — 3-5 lines.
-var whatsNew = map[string]whatsNewEntry{
-	"0.30.0": {
-		headline: "\"Not checked\" stops looking like \"fine\".",
-		items: []whatsNewItem{
-			{
-				title: "When it is GitHub, octoscope says so",
-				desc:  "octoscope does nothing but talk to GitHub, so an outage there looks exactly like octoscope being broken — a timeout, an empty tab, a 502. It now asks GitHub's own status page and tells you which it is, at the moment you are deciding who to blame. Silent while GitHub is healthy, and silent again if the status page cannot be reached: it never renders a clean bill of health it has not verified. Only the services it actually uses count, so a Codespaces incident does not warn you. One unauthenticated request, a different host from the API, and no polling.",
-			},
-			{
-				title: "The scan report says how wide its window was",
-				desc:  "The scan runs when you ask it to, not on a schedule, so its store records when you were looking rather than what happened over time. A delta measured over four minutes and one measured over four weeks used to read identically. The report now states the span once, under the verdict, and a repository where nothing changed says it too — \"unchanged across a coffee break\" and \"unchanged across a year\" are different sentences. Always a gap, never \"unchanged for N days\", which would claim a watch it does not keep.",
-			},
-			{
-				title: "A chain it cannot follow is said out loud",
-				desc:  "A uses: into another repository — or one into your own that octoscope did not read — is now always disclosed, not only where an outsider could reach the caller. A cross-repository call that rendered exactly like a chain which ended safely was the one collapse this axis exists to prevent. Still a note and never a score: reachability decides what counts against the verdict, it just no longer decides whether you are told.",
-			},
-			{
-				title: "A file that changes back is recognised",
-				desc:  "octoscope now keeps every distinct version it has ever seen at a path, so A to B and back to A reports the return with the date that content was first observed there. No expiry: a fixed lookback is a published waiting time, and waiting is the whole point of the attack this notices. A note rather than a score, since reverting is usually somebody undoing a mistake — and it says observed, never was here, because an on-demand scan cannot know what stood there while nobody was looking.",
-			},
+var whatsNew030 = whatsNewEntry{
+	headline: "\"Not checked\" stops looking like \"fine\".",
+	items: []whatsNewItem{
+		{
+			title: "When it is GitHub, octoscope says so",
+			desc:  "An outage on GitHub's side looks exactly like octoscope being broken. It now asks GitHub's own status page and tells you which it is. Silent while GitHub is healthy — and silent if the status page cannot be reached, because a clean bill of health it has not verified is worse than none.",
+		},
+		{
+			title: "The scan says how wide its window was",
+			desc:  "The scan runs when you ask it to, not on a schedule, so \"nothing changed since the last scan\" means very different things four minutes apart and four weeks apart. The report now states the span, and a repository where nothing changed says it too.",
+		},
+		{
+			title: "A chain it cannot follow is said out loud",
+			desc:  "A uses: into another repository is now always disclosed, not only where an outsider could reach the caller. A cross-repository call that renders like a chain which ended safely is the one collapse this axis exists to prevent. Still a note, never a score.",
+		},
+		{
+			title: "A file that changes back is recognised",
+			desc:  "octoscope keeps every distinct version it has seen at a path, so A to B and back to A reports the return. No expiry: a fixed lookback is a published waiting time. It says observed, never was here — an on-demand scan cannot know what stood there while nobody was looking.",
 		},
 	},
+}
+
+var whatsNew = map[string]whatsNewEntry{
+	// 0.30.1 shows 0.30.0's highlights, deliberately. The tab renders
+	// only the running version's entry, so anyone upgrading straight from
+	// 0.29.0 lands on the patch and would otherwise never learn what the
+	// release was about. The patch's own fix is a display bug in this very
+	// tab — the tab rendering correctly is the evidence.
+	"0.30.1": whatsNew030,
+	"0.30.0": whatsNew030,
 	"0.29.0": {
 		headline: "The things you still opened a browser for.",
 		items: []whatsNewItem{

--- a/internal/ui/whatsnew_test.go
+++ b/internal/ui/whatsnew_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/charmbracelet/x/ansi"
 	"github.com/gfazioli/octoscope/internal/github"
 )
@@ -92,5 +94,94 @@ func TestWhatsNewTabWiring(t *testing.T) {
 	}
 	if _, cmd := m.Update(key("x")); cmd != nil {
 		t.Error("'x' on What's new should be a no-op (nil cmd)")
+	}
+}
+
+// The What's new tab was the only long static surface without a
+// viewport, and renderWhatsNewTab took a width and no height — so it
+// could neither clip nor scroll. 0.30.0 shipped an entry that rendered
+// 57 lines against a tab budget of roughly 24, and the body pushed the
+// banner, profile card and tab bar off the top of the terminal with no
+// way to bring them back.
+func TestWhatsNewNeverPushesTheChromeOffScreen(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "not-used")
+	_ = applyTheme("octoscope", "")
+	c, err := github.New("octocat", github.Options{})
+	if err != nil {
+		t.Fatalf("github.New: %v", err)
+	}
+
+	for _, h := range []int{24, 30, 40, 60} {
+		m := NewModel(c, "0.30.0", Options{})
+		m.stats = &github.Stats{Login: "octocat", Name: "Test User"}
+		m.loading = false
+		m.activeTab = TabWhatsNew
+		m.width, m.height = 120, h
+		syncWhatsNewViewport(&m)
+
+		out := ansi.Strip(m.View())
+		if n := len(strings.Split(out, "\n")); n > h {
+			t.Errorf("at height %d the view rendered %d lines — the chrome is pushed off the top", h, n)
+		}
+		// The three pieces that vanished, named individually so a
+		// failure says which one.
+		for _, want := range []string{"octoscope  0.30.0", "What's new", "q quit"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("at height %d, %q is missing from the view", h, want)
+			}
+		}
+	}
+}
+
+// A scroll the footer advertises has to actually happen, and one it does
+// not advertise has to not be needed.
+func TestWhatsNewScrollsAndSaysSo(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "not-used")
+	_ = applyTheme("octoscope", "")
+	c, err := github.New("octocat", github.Options{})
+	if err != nil {
+		t.Fatalf("github.New: %v", err)
+	}
+	m := NewModel(c, "0.30.0", Options{})
+	m.stats = &github.Stats{Login: "octocat", Name: "Test User"}
+	m.loading = false
+	m.activeTab = TabWhatsNew
+	m.width, m.height = 120, 30
+	syncWhatsNewViewport(&m)
+
+	if !strings.Contains(ansi.Strip(m.View()), "scroll") {
+		t.Error("a body taller than the tab did not advertise scrolling")
+	}
+	first := ansi.Strip(m.View())
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	if ansi.Strip(m.View()) == first {
+		t.Error("down did not move the viewport")
+	}
+
+	// The support links still work — the viewport must not swallow them.
+	for _, k := range []string{"o", "b", "c"} {
+		mm := m
+		_, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)})
+		if cmd == nil {
+			t.Errorf("%q stopped doing anything once the viewport took the keys", k)
+		}
+	}
+}
+
+// The instruction above the map asks for 3-5 lines an item, and 0.30.0's
+// entry was written as paragraphs — 1981 characters against 647 for
+// 0.26.0. The viewport makes that survivable rather than acceptable, so
+// this is the guard the next entry gets measured against.
+func TestWhatsNewEntriesStayShort(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+	const maxLines = 48 // 0.29.0, the longest that shipped before the fix
+	for v := range whatsNew {
+		n := len(strings.Split(ansi.Strip(renderWhatsNewTab(v, 120)), "\n"))
+		if n > maxLines {
+			t.Errorf("the %s entry renders %d lines, over the %d-line budget — "+
+				"keep it to 3-5 lines an item", v, n, maxLines)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.30.0"
+const version = "0.30.1"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Reported with a screenshot on 0.30.0: the What's new tab pushed the banner, profile card and tab bar off the top of the terminal, with **no way to scroll them back**.

Two defects, and the smaller one is mine.

## Mine

The instruction sits directly above the map in `whatsnew.go`:

> `RELEASE CHECKLIST: … Keep it short — 3-5 lines.`

0.30.0's entry was written as paragraphs. **1981 characters** — against 1528 for 0.29.0 and 647 for 0.26.0, the longest ever shipped.

| entry | rendered lines (before) |
|---|---|
| **0.30.0** | **57** |
| 0.29.0 | 48 |
| 0.28.0 | 44 |
| 0.26.0 | 37 |

Trimmed to the shape the others have: **57 → 42**, now the shortest of the recent four.

## The older one, which mine exposed

The What's new tab was the **only long static surface without a viewport**. Overview, Activity, every drill-in and the scan panel all have one.

Worse, the signature made it impossible:

```go
func renderWhatsNewTab(version string, available int) string
```

A width and *no height* — so it could neither clip nor scroll. The body was written in full and the terminal carried the chrome away.

It has a viewport now, wired exactly the way the Overview tab's is: synced on resize, on new stats (the profile card changes the budget) and on the tab's own key path, with the footer advertising the scroll only when there is one to do. The `o` / `b` / `c` support links still work — a test asserts the viewport did not swallow them.

**The shorter entry alone would not have fixed this.** 0.26.0's 37 lines still overflow a 30-row terminal, so the bug was old and general; the long entry made it certain rather than likely.

## Verified at four heights

```
altezza 24 → banner ✓  tabbar ✓  footer ✓  hint-scroll ✓
altezza 30 → 29 righe rese (entro il budget)
altezza 40 → 39 righe rese
altezza 60 → 59 righe rese
```

## 0.30.1 shows 0.30.0's highlights, deliberately

The tab renders only the *running* version's entry. Anyone upgrading straight from 0.29.0 lands on the patch and would otherwise never learn what the release was about — and this patch's own fix is a display bug in that very tab, which the tab rendering correctly is the evidence for. Both keys point at one shared entry rather than a copy.

## Testing

A test now measures **every** entry against a 48-line budget (0.29.0, the longest that shipped before the fix). That is the guard that would have caught this before release.

Four mutants, all caught — including one that reverts the render call to exactly what 0.30.0 shipped, and one that pads an entry back over the budget.