### PR TITLE
feat(release): publish bare binaries alongside the archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -134,9 +134,9 @@ release:
     `curl` in a CI step or a Docker build stage:
 
     ```bash
-    curl -sSL -o octoscope \
-      https://github.com/gfazioli/octoscope/releases/download/{{ .Tag }}/octoscope_{{ .Version }}_linux-amd64
-    chmod +x octoscope
+    curl -fsSL -o octoscope \
+      https://github.com/gfazioli/octoscope/releases/download/{{ .Tag }}/octoscope_{{ .Version }}_linux-amd64 \
+      && chmod +x octoscope
     ```
 
 brews:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,6 +62,23 @@ archives:
       - README.md
       - LICENSE
 
+  # Bare binaries alongside the archives, for the consumers that cannot
+  # unpack one: `gh extension install`, a curl in a CI step, a Docker
+  # build stage. gh is the strict one — it downloads the release asset
+  # and writes it straight to disk as the executable (manager.go's
+  # installBin), so an archive is not merely inconvenient there, it is
+  # unusable.
+  #
+  # The name must END with <goos>-<goarch>, because gh selects by
+  # suffix: strings.HasSuffix(a.Name, platform+ext). Hence the raw
+  # {{ .Os }}-{{ .Arch }} here rather than the friendly macOS/x86_64
+  # spelling the archives use — this template is read by a matcher, not
+  # by a human. goreleaser appends .exe on Windows, which is the `ext`
+  # half of that same suffix.
+  - id: binary
+    formats: [binary]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}-{{ .Arch }}"
+
 checksum:
   name_template: "checksums.txt"
 
@@ -112,6 +129,15 @@ release:
     ```
 
     Or download a platform-specific archive below and drop the binary on your `$PATH`.
+
+    The bare `*_<os>-<arch>` assets are the same binary without the archive, for a
+    `curl` in a CI step or a Docker build stage:
+
+    ```bash
+    curl -sSL -o octoscope \
+      https://github.com/gfazioli/octoscope/releases/download/{{ .Tag }}/octoscope_{{ .Version }}_linux-amd64
+    chmod +x octoscope
+    ```
 
 brews:
   - name: octoscope


### PR DESCRIPTION
Groundwork for #79, and useful on its own.

## Why the archives are not enough

`gh extension install` downloads a release asset and writes it **straight to disk as the executable** — there is no unpacking step:

```go
binPath := filepath.Join(targetDir, name)
binPath += ext
err = downloadAsset(m.client, safeurl.NewImmutableSafeURL(asset.APIURL), binPath)
```

(`cli/cli`, `pkg/cmd/extension/manager.go`, `installBin`.) So the `.tar.gz` / `.zip` we ship today are not merely inconvenient there, they are unusable. Same for a `curl` in a CI step or a Docker build stage — which is why this is worth having independently of #79.

## The naming is a matcher's contract, not a style choice

gh picks the asset by **suffix**:

```go
platform, ext := m.platform()          // "darwin-arm64", "" / ".exe"
if strings.HasSuffix(a.Name, platform+ext) { … }
```

so the tail has to be exactly `darwin-arm64`, `windows-amd64.exe`, and so on. Hence `{{ .Os }}-{{ .Arch }}` in the new template rather than the friendly `macOS` / `x86_64` spelling the archives use — that one is read by people, this one by a matcher. goreleaser appends `.exe` on Windows itself, supplying the `ext` half.

Cross-checked against a real precompiled extension in the wild: `gh-dash` publishes `gh-dash_v4.25.2_darwin-arm64` — bare binary, no archive, no extension.

## Verified against a snapshot, not the docs

`goreleaser release --snapshot` with the same `~> v2` the release workflow uses:

| check | result |
| --- | --- |
| all five shipped platforms resolve under gh's suffix matcher | ✅ `darwin-{amd64,arm64}`, `linux-{amd64,arm64}`, `windows-amd64.exe` |
| `.exe` appended on Windows automatically | ✅ `octoscope_…_windows-amd64.exe` |
| `checksums.txt` covers the new assets | ✅ 10 entries, 5 of them bare binaries |
| archives unchanged | ✅ same three members (`LICENSE`, `README.md`, `octoscope`) — the Homebrew formula is untouched |
| bare binary is a real executable | ✅ `Mach-O 64-bit executable arm64`, `--version` prints `octoscope 0.30.1` |
| a platform we do not build (`linux-386`) | ✅ no match — gh would correctly report it unsupported |

Note on how goreleaser represents these: with `formats: [binary]` it does not copy the file under the new name locally. It registers an artifact whose **upload name** is the template and whose path points at the build output, so `dist/` looks unchanged while the release gets `octoscope_0.31.0_darwin-arm64`.

## Also

The release footer now points at the bare assets with a copy-pasteable `curl`, so they are discoverable rather than mysterious.

## One thing this surfaced but does not fix

`goreleaser check` exits non-zero — `brews` is deprecated in v2. **Not caused by this change**, and not urgent (deprecated options are only removed on major versions, and the workflow pins `~> v2`), but the replacement is not a like-for-like swap: `brews` makes a Formula, `homebrew_casks` makes a Cask, and the current formula serves Linux. Filed as #142 with the open question written down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added downloadable bare binary assets with consistent platform-specific names.
  * Windows binaries now include the `.exe` extension.
  * Release notes include a direct `curl` download example for automated installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->