### PR TITLE
ci(windows): stop shipping a binary nobody has ever run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 # CI workflow. Runs on every push and pull-request against main to
 # catch the obvious regressions before they reach a tag.
 #
-# Four jobs: build (compile-only sanity), test (race-checked unit
-# suite), lint (gofmt + go vet), and govulncheck (known-vulnerability
-# scan of the module dependencies). Each runs on the same Ubuntu
-# runner with caching keyed on go.sum so successive runs are fast.
+# Five jobs: build (compile-only sanity), test (race-checked unit
+# suite), lint (gofmt + go vet), govulncheck (known-vulnerability scan
+# of the module dependencies) and windows (the same suite plus a
+# start-up smoke on a real Windows runner). The first four share one
+# Ubuntu runner with caching keyed on go.sum so successive runs are
+# fast.
+#
+# Until 2026-09 nothing here ran on Windows at all: goreleaser
+# cross-compiles the windows/amd64 binary at tag time and it was
+# shipped without ever having been built natively, tested, or started.
+# The windows job exists to stop that binary being a claim.
 #
 # The vhs-driven smoke tapes (tapes/*.tape) are NOT invoked here —
 # they require a real GITHUB_TOKEN with the same scopes a user
@@ -86,3 +93,68 @@ jobs:
           cache: true
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...
+
+  # Windows is the only platform octoscope ships to and never exercises:
+  # three packages branch on runtime.GOOS (browse, clipboard, notify)
+  # and their Windows arms had never been compiled by CI, let alone run.
+  #
+  # Deliberately NOT -race here: the Linux `test` job already covers it,
+  # and keeping this one to a plain run leaves it fast and independent of
+  # whichever C toolchain the runner image happens to ship.
+  #
+  # The smoke step asserts only what is deterministic and needs no
+  # credentials. It does NOT call the GitHub API: an unauthenticated
+  # request would depend on the 60/h anonymous quota of a shared runner
+  # IP, which is a flake, not a test.
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test ./...
+      # bash (Git Bash, preinstalled on the runner) rather than pwsh: the
+      # assertions are about the binary's exit code and its two streams,
+      # and PowerShell's native-command redirection adds an encoding
+      # question — a BOM on an "empty" file — that has nothing to do with
+      # what is being measured. The binary under test is native Windows
+      # either way.
+      - name: Smoke — the binary starts and fails honestly
+        shell: bash
+        env:
+          # auth.TokenSource falls back to `gh auth token`, and gh is
+          # preinstalled here. Point it at an empty config so the fallback
+          # fails the same way on every run.
+          GITHUB_TOKEN: ""
+          GH_TOKEN: ""
+          GH_CONFIG_DIR: ${{ runner.temp }}/empty-gh-config
+        run: |
+          set -euo pipefail
+          go build -o octoscope.exe .
+
+          version=$(./octoscope.exe --version)
+          echo "version: $version"
+          case "$version" in
+            octoscope*) ;;
+            *) echo "--version printed '$version'"; exit 1 ;;
+          esac
+
+          ./octoscope.exe --help > /dev/null
+
+          # No token and no username: the scriptable surface must exit
+          # non-zero with an empty stdout, so a `--json | jq` pipeline in
+          # CI fails instead of parsing nothing. Checked here because this
+          # is the entry path a Windows user hits first.
+          rc=0
+          ./octoscope.exe --json > out.txt 2> err.txt || rc=$?
+          echo "--- stderr ---"; cat err.txt
+          [ "$rc" -eq 1 ] || { echo "want exit 1, got $rc"; exit 1; }
+          [ ! -s out.txt ] || { echo "wrote to stdout on the error path"; exit 1; }
+          grep -q "GITHUB_TOKEN" err.txt || { echo "stderr does not name the fix"; exit 1; }

