### PR TITLE
feat(docker): publish a multi-arch image for the scriptable half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 # CI workflow. Runs on every push and pull-request against main to
 # catch the obvious regressions before they reach a tag.
 #
-# Five jobs: build (compile-only sanity), test (race-checked unit
-# suite), lint (gofmt + go vet), govulncheck (known-vulnerability scan
-# of the module dependencies) and windows (the same suite plus a
-# start-up smoke on a real Windows runner). The first four share one
-# Ubuntu runner with caching keyed on go.sum so successive runs are
-# fast.
+# Six jobs: build (compile-only sanity), test (race-checked unit suite),
+# lint (gofmt + go vet), govulncheck (known-vulnerability scan of the
+# module dependencies), windows (the same suite plus a start-up smoke on
+# a real Windows runner) and docker (builds and runs the released
+# image). All but windows share the Ubuntu runner, with caching keyed on
+# go.sum so successive runs are fast.
 #
 # Until 2026-09 nothing here ran on Windows at all: goreleaser
 # cross-compiles the windows/amd64 binary at tag time and it was
@@ -158,3 +158,83 @@ jobs:
           [ "$rc" -eq 1 ] || { echo "want exit 1, got $rc"; exit 1; }
           [ ! -s out.txt ] || { echo "wrote to stdout on the error path"; exit 1; }
           grep -q "GITHUB_TOKEN" err.txt || { echo "stderr does not name the fix"; exit 1; }
+
+  # The image ships to ghcr.io on every tag, built by goreleaser's
+  # dockers_v2 — so a broken Dockerfile is currently only discoverable
+  # during a release. This builds it on every PR instead.
+  #
+  # It also keeps two assumptions honest rather than held: that `docker
+  # buildx` is present on GitHub's Ubuntu runners, which dockers_v2
+  # requires, and that a foreign-architecture build needs no emulation
+  # here, which holds only while the Dockerfile has no RUN.
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build the image the way goreleaser will
+        run: |
+          set -euo pipefail
+          docker buildx version
+
+          # goreleaser lays the binaries out per platform and the
+          # Dockerfile reads $TARGETPLATFORM, so the context has to be
+          # shaped the same way or this would be testing a different
+          # Dockerfile from the one that ships.
+          for arch in amd64 arm64; do
+            mkdir -p ctx/linux/$arch
+            CGO_ENABLED=0 GOOS=linux GOARCH=$arch \
+              go build -trimpath -ldflags "-s -w" -o "ctx/linux/$arch/octoscope" .
+          done
+          cp Dockerfile ctx/
+
+          # Both platforms, because getting TARGETPLATFORM wrong produces
+          # an image that builds and runs the other architecture's binary.
+          docker build --platform=linux/amd64 -t octoscope:ci-amd64 ctx
+          docker build --platform=linux/arm64 -t octoscope:ci-arm64 ctx
+
+          for a in amd64 arm64; do
+            got=$(docker image inspect "octoscope:ci-$a" --format '{{.Architecture}}')
+            echo "octoscope:ci-$a -> $got"
+            [ "$got" = "$a" ] || { echo "wanted $a"; exit 1; }
+          done
+
+      - name: Smoke — the image starts and fails honestly
+        run: |
+          set -euo pipefail
+          # Only the native one is run: the runner is amd64 and executing
+          # the arm64 image would need emulation this job deliberately
+          # does not install.
+          version=$(docker run --rm octoscope:ci-amd64 --version)
+          echo "version: $version"
+          case "$version" in
+            octoscope*) ;;
+            *) echo "--version printed '$version'"; exit 1 ;;
+          esac
+
+          # Same contract the windows job asserts, and the one a
+          # `docker run ... --json | jq` pipeline in someone's CI depends
+          # on: no token means exit 1 with an empty stdout, not an empty
+          # object parsed as success.
+          rc=0
+          docker run --rm octoscope:ci-amd64 --json > out.txt 2> err.txt || rc=$?
+          echo "--- stderr ---"; cat err.txt
+          [ "$rc" -eq 1 ] || { echo "want exit 1, got $rc"; exit 1; }
+          [ ! -s out.txt ] || { echo "wrote to stdout on the error path"; exit 1; }
+          grep -q "GITHUB_TOKEN" err.txt || { echo "stderr does not name the fix"; exit 1; }
+
+      - name: The image runs unprivileged
+        run: |
+          set -euo pipefail
+          # distroless:nonroot is the reason; asserted because swapping the
+          # base tag by accident would silently give the container root.
+          user=$(docker image inspect octoscope:ci-amd64 --format '{{.Config.User}}')
+          echo "user: $user"
+          [ -n "$user" ] && [ "$user" != "root" ] && [ "$user" != "0" ] \
+            || { echo "image would run as root"; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,12 +163,25 @@ jobs:
   # dockers_v2 — so a broken Dockerfile is currently only discoverable
   # during a release. This builds it on every PR instead.
   #
-  # It also keeps two assumptions honest rather than held: that `docker
-  # buildx` is present on GitHub's Ubuntu runners, which dockers_v2
-  # requires, and that a foreign-architecture build needs no emulation
-  # here, which holds only while the Dockerfile has no RUN.
+  # It does ONE multi-platform build with --push, because that is what
+  # dockers_v2 does. The first version of this job ran two independent
+  # single-platform `docker build` calls, which pass on a builder that
+  # cannot export a manifest list at all — a check that could not fail
+  # for the reason it existed to catch. The default `docker` driver only
+  # manages multi-platform when the daemon runs the containerd image
+  # store; a developer machine that has it enabled builds this happily
+  # while a GitHub runner does not, which is how the gap stayed hidden.
+  #
+  # Pushing needs somewhere to push, hence the throwaway registry beside
+  # the job. network=host is what lets the docker-container builder see
+  # it on localhost.
   docker:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -177,11 +190,15 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver-opts: network=host
 
       - name: Build the image the way goreleaser will
         run: |
           set -euo pipefail
           docker buildx version
+          docker buildx inspect --bootstrap | grep -E '^(Name|Driver|Platforms):'
 
           # goreleaser lays the binaries out per platform and the
           # Dockerfile reads $TARGETPLATFORM, so the context has to be
@@ -194,24 +211,32 @@ jobs:
           done
           cp Dockerfile ctx/
 
-          # Both platforms, because getting TARGETPLATFORM wrong produces
-          # an image that builds and runs the other architecture's binary.
-          docker build --platform=linux/amd64 -t octoscope:ci-amd64 ctx
-          docker build --platform=linux/arm64 -t octoscope:ci-arm64 ctx
+          docker buildx build --platform=linux/amd64,linux/arm64 \
+            -t localhost:5000/octoscope:ci --push ctx
 
-          for a in amd64 arm64; do
-            got=$(docker image inspect "octoscope:ci-$a" --format '{{.Architecture}}')
-            echo "octoscope:ci-$a -> $got"
-            [ "$got" = "$a" ] || { echo "wanted $a"; exit 1; }
+      - name: The manifest carries both architectures
+        run: |
+          set -euo pipefail
+          # Getting TARGETPLATFORM wrong produces a manifest that looks
+          # right and serves one architecture's binary under both
+          # entries, so the digests are compared as well as the labels.
+          docker buildx imagetools inspect localhost:5000/octoscope:ci
+          for want in linux/amd64 linux/arm64; do
+            docker buildx imagetools inspect localhost:5000/octoscope:ci \
+              --format '{{ range .Manifest.Manifests }}{{ .Platform.OS }}/{{ .Platform.Architecture }} {{ end }}' \
+              | grep -qw "$want" || { echo "manifest is missing $want"; exit 1; }
           done
 
       - name: Smoke — the image starts and fails honestly
         run: |
           set -euo pipefail
+          img=localhost:5000/octoscope:ci
           # Only the native one is run: the runner is amd64 and executing
           # the arm64 image would need emulation this job deliberately
           # does not install.
-          version=$(docker run --rm octoscope:ci-amd64 --version)
+          docker pull --platform=linux/amd64 -q "$img"
+
+          version=$(docker run --rm --platform=linux/amd64 "$img" --version)
           echo "version: $version"
           case "$version" in
             octoscope*) ;;
@@ -223,18 +248,28 @@ jobs:
           # on: no token means exit 1 with an empty stdout, not an empty
           # object parsed as success.
           rc=0
-          docker run --rm octoscope:ci-amd64 --json > out.txt 2> err.txt || rc=$?
+          docker run --rm --platform=linux/amd64 "$img" --json > out.txt 2> err.txt || rc=$?
           echo "--- stderr ---"; cat err.txt
           [ "$rc" -eq 1 ] || { echo "want exit 1, got $rc"; exit 1; }
           [ ! -s out.txt ] || { echo "wrote to stdout on the error path"; exit 1; }
           grep -q "GITHUB_TOKEN" err.txt || { echo "stderr does not name the fix"; exit 1; }
+
+          # And with no arguments at all: it must refuse, not hang. The
+          # TUI is unreachable in a container and the honest answer is to
+          # say so and exit — a run that blocked forever would wedge
+          # anybody's pipeline.
+          rc=0
+          docker run --rm --platform=linux/amd64 "$img" > na.out 2> na.err || rc=$?
+          echo "--- stderr (no args) ---"; cat na.err
+          [ "$rc" -ne 0 ] || { echo "argument-less run exited 0"; exit 1; }
+          grep -qi "tty" na.err || { echo "stderr does not explain the refusal"; exit 1; }
 
       - name: The image runs unprivileged
         run: |
           set -euo pipefail
           # distroless:nonroot is the reason; asserted because swapping the
           # base tag by accident would silently give the container root.
-          user=$(docker image inspect octoscope:ci-amd64 --format '{{.Config.User}}')
+          user=$(docker image inspect localhost:5000/octoscope:ci --format '{{.Config.User}}')
           echo "user: $user"
           [ -n "$user" ] && [ "$user" != "root" ] && [ "$user" != "0" ] \
             || { echo "image would run as root"; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           # on: no token means exit 1 with an empty stdout, not an empty
           # object parsed as success.
           rc=0
-          docker run --rm --platform=linux/amd64 "$img" --json > out.txt 2> err.txt || rc=$?
+          timeout 60 docker run --rm --platform=linux/amd64 "$img" --json > out.txt 2> err.txt || rc=$?
           echo "--- stderr ---"; cat err.txt
           [ "$rc" -eq 1 ] || { echo "want exit 1, got $rc"; exit 1; }
           [ ! -s out.txt ] || { echo "wrote to stdout on the error path"; exit 1; }
@@ -265,10 +265,18 @@ jobs:
           # the auth check. The first version of this pinned the TTY
           # string, having been written against a local run that had a
           # token — and this job, which has none, is what caught it.
+          #
+          # Bounded, and asserted on exit 1 rather than merely non-zero:
+          # this is the check that the container does not block, so an
+          # unbounded run would hang here instead of reporting it — and
+          # `timeout` reports a hang as 124, which "non-zero" would have
+          # accepted as a pass. Both refusal paths exit 1 (measured: the
+          # TTY one with a token, the auth one without), so 1 is the
+          # invariant and 124 is excluded by construction.
           rc=0
-          docker run --rm --platform=linux/amd64 "$img" > na.out 2> na.err || rc=$?
+          timeout 30 docker run --rm --platform=linux/amd64 "$img" > na.out 2> na.err || rc=$?
           echo "--- stderr (no args) ---"; cat na.err
-          [ "$rc" -ne 0 ] || { echo "argument-less run exited 0"; exit 1; }
+          [ "$rc" -eq 1 ] || { echo "argument-less run exited $rc, want 1 (124 = it hung)"; exit 1; }
           [ ! -s na.out ] || { echo "wrote to stdout while refusing"; exit 1; }
           [ -s na.err ] || { echo "refused without saying why"; exit 1; }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,15 +254,23 @@ jobs:
           [ ! -s out.txt ] || { echo "wrote to stdout on the error path"; exit 1; }
           grep -q "GITHUB_TOKEN" err.txt || { echo "stderr does not name the fix"; exit 1; }
 
-          # And with no arguments at all: it must refuse, not hang. The
-          # TUI is unreachable in a container and the honest answer is to
-          # say so and exit — a run that blocked forever would wedge
-          # anybody's pipeline.
+          # And with no arguments at all: it must refuse and say why, not
+          # hang. The dashboard is unreachable in a container and a run
+          # that blocked forever would wedge anybody's pipeline.
+          #
+          # Deliberately not asserting *which* refusal. There are two,
+          # and which one you get depends on the environment rather than
+          # on the image: with a token it reaches the TUI and reports
+          # "could not open a new TTY", without one it stops earlier at
+          # the auth check. The first version of this pinned the TTY
+          # string, having been written against a local run that had a
+          # token — and this job, which has none, is what caught it.
           rc=0
           docker run --rm --platform=linux/amd64 "$img" > na.out 2> na.err || rc=$?
           echo "--- stderr (no args) ---"; cat na.err
           [ "$rc" -ne 0 ] || { echo "argument-less run exited 0"; exit 1; }
-          grep -qi "tty" na.err || { echo "stderr does not explain the refusal"; exit 1; }
+          [ ! -s na.out ] || { echo "wrote to stdout while refusing"; exit 1; }
+          [ -s na.err ] || { echo "refused without saying why"; exit 1; }
 
       - name: The image runs unprivileged
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,12 @@ jobs:
                    "https://ghcr.io/v2/${repo}/manifests/${tag}")
           echo "anonymous manifest fetch: HTTP $code"
           if [ "$code" != "200" ]; then
-            echo "::warning title=Container image is not public::ghcr.io/${repo}:${tag} answered HTTP ${code} to an anonymous pull. A new GHCR package is private until changed by hand — set it to Public once at https://github.com/users/gfazioli/packages/container/octoscope/settings . The README documents an unauthenticated docker pull until then."
+            # Pointing at the package list rather than at a settings URL
+            # composed by hand: that path cannot be visited before the
+            # package exists, and a link nobody can check is a link that
+            # rots quietly. The list page is stable, works today, and the
+            # settings button is one click from it.
+            echo "::warning title=Container image is not public::ghcr.io/${repo}:${tag} answered HTTP ${code} to an anonymous pull, so the README's docker pull is denied for everyone. A new GHCR package is private until changed by hand, once, and there is no API for it: open https://github.com/gfazioli?tab=packages -> octoscope -> Package settings -> Change visibility -> Public."
           fi
 
   # gfazioli/gh-octoscope exists for one reason: `gh` derives an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,19 +39,22 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
+# Nothing at the workflow level beyond read: a token minted for one job
+# is a token every future job inherits, and the two that need more say so
+# themselves below.
 permissions:
-  # packages:write lets goreleaser push the container images to
-  # ghcr.io/gfazioli/octoscope. Scoped at the workflow level, then
-  # narrowed to contents:read on the mirror job, which needs neither.
-  packages: write
-  # contents:write lets goreleaser create the GitHub Release and
-  # upload archives to it. No other scopes needed on this repo —
-  # the Homebrew push uses HOMEBREW_TAP_TOKEN instead.
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      # contents:write lets goreleaser create the GitHub Release and
+      # upload the archives. The Homebrew push crosses into another repo
+      # and travels on HOMEBREW_TAP_TOKEN instead.
+      contents: write
+      # packages:write lets it push the images to ghcr.io.
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,17 @@ jobs:
           go-version: stable
           cache: true
 
+      # dockers_v2 issues ONE `docker buildx build --platform
+      # linux/amd64,linux/arm64 --push`, and the default `docker` driver
+      # can only export a multi-platform image when the daemon runs the
+      # containerd image store. GitHub's Ubuntu runners do not, so the
+      # export would fail here even though it succeeds on a developer
+      # machine that happens to have containerd enabled — which is
+      # exactly how this nearly shipped. A docker-container builder
+      # supports it regardless of the host's image store.
+      - name: Set up a multi-platform builder
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
       # goreleaser's dockers_v2 pushes to ghcr.io, which needs the daemon
       # authenticated first. GITHUB_TOKEN is enough — ghcr.io accepts it
       # for packages under the same owner — so no extra secret, unlike the
@@ -84,6 +95,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      # A GHCR package does NOT inherit its repository's visibility —
+      # GitHub's own docs say permissions are inherited "but not the
+      # visibility" — so the package this release creates is private
+      # until somebody flips it once, by hand, in the package settings.
+      # There is no REST endpoint for it.
+      #
+      # Until that happens the README advertises a `docker pull` that
+      # every user is denied, and nothing else in this workflow would
+      # notice: goreleaser pushed successfully, using credentials.
+      # So: ask for an anonymous pull token the way an unauthenticated
+      # client does, and say so loudly if it comes back without access.
+      #
+      # A warning rather than a failure, deliberately. Everything above
+      # has already published by this point, and re-running the job would
+      # die at goreleaser on the release that now exists — turning a
+      # one-time settings change into a stuck release.
+      - name: Can a stranger pull the image?
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          set -euo pipefail
+          repo=gfazioli/octoscope
+          tag="${GITHUB_REF_NAME#v}"
+          token=$(curl -sS "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" \
+                    | jq -r '.token // empty')
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+                   -H "Authorization: Bearer ${token}" \
+                   -H "Accept: application/vnd.oci.image.index.v1+json" \
+                   "https://ghcr.io/v2/${repo}/manifests/${tag}")
+          echo "anonymous manifest fetch: HTTP $code"
+          if [ "$code" != "200" ]; then
+            echo "::warning title=Container image is not public::ghcr.io/${repo}:${tag} answered HTTP ${code} to an anonymous pull. A new GHCR package is private until changed by hand — set it to Public once at https://github.com/users/gfazioli/packages/container/octoscope/settings . The README documents an unauthenticated docker pull until then."
+          fi
 
   # gfazioli/gh-octoscope exists for one reason: `gh` derives an
   # extension's name from the repository name and refuses anything not

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # packages:write lets goreleaser push the container images to
+  # ghcr.io/gfazioli/octoscope. Scoped at the workflow level, then
+  # narrowed to contents:read on the mirror job, which needs neither.
+  packages: write
   # contents:write lets goreleaser create the GitHub Release and
   # upload archives to it. No other scopes needed on this repo —
   # the Homebrew push uses HOMEBREW_TAP_TOKEN instead.
@@ -61,6 +65,13 @@ jobs:
         with:
           go-version: stable
           cache: true
+
+      # goreleaser's dockers_v2 pushes to ghcr.io, which needs the daemon
+      # authenticated first. GITHUB_TOKEN is enough — ghcr.io accepts it
+      # for packages under the same owner — so no extra secret, unlike the
+      # Homebrew and gh-octoscope pushes which cross into other repos.
+      - name: Log in to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,6 +79,61 @@ archives:
     formats: [binary]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}-{{ .Arch }}"
 
+# Images for the scriptable half — `--json` / `--plain` in a CI step or a
+# remote shell. See Dockerfile for why the base is distroless rather than
+# scratch, and why there is no build stage.
+#
+# dockers_v2 rather than the older `dockers` + `docker_manifests` pair,
+# which goreleaser is phasing out: one entry, both platforms, and the
+# multi-arch manifest assembled for us. It uses `docker buildx`, which is
+# preinstalled on GitHub's Ubuntu runners — and the ci workflow now builds
+# this image on every PR, so that stays a checked fact rather than an
+# assumption held until the first tag.
+#
+# `latest` is conditional on the tag not being a prerelease. Empty tags are
+# ignored, so a -rc still publishes its own versioned image — inspectable,
+# without moving the tag everybody pulls. Same shape as the Homebrew
+# formula's skip_upload: auto.
+dockers_v2:
+  - id: octoscope
+    ids: [octoscope]
+    dockerfile: Dockerfile
+    images:
+      - "ghcr.io/gfazioli/octoscope"
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    # Both, deliberately. Annotations live on the manifest and are the
+    # modern OCI surface; labels live in the image config and are what
+    # `docker inspect` shows — and what GHCR reads to link a package back
+    # to its repository. Setting only annotations leaves the package page
+    # orphaned, which is invisible until somebody goes looking for the
+    # source from the registry.
+    labels:
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.description": "Terminal dashboard for your GitHub account"
+      "org.opencontainers.image.url": "https://github.com/gfazioli/octoscope"
+      # Spelled out rather than {{ .GitURL }}, which renders the clone
+      # URL with a .git suffix. GHCR reads this label to link the package
+      # back to its repository, and that link is the point.
+      "org.opencontainers.image.source": "https://github.com/gfazioli/octoscope"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.licenses": "MIT"
+    annotations:
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.description": "Terminal dashboard for your GitHub account"
+      "org.opencontainers.image.url": "https://github.com/gfazioli/octoscope"
+      "org.opencontainers.image.source": "https://github.com/gfazioli/octoscope"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.licenses": "MIT"
+
 checksum:
   name_template: "checksums.txt"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ COPY $TARGETPLATFORM/octoscope /octoscope
 #   octoscope: could not open a new TTY: open /dev/tty: no such device or address
 #   exit 1
 #