--- a/internal/browse/open.go
+++ b/internal/browse/open.go
@@ -17,20 +17,44 @@ import (
 // command fails to start. The caller is expected to surface or
 // ignore the error — octoscope ignores it (failure is non-fatal).
 func OpenURL(url string) error {
-	if url == "" {
-		return errors.New("browse: empty url")
-	}
-
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "linux":
-		cmd = exec.Command("xdg-open", url)
-	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", "", url)
-	default:
-		return errors.New("browse: unsupported platform: " + runtime.GOOS)
+	cmd, err := makeOpenCmd(url)
+	if err != nil {
+		return err
 	}
 	return cmd.Start()
+}
+
+// makeOpenCmd picks the right launcher for the host OS and returns it
+// ready to start. Pure construction — never runs the command, which is
+// what lets a test assert the argv without opening a browser on the
+// machine running the suite.
+func makeOpenCmd(url string) (*exec.Cmd, error) {
+	return makeOpenCmdFor(runtime.GOOS, url)
+}
+
+// makeOpenCmdFor takes the OS as an argument rather than reading
+// runtime.GOOS, so every platform's argv is assertable from every
+// platform. That is the whole point: with the switch reading the
+// constant directly, the Windows branch could only ever be checked by a
+// Windows machine — and a mutation to it survived the suite everywhere
+// else, silently. The launcher for an OS is a fact about that OS, not
+// about the host, so it does not need the host to be one.
+//
+// The Windows form needs its empty third argument: `start` reads a
+// first quoted argument as the new console's *title*, so `start <url>`
+// with a quoted URL sets a title and opens nothing.
+func makeOpenCmdFor(goos, url string) (*exec.Cmd, error) {
+	if url == "" {
+		return nil, errors.New("browse: empty url")
+	}
+
+	switch goos {
+	case "darwin":
+		return exec.Command("open", url), nil
+	case "linux":
+		return exec.Command("xdg-open", url), nil
+	case "windows":
+		return exec.Command("cmd", "/c", "start", "", url), nil
+	}
+	return nil, errors.New("browse: unsupported platform: " + goos)
 }

--- a/internal/browse/open_test.go
+++ b/internal/browse/open_test.go
@@ -1,0 +1,96 @@
+package browse
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestMakeOpenCmdForEveryPlatform pins the launcher argv for every OS
+// octoscope ships to, from whichever OS is running the suite.
+//
+// It exists because this package had no test at all and CI ran only on
+// Ubuntu, so the Windows branch had shipped in every release without
+// once being compiled on Windows, let alone exercised. Reading the OS
+// through a parameter instead of runtime.GOOS is what makes the other
+// two rows checkable here — with the switch on the constant, a mutation
+// to the Windows argv survived the suite on every non-Windows host.
+func TestMakeOpenCmdForEveryPlatform(t *testing.T) {
+	const url = "https://example.com"
+	cases := []struct {
+		goos string
+		want []string
+	}{
+		{"darwin", []string{"open", url}},
+		{"linux", []string{"xdg-open", url}},
+		// The empty third argument is load-bearing: `start` reads a
+		// quoted first argument as the console title, so dropping it
+		// makes Windows open a titled window and no page.
+		{"windows", []string{"cmd", "/c", "start", "", url}},
+	}
+	for _, c := range cases {
+		t.Run(c.goos, func(t *testing.T) {
+			cmd, err := makeOpenCmdFor(c.goos, url)
+			if err != nil {
+				t.Fatalf("makeOpenCmdFor(%q): %v", c.goos, err)
+			}
+			if got := cmd.Args; !equal(got, c.want) {
+				t.Errorf("argv = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestMakeOpenCmdForRejectsUnknown keeps the default arm honest: an OS
+// with no launcher must produce an error naming it, not a command that
+// fails obscurely at Start.
+func TestMakeOpenCmdForRejectsUnknown(t *testing.T) {
+	cmd, err := makeOpenCmdFor("plan9", "https://example.com")
+	if err == nil {
+		t.Fatalf("makeOpenCmdFor(plan9) = %v, want an error", cmd)
+	}
+	if !strings.Contains(err.Error(), "plan9") {
+		t.Errorf("error %q does not name the platform", err)
+	}
+}
+
+// TestMakeOpenCmdForRejectsEmpty keeps the guard ahead of the switch:
+// an empty URL must not reach a launcher on any platform. On Windows
+// `start ""` with no target opens a blank console rather than failing,
+// so the check has to happen here.
+func TestMakeOpenCmdForRejectsEmpty(t *testing.T) {
+	for _, goos := range []string{"darwin", "linux", "windows"} {
+		if cmd, err := makeOpenCmdFor(goos, ""); err == nil {
+			t.Errorf("makeOpenCmdFor(%q, \"\") = %v, want an error", goos, cmd)
+		} else if !strings.Contains(err.Error(), "empty url") {
+			t.Errorf("error on %s is %q, which does not name the cause", goos, err)
+		}
+	}
+}
+
+// TestMakeOpenCmdUsesTheHost is the seam check: the exported path must
+// actually delegate with runtime.GOOS, or the table above would be
+// pinning a function nothing calls.
+func TestMakeOpenCmdUsesTheHost(t *testing.T) {
+	const url = "https://example.com"
+	got, gotErr := makeOpenCmd(url)
+	want, wantErr := makeOpenCmdFor(runtime.GOOS, url)
+	if (gotErr == nil) != (wantErr == nil) {
+		t.Fatalf("makeOpenCmd err = %v, makeOpenCmdFor(%s) err = %v", gotErr, runtime.GOOS, wantErr)
+	}
+	if gotErr == nil && !equal(got.Args, want.Args) {
+		t.Errorf("makeOpenCmd argv = %q, want %q", got.Args, want.Args)
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -26,6 +26,14 @@ import (
 // guessing distros.
 var ErrNoHelper = errors.New("no clipboard helper found (install xclip, xsel, or wl-copy on Linux)")
 
+// lookPath is exec.LookPath behind a package var so a test can state
+// which helpers exist and pin the priority order below. Without the
+// seam that order is only checkable on a host that happens to have
+// several installed — which no CI runner does, so a mutation swapping
+// wl-copy and xclip survived the suite everywhere. Same idiom as
+// auth.ghTokenOutput.
+var lookPath = exec.LookPath
+
 // Copy writes `text` to the system clipboard. Blocks until the
 // helper has consumed the input or fails — typically <50ms.
 //
@@ -53,7 +61,16 @@ func Copy(text string) error {
 // and returns it ready to receive stdin. Pure construction — never
 // runs the command.
 func makeCopyCmd() (*exec.Cmd, error) {
-	switch runtime.GOOS {
+	return makeCopyCmdFor(runtime.GOOS)
+}
+
+// makeCopyCmdFor takes the OS as an argument rather than reading
+// runtime.GOOS, so the darwin and windows helpers are assertable from
+// any host — see browse.makeOpenCmdFor for the reasoning. The Linux
+// arm still resolves against the real PATH, because *which* helper is
+// installed is a fact about the host and cannot be parameterised away.
+func makeCopyCmdFor(goos string) (*exec.Cmd, error) {
+	switch goos {
 	case "darwin":
 		return exec.Command("pbcopy"), nil
 	case "windows":
@@ -71,7 +88,7 @@ func makeCopyCmd() (*exec.Cmd, error) {
 		{"xclip", []string{"-selection", "clipboard"}},
 		{"xsel", []string{"--clipboard", "--input"}},
 	} {
-		if _, err := exec.LookPath(c.bin); err == nil {
+		if _, err := lookPath(c.bin); err == nil {
 			return exec.Command(c.bin, c.args...), nil
 		}
 	}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,166 @@
+package clipboard
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+// TestMakeCopyCmdForFixedPlatforms pins the two helpers that are a
+// property of the OS rather than of the host's installed packages.
+// Same reason as browse's twin: this package had no test, CI was
+// Ubuntu-only, and the Windows arm (`clip`) shipped unexercised in
+// every release. Taking the OS as a parameter is what lets a macOS or
+// Linux run catch a mutation to it.
+//
+// Asserted on Args[0] rather than cmd.Path: exec.Command resolves Path
+// through LookPath, so it is an absolute path where the helper exists
+// and the bare name where it does not. Args[0] is always the name that
+// was asked for, which is the decision under test.
+func TestMakeCopyCmdForFixedPlatforms(t *testing.T) {
+	cases := []struct{ goos, want string }{
+		{"darwin", "pbcopy"},
+		{"windows", "clip"},
+	}
+	for _, c := range cases {
+		t.Run(c.goos, func(t *testing.T) {
+			cmd, err := makeCopyCmdFor(c.goos)
+			if err != nil {
+				t.Fatalf("makeCopyCmdFor(%q): %v", c.goos, err)
+			}
+			if got := cmd.Args[0]; got != c.want {
+				t.Errorf("helper = %q, want %q", got, c.want)
+			}
+			if len(cmd.Args) != 1 {
+				t.Errorf("argv = %q, want the bare helper with no arguments", cmd.Args)
+			}
+		})
+	}
+}
+
+// TestMakeCopyCmdForSearchesOnUnixLikes covers the arm that cannot be
+// parameterised away: which of the three helpers exists is a fact about
+// the host. Both outcomes are correct — what must hold is that a
+// returned command is one of the three and that the absent case is
+// ErrNoHelper with a nil command, never a nil/nil pair.
+func TestMakeCopyCmdForSearchesOnUnixLikes(t *testing.T) {
+	cmd, err := makeCopyCmdFor("linux")
+	if err != nil {
+		if !errors.Is(err, ErrNoHelper) {
+			t.Fatalf("makeCopyCmdFor(linux) = %v, want ErrNoHelper", err)
+		}
+		if cmd != nil {
+			t.Error("ErrNoHelper returned alongside a non-nil command")
+		}
+		return
+	}
+	if cmd == nil {
+		t.Fatal("nil command with a nil error")
+	}
+	switch cmd.Args[0] {
+	case "wl-copy", "xclip", "xsel":
+	default:
+		t.Errorf("helper = %q, want one of wl-copy/xclip/xsel", cmd.Args[0])
+	}
+}
+
+// TestMakeCopyCmdForPriority pins the search order documented in
+// makeCopyCmdFor by stating which helpers exist rather than asking the
+// host. The earlier version of this test skipped unless wl-copy was
+// installed, which is to say it skipped on every machine that runs the
+// suite — and a mutation swapping wl-copy and xclip survived it.
+func TestMakeCopyCmdForPriority(t *testing.T) {
+	// The full argv, not just the binary: xclip and xsel both default
+	// to the X11 PRIMARY selection (middle-click paste) unless told
+	// otherwise, so "-selection clipboard" is the flag that makes Copy
+	// mean what the user pressed. Asserting only Args[0] let a mutation
+	// to it survive.
+	var (
+		wayland = []string{"wl-copy"}
+		xclip   = []string{"xclip", "-selection", "clipboard"}
+		xsel    = []string{"xsel", "--clipboard", "--input"}
+	)
+	cases := []struct {
+		name      string
+		installed []string
+		want      []string
+	}{
+		{"all three -> wayland wins", []string{"wl-copy", "xclip", "xsel"}, wayland},
+		{"xclip and xsel -> xclip", []string{"xclip", "xsel"}, xclip},
+		{"xsel alone", []string{"xsel"}, xsel},
+		{"wayland alone", []string{"wl-copy"}, wayland},
+		// X11 compatibility is the case the order exists for: a Wayland
+		// session commonly has xclip too, and picking it would work but
+		// go through the compatibility layer rather than the native path.
+		{"wayland session with xclip present", []string{"xclip", "wl-copy"}, wayland},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			withHelpers(t, c.installed)
+			cmd, err := makeCopyCmdFor("linux")
+			if err != nil {
+				t.Fatalf("makeCopyCmdFor(linux): %v", err)
+			}
+			if got := cmd.Args; !equalArgs(got, c.want) {
+				t.Errorf("argv = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestMakeCopyCmdForNoHelper pins the empty case: nothing installed
+// must be ErrNoHelper with a nil command, so Copy can surface the
+// "clipboard not available" toast rather than dereferencing nil.
+func TestMakeCopyCmdForNoHelper(t *testing.T) {
+	withHelpers(t, nil)
+	cmd, err := makeCopyCmdFor("linux")
+	if !errors.Is(err, ErrNoHelper) {
+		t.Fatalf("err = %v, want ErrNoHelper", err)
+	}
+	if cmd != nil {
+		t.Error("ErrNoHelper returned alongside a non-nil command")
+	}
+}
+
+// withHelpers replaces the lookPath seam for one test, reporting only
+// the named binaries as present, and restores it afterwards.
+func withHelpers(t *testing.T, installed []string) {
+	t.Helper()
+	prev := lookPath
+	t.Cleanup(func() { lookPath = prev })
+	lookPath = func(bin string) (string, error) {
+		for _, b := range installed {
+			if b == bin {
+				return "/usr/bin/" + bin, nil
+			}
+		}
+		return "", exec.ErrNotFound
+	}
+}
+
+// TestMakeCopyCmdUsesTheHost is the seam check: the caller Copy uses
+// must delegate with runtime.GOOS, or the table above pins a function
+// nothing reaches.
+func TestMakeCopyCmdUsesTheHost(t *testing.T) {
+	got, gotErr := makeCopyCmd()
+	want, wantErr := makeCopyCmdFor(runtime.GOOS)
+	if (gotErr == nil) != (wantErr == nil) {
+		t.Fatalf("makeCopyCmd err = %v, makeCopyCmdFor(%s) err = %v", gotErr, runtime.GOOS, wantErr)
+	}
+	if gotErr == nil && got.Args[0] != want.Args[0] {
+		t.Errorf("makeCopyCmd helper = %q, want %q", got.Args[0], want.Args[0])
+	}
+}
+
+func equalArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -38,6 +38,13 @@ func TestResolveIconWritesTheEmbeddedPNG(t *testing.T) {
 // same path without rewriting the file.
 func TestResolveIconIsIdempotent(t *testing.T) {
 	first := resolveIcon()
+	// Checked here and not left to the sibling test above: resolveIcon
+	// returns "" when the write failed, and two empty strings are equal
+	// — so without this line the whole test passes on the failure it is
+	// meant to be indifferent to.
+	if first == "" {
+		t.Fatal("resolveIcon returned an empty path")
+	}
 	if second := resolveIcon(); second != first {
 		t.Errorf("resolveIcon returned %q then %q", first, second)
 	}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,44 @@
+package notify
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// TestResolveIconWritesTheEmbeddedPNG covers the one part of this
+// package that is not somebody else's code: Send falls through to beeep
+// everywhere except macOS, so the octoscope-specific behaviour on
+// Windows and Linux is entirely "write the embedded icon somewhere the
+// backend can read it".
+//
+// Worth a test on every platform because the path comes from
+// os.TempDir(), which is %TEMP% on Windows and /tmp elsewhere — the
+// kind of difference that only shows up on the platform nobody runs.
+func TestResolveIconWritesTheEmbeddedPNG(t *testing.T) {
+	path := resolveIcon()
+	if path == "" {
+		t.Fatal("resolveIcon returned an empty path")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the icon back from %s: %v", path, err)
+	}
+	if !bytes.Equal(got, iconBytes) {
+		t.Errorf("icon on disk is %d bytes, embedded is %d", len(got), len(iconBytes))
+	}
+	if !bytes.HasPrefix(got, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Error("the written file is not a PNG")
+	}
+}
+
+// TestResolveIconIsIdempotent pins the sync.Once contract: Send calls
+// resolveIcon on every notification, so a second call must return the
+// same path without rewriting the file.
+func TestResolveIconIsIdempotent(t *testing.T) {
+	first := resolveIcon()
+	if second := resolveIcon(); second != first {
+		t.Errorf("resolveIcon returned %q then %q", first, second)
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -35,7 +35,14 @@ func TestResolveIconWritesTheEmbeddedPNG(t *testing.T) {
 
 // TestResolveIconIsIdempotent pins the sync.Once contract: Send calls
 // resolveIcon on every notification, so a second call must return the
-// same path without rewriting the file.
+// same path *without rewriting the file*.
+//
+// Comparing the two returned paths does not test that. The path is a
+// fixed name under os.TempDir(), so a resolveIcon with the Once removed
+// returns the same string on every call and writes the PNG every time —
+// measured: that mutation survived the earlier version of this test.
+// The contract only becomes observable on disk, so the check is to
+// overwrite the file and require the second call to leave it alone.
 func TestResolveIconIsIdempotent(t *testing.T) {
 	first := resolveIcon()
 	// Checked here and not left to the sibling test above: resolveIcon
@@ -45,7 +52,32 @@ func TestResolveIconIsIdempotent(t *testing.T) {
 	if first == "" {
 		t.Fatal("resolveIcon returned an empty path")
 	}
-	if second := resolveIcon(); second != first {
+
+	// The path is process-independent (a fixed name in the temp dir), so
+	// put the real icon back rather than leaving a marker for the next
+	// run — or for a Send in another test binary.
+	t.Cleanup(func() {
+		if err := os.WriteFile(first, iconBytes, 0o644); err != nil {
+			t.Errorf("restoring the icon at %s: %v", first, err)
+		}
+	})
+
+	marker := []byte("deliberately not a PNG")
+	if err := os.WriteFile(first, marker, 0o644); err != nil {
+		t.Fatalf("overwriting the icon at %s: %v", first, err)
+	}
+
+	second := resolveIcon()
+	if second != first {
 		t.Errorf("resolveIcon returned %q then %q", first, second)
+	}
+
+	after, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatalf("reading %s back: %v", first, err)
+	}
+	if !bytes.Equal(after, marker) {
+		t.Errorf("the second call rewrote the file (%d bytes on disk), want the %d-byte marker untouched",
+			len(after), len(marker))
 	}
 }


### PR DESCRIPTION
## What

A fifth CI job on `windows-latest` — build, `go test ./...`, start-up smoke — and the tests that job proved were missing.

## Why

`goreleaser` cross-compiles `windows/amd64` on every tag. Until now that binary reached users without CI ever having **built it natively, run its tests, or started it once**: all four existing jobs are `ubuntu-latest`.

## What the smoke asserts

Only what is deterministic and needs no credentials:

- `--version` prints something starting with `octoscope`
- `--help` exits 0
- `--json` with no token exits **1**, writes **nothing** to stdout, and names the fix on stderr

That last one is the contract a `--json | jq` pipeline depends on, checked at the entry path a Windows user hits first.

## The first run corrected this PR

The job went green, and the log killed a claim the opening commit had made. `go test ./...` reported:

```
github.com/gfazioli/octoscope/internal/browse     [no test files]
github.com/gfazioli/octoscope/internal/clipboard  [no test files]
github.com/gfazioli/octoscope/internal/notify     [no test files]
```

Those are precisely the three packages that branch on the OS. CI compiled their Windows arms and ran nothing in them, so *"`go test` on a real runner exercises them"* was false. Second commit closes it.

## Why the tests needed a refactor rather than just being written

With the switch reading `runtime.GOOS` inline, the Windows branch is only assertable **from Windows** — and that is not a theoretical limit. Measured locally on macOS:

| mutation | outcome before |
| --- | --- |
| `start "" <url>` → `start <url>` | **survived** |
| `clip` → `pbcopy` | **survived** |

So the OS becomes a parameter — `makeOpenCmdFor(goos, url)`, `makeCopyCmdFor(goos)` — with the exported functions delegating via `runtime.GOOS` and a seam test pinning that delegation, so the tables cannot drift into covering a function nothing calls. Which launcher an OS uses is a fact about that OS, not about the host; it does not need the host to be one.

Two more found on the way down:

- **The wl-copy priority test skipped unless wl-copy was installed** — i.e. on every machine that has ever run the suite. `lookPath` is now a package var (the idiom `auth.ghTokenOutput` already uses), so the order is stated rather than discovered.
- **Asserting `Args[0]` was not enough.** `xclip` and `xsel` default to the X11 PRIMARY selection, so dropping `-selection clipboard` still copies — to the middle-click buffer. The tables now pin the full argv.

`notify` needed no seam: outside darwin it hands off to beeep, so the octoscope-specific part is `resolveIcon`, which writes the embedded PNG under `os.TempDir()` — `%TEMP%` on Windows, which is the reason to pin it.

**Fourteen mutations, all caught** — and then a fifteenth, from the Codex review, that was not.

## The one the battery missed

`TestResolveIconIsIdempotent` compared the two returned paths. That is not the contract: the path is a fixed name under `os.TempDir()`, so a `resolveIcon` with the `sync.Once` removed returns the same string on every call *and rewrites the PNG every time*. Verified rather than taken on trust — the mutation survived.

The guarantee is only observable on disk, so the test now overwrites the icon with a marker, calls again, and requires the marker to survive (restored on cleanup, since the path is shared rather than process-scoped). With that, the `sync.Once` mutation is caught.

Worth stating as the general shape, because the earlier commit fixed the same defect one layer up: **a memoised call and an unmemoised one differ in what they touch, never in what they return.** A test whose subject is a cache and whose assertions are all on return values is testing the wrong surface.

## What it deliberately does not do

- **No GitHub API call.** An unauthenticated request rides the 60/h anonymous quota of a shared runner IP — a flake, not a test. The step points `GH_CONFIG_DIR` at an empty directory so `auth.TokenSource`'s `gh auth token` fallback fails identically every run.
- **No `-race` on Windows.** The Linux `test` job covers it; keeping this one plain leaves it fast and independent of the runner image's C toolchain.
- **Nothing about the TUI rendering.** A CI runner has no interactive terminal, so ANSI/VT, box-drawing glyphs and colours on Windows Terminal vs conhost stay unverified.

## Relation to #80

A Scoop or Winget manifest asserts that octoscope works on Windows. This is the half of that assertion measurable without a Windows machine. The other half — that the dashboard actually *renders* — still needs a human at a Windows terminal before any install path is published.

Also worth correcting in #80's body: it claims goreleaser builds Windows `amd64` **and** `arm64`. `.goreleaser.yaml` excludes `windows/arm64` explicitly, with a comment. Only `amd64` ships today.

## Verification

`actionlint v1.7.7` clean · `gofmt`/`go vet` clean, including `GOOS=windows go vet` · `go test -race ./...` green on darwin · smoke script logic dry-run locally against the darwin binary · 14/14 mutations caught.