+# — or, with no token in the environment, the auth check refuses one step
+# earlier and never reaches the TUI at all. Either way: exit 1, nothing on
+# stdout, and a reason on stderr.
+#
 # It refuses immediately and names the real cause. A `CMD ["--help"]` would
 # be friendlier to explore and worse to depend on: help text on stdout at
 # exit 0 is something a `| jq` pipeline can mistake for output, where the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# The image exists for the scriptable half of octoscope, not the dashboard.
+# A TUI in a container is the wrong shape — nothing is attached to read it —
+# while `--json` / `--plain` fetch once, print and exit, which is exactly a
+# container workload. The README documents the CI recipe.
+#
+# No build stage: goreleaser has already produced the static binaries by the
+# time it builds this, and lays them out in the build context. Compiling
+# again here would ship a binary nobody had checksummed — and goreleaser's
+# own docs open with "Don't build binaries in your Dockerfile".
+#
+# Base chosen by measurement rather than by reputation. `FROM scratch`
+# builds fine, is 0.6 MB smaller, and answers `--version` correctly — then
+# fails on the first real call with:
+#
+#   tls: failed to verify certificate: x509: certificate signed by unknown authority
+#
+# because a static Go binary still needs the host's CA bundle to reach
+# api.github.com, and scratch has none. That is a failure no build-time
+# check catches. distroless/static carries the bundle, runs as an
+# unprivileged user out of the box, and receives updates for both.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# dockers_v2 builds every platform in one buildx pass, so the binaries are
+# laid out per platform rather than at the context root: TARGETPLATFORM is
+# "linux/amd64" or "linux/arm64" and buildx sets it per image being built.
+# Copying a bare ./octoscope instead would fail the build outright, which is
+# at least the honest failure — the dangerous version of getting this wrong
+# is an image that runs the other architecture's binary.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/octoscope /octoscope
+
+# No CMD: every useful invocation passes a flag (`--json`, `--plain`), and a
+# default of the interactive TUI would start something the container cannot
+# display and that never exits.
+ENTRYPOINT ["/octoscope"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,15 @@ FROM gcr.io/distroless/static-debian12:nonroot
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/octoscope /octoscope
 
-# No CMD: every useful invocation passes a flag (`--json`, `--plain`), and a
-# default of the interactive TUI would start something the container cannot
-# display and that never exits.
+# No CMD, and no `--help` default either. Every useful invocation passes a
+# flag (`--json`, `--plain`), and what a bare `docker run` actually does is
+# worth stating because it is better than the alternatives — measured:
+#
+#   octoscope: could not open a new TTY: open /dev/tty: no such device or address
+#   exit 1
+#
+# It refuses immediately and names the real cause. A `CMD ["--help"]` would
+# be friendlier to explore and worse to depend on: help text on stdout at
+# exit 0 is something a `| jq` pipeline can mistake for output, where the
+# refusal above cannot.
 ENTRYPOINT ["/octoscope"]

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Useful fields for a gate: `.rate_limit` (`remaining`, `reset_at`),
 Run it with no flag at all and it refuses rather than hanging — the
 dashboard needs a terminal the container does not have:
 
-```
+```text
 octoscope: could not open a new TTY: open /dev/tty: no such device or address
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ tabs, drill-ins, themes, configuration, scripting, and a full keyboard reference
 - [Install](#install)
   - [Homebrew (macOS & Linux)](#homebrew-macos--linux)
   - [From source](#from-source)
+  - [gh extension](#gh-extension)
+  - [Docker](#docker)
   - [Pre-built binary](#pre-built-binary)
 - [Usage](#usage)
 - [Themes](#themes)
@@ -484,11 +486,63 @@ go install github.com/gfazioli/octoscope@latest
 
 Requires Go 1.25.11 or later.
 
+### gh extension
+
+```bash
+gh extension install gfazioli/gh-octoscope
+gh octoscope
+```
+
+The same binary from the same release, reachable without leaving `gh`.
+It lives in a [second repository](https://github.com/gfazioli/gh-octoscope)
+only because `gh` derives an extension's name from the repository name and
+refuses anything not prefixed `gh-` — there is nothing else in it, and
+issues belong here.
+
+### Docker
+
+The image is for the **scriptable** half of octoscope, not the dashboard: a
+TUI in a container has nothing attached to read it, while `--json` and
+`--plain` fetch once, print and exit.
+
+```bash
+docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest --plain
+```
+
+Multi-arch (`linux/amd64`, `linux/arm64`), ~7 MB, and it runs as an
+unprivileged user. `-e GITHUB_TOKEN` with no value passes the variable
+through from your shell rather than baking it into the command line, where
+it would be visible in `ps` and in your shell history.
+
+In a CI step, piping into `jq`:
+
+```yaml
+- name: Publish account stats
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest --json \
+      | jq -r '"followers=\(.social.followers) stars=\(.social.total_stars)"'
+```
+
+With no token it exits **1** with an empty stdout, so a pipeline fails
+rather than parsing nothing. Useful fields for a gate: `.rate_limit`
+(`remaining`, `reset_at`), `.review_requests`, `.activity`.
+
 ### Pre-built binary
 
 Download the right platform archive from the
 [latest GitHub Release](https://github.com/gfazioli/octoscope/releases/latest),
 unpack it, and drop the `octoscope` binary anywhere on your `$PATH`.
+
+Each release also carries the bare executables next to the archives, named
+`octoscope_<version>_<os>-<arch>`, for when unpacking is the awkward part:
+
+```bash
+curl -fsSL -o octoscope \
+  https://github.com/gfazioli/octoscope/releases/latest/download/octoscope_0.30.1_linux-amd64 \
+  && chmod +x octoscope
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -521,13 +521,19 @@ In a CI step, piping into `jq`:
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run: |
+    set -o pipefail
     docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest --json \
       | jq -r '"followers=\(.social.followers) stars=\(.social.total_stars)"'
 ```
 
-With no token it exits **1** with an empty stdout, so a pipeline fails
-rather than parsing nothing. Useful fields for a gate: `.rate_limit`
-(`remaining`, `reset_at`), `.review_requests`, `.activity`.
+With no token it exits **1** with an empty stdout — but a pipeline only
+notices with `pipefail` set, otherwise the exit status is `jq`'s and `jq`
+is perfectly happy with no input. GitHub Actions does **not** set it for
+you unless the step says `shell: bash`; the default is `bash -e {0}`.
+Hence the line above, which travels to any CI.
+
+Useful fields for a gate: `.rate_limit` (`remaining`, `reset_at`),
+`.review_requests`, `.activity`.
 
 ### Pre-built binary
 
@@ -539,10 +545,16 @@ Each release also carries the bare executables next to the archives, named
 `octoscope_<version>_<os>-<arch>`, for when unpacking is the awkward part:
 
 ```bash
+VERSION=0.30.1   # or whatever the latest release says
 curl -fsSL -o octoscope \
-  https://github.com/gfazioli/octoscope/releases/latest/download/octoscope_0.30.1_linux-amd64 \
+  "https://github.com/gfazioli/octoscope/releases/download/v${VERSION}/octoscope_${VERSION}_linux-amd64" \
   && chmod +x octoscope
 ```
+
+The version appears in the asset's own name, so the `releases/latest/`
+shortcut cannot be used here — it resolves the newest release but still
+asks for the file name you typed, which 404s the moment a newer one
+ships.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -535,6 +535,13 @@ Hence the line above, which travels to any CI.
 Useful fields for a gate: `.rate_limit` (`remaining`, `reset_at`),
 `.review_requests`, `.activity`.
 
+Run it with no flag at all and it refuses rather than hanging — the
+dashboard needs a terminal the container does not have:
+
+```
+octoscope: could not open a new TTY: open /dev/tty: no such device or address
+```
+
 ### Pre-built binary
 
 Download the right platform archive from the


### PR DESCRIPTION
Closes #81, and completes the distribution cycle.

## What it is for

`--json` / `--plain`, not the dashboard. A TUI in a container has nothing attached to read it; the non-interactive output fetches once, prints and exits — which is exactly a container workload. The issue said as much, and it turned out to be the right frame: everything below follows from *not* trying to ship the TUI.

```bash
docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest --plain
```

Multi-arch (`linux/amd64`, `linux/arm64`), ~7 MB, unprivileged.

## The base was chosen by measurement

`FROM scratch` is the obvious answer for a static Go binary, and it is wrong here in the way that hurts most: it **builds**, it is 0.6 MB smaller, and `--version` answers correctly. Then the first real call fails —

```
octoscope: Post "https://api.github.com/graphql": tls: failed to verify certificate:
x509: certificate signed by unknown authority
```

— because a static binary still needs the host's CA bundle, and scratch has none. No build-time check catches it. Measured across three variants against a live daemon:

| base | build | `--version` | real API call |
| --- | --- | --- | --- |
| `scratch` | ✅ 5.9 MB | ✅ | ❌ x509 |
| `scratch` + copied CA bundle | ✅ 6.0 MB | ✅ | ✅ |
| `distroless/static:nonroot` | ✅ 6.6 MB | ✅ | ✅ |

distroless wins the last 0.6 MB back with an unprivileged default user and updates for the bundle.

## `dockers_v2`, not `dockers` + `docker_manifests`

The first draft used the older pair. `goreleaser check` said they are being phased out — so shipping them would have been filing #142 against ourselves on the same afternoon it was opened.

`dockers_v2` changes the Dockerfile's shape, and this is the part worth knowing: it builds every platform in one buildx pass, so binaries land **per platform** in the context and the COPY reads `$TARGETPLATFORM`. The first attempt failed with `"/octoscope": not found`, which is the honest outcome — the dangerous version of getting this wrong is an image that builds fine and runs the other architecture's binary.

It also retired a `.dockerignore` I had written, which would have excluded the very `linux/amd64/` directory the binary now arrives in.

## Labels *and* annotations

Annotations live on the manifest and are the modern OCI surface; labels live in the image config, are what `docker inspect` shows, and are what **GHCR reads to link a package back to its repository**. Annotations alone leave the package page orphaned — invisible until somebody tries to find the source from the registry.

`org.opencontainers.image.source` is spelled out rather than `{{ .GitURL }}`, which renders the clone URL with a `.git` suffix.

## A CI job, so two assumptions stop being assumptions

`dockers_v2` requires `docker buildx`, and a foreign-architecture build needs no emulation *only* while the Dockerfile has no `RUN`. Both were things I believed. Now a `docker` job builds the image on every PR, asserts each image reports the architecture it claims, runs the native one, and checks:

- `--version` prints
- `--json` with no token exits **1** with empty stdout and names the fix — the same contract the `windows` job asserts, and the one a `docker run … --json | jq` pipeline depends on
- the image does not run as root

## README

Also documents the two channels that shipped earlier in this cycle and were never written up: the **gh extension** (#79) and the **bare binaries** (#143). An install channel nobody has documented does not exist. Every `jq` field in the examples was read off a live `--json`, not invented — the first draft used camelCase keys that do not exist.

## Verification

Against a real daemon (colima), not reasoned about: three base variants and their TLS behaviour · both architectures built and executed, each reporting the correct `Architecture` · the goreleaser pipeline run end to end in snapshot mode, producing tagged images · labels confirmed present via `docker inspect` after the annotations-only version showed none · `actionlint` clean on both workflows · `goreleaser check` clean apart from the pre-existing `brews` deprecation (#142).

**Not verified:** the push to ghcr.io itself, which only happens on a tag. The login step uses `GITHUB_TOKEN` with `packages: write`, which is the documented path for packages under the same owner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-architecture Docker image for the scriptable interface, supporting amd64 and arm64.
  * Docker images run as a non-root user and include release metadata.
  * Added installation support through the GitHub CLI extension.
  * Added standalone versioned binary downloads alongside release archives.

* **Documentation**
  * Expanded installation guidance with Docker, JSON/plain output, CI pipeline, GitHub CLI, and binary download examples.
  * Documented Docker behavior for missing tokens and missing command-line flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->