### PR TITLE
chore(release): 0.31.0 — octoscope installs where you already are

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ Each release also carries the bare executables next to the archives, named
 `octoscope_<version>_<os>-<arch>`, for when unpacking is the awkward part:
 
 ```bash
-VERSION=0.30.1   # or whatever the latest release says
+VERSION=0.31.0   # or whatever the latest release says
 curl -fsSL -o octoscope \
   "https://github.com/gfazioli/octoscope/releases/download/v${VERSION}/octoscope_${VERSION}_linux-amd64" \
   && chmod +x octoscope

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -45,7 +45,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.30.1</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.31.0</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -30,6 +30,21 @@
         </div>
         <p>Or build from source with a Go 1.25+ toolchain — <code>go install github.com/gfazioli/octoscope@latest</code>.</p>
 
+        <p>Since v0.31.0 there are two more ways in. From inside the GitHub CLI:</p>
+        <div class="code">
+          <button class="copy">copy</button>
+          <pre><span class="prompt">$ </span>gh extension install gfazioli/gh-octoscope
+<span class="prompt">$ </span>gh octoscope</pre>
+        </div>
+        <p>The same binary from the same release. It sits under a second repository name only because <code>gh</code> takes an extension's name from the repository and refuses anything not prefixed <code>gh-</code> — everything else, issues included, stays in the main repository.</p>
+
+        <p>And a container, which is for the <a href="scripting.html">scriptable output</a> rather than the dashboard — a TUI inside a container has nothing attached to read it:</p>
+        <div class="code">
+          <button class="copy">copy</button>
+          <pre><span class="prompt">$ </span>docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest <span class="flag">--plain</span></pre>
+        </div>
+        <p>Multi-architecture, around 7&nbsp;MB, and it runs as an unprivileged user. Every release also carries the bare executables beside the archives — <code>octoscope_&lt;version&gt;_&lt;os&gt;-&lt;arch&gt;</code> — for a <code>curl</code> where unpacking is the awkward part.</p>
+
         <h2>Run it</h2>
         <p>With no arguments octoscope opens on your own authenticated account. Pass a username to inspect anyone's public profile:</p>
         <div class="code">

--- a/docs/guide/scripting.html
+++ b/docs/guide/scripting.html
@@ -50,7 +50,17 @@
           <a href="settings.html"><small>Previous</small><b>← Configuration</b></a>
           <a class="next" href="flags.html"><small>Next</small><b>CLI flags →</b></a>
         </div>
-      </article>
+      
+        <h2>In a container</h2>
+        <p>Since v0.31.0 the same two flags are available as an image, which is the shape a CI step wants — no install, fetch once, print, exit:</p>
+        <div class="code">
+          <button class="copy">copy</button>
+          <pre><span class="prompt">$ </span>docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest <span class="flag">--json</span> | jq .social</pre>
+        </div>
+        <p><code>-e GITHUB_TOKEN</code> with no value passes the variable through from the surrounding environment rather than putting the token on the command line, where it would show up in <code>ps</code> and in shell history.</p>
+        <p>Two behaviours worth knowing before you depend on it. With no token it exits <strong>1</strong> and writes nothing to standard output — but a shell pipeline only notices that with <code>set -o pipefail</code>, since otherwise the exit status is <code>jq</code>'s and <code>jq</code> is perfectly happy with no input. GitHub Actions does not enable it for you unless the step says <code>shell: bash</code>. And with no flag at all the container refuses rather than hanging, because the dashboard needs a terminal it does not have.</p>
+
+</article>
     </main>
   </div>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1251,7 +1251,7 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.30.1</span>
+                <span class="version-tag" id="version-pill">0.31.0</span>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1360,6 +1360,11 @@
                  stretch) but vary in width via the w-* size classes. -->
             <div class="glance-marquee" tabindex="0" role="group" aria-label="At a glance — feature highlights">
                 <div class="glance-track">
+                <div class="feature w-m">
+                    <div class="feature-label">Install</div>
+                    <h3>Wherever you already are</h3>
+                    <p>Homebrew, <code>go install</code>, a <code>gh</code> extension, or a container for CI — <code>docker run … --json | jq</code>. Every release also ships the bare executables beside the archives, for a <code>curl</code> where unpacking is the awkward part.</p>
+                </div>
                 <div class="feature w-m">
                     <div class="feature-label">Status</div>
                     <h3>Is it GitHub, or is it you?</h3>

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -48,7 +48,30 @@ var whatsNew030 = whatsNewEntry{
 	},
 }
 
+var whatsNew031 = whatsNewEntry{
+	headline: "octoscope installs where you already are.",
+	items: []whatsNewItem{
+		{
+			title: "Install it without leaving gh",
+			desc:  "`gh extension install gfazioli/gh-octoscope`, then `gh octoscope`. The same binary from the same release — it lives under a second repository name only because gh derives an extension's name from the repository and refuses anything not prefixed gh-.",
+		},
+		{
+			title: "A container, for the scriptable half",
+			desc:  "`docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest --json`. Multi-arch, around 7 MB, unprivileged. Deliberately not the dashboard: a TUI in a container has nothing attached to read it, while --json fetches once, prints and exits.",
+		},
+		{
+			title: "Bare binaries, next to the archives",
+			desc:  "Every release now also carries the executable on its own, named for its platform, for a curl in a CI step or a Docker stage — the places where unpacking an archive is the awkward part.",
+		},
+		{
+			title: "Windows is tested, at last",
+			desc:  "The Windows binary had shipped in every release without CI ever building it natively, running its tests, or starting it once. It now does all three on every push. The three packages that branch on the operating system had no tests at all; they do now.",
+		},
+	},
+}
+
 var whatsNew = map[string]whatsNewEntry{
+	"0.31.0": whatsNew031,
 	// 0.30.1 shows 0.30.0's highlights, deliberately. The tab renders
 	// only the running version's entry, so anyone upgrading straight from
 	// 0.29.0 lands on the patch and would otherwise never learn what the

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.30.1"
+const version = "0.31.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Release prep for **0.31.0**, the features cycle. Steps 1–5 of the checklist; the hero screenshot (step 6) is post-merge, pre-tag.

## What the release is

Four issues, one sentence — **octoscope installs where you already are**:

| | |
| --- | --- |
| #79 | `gh extension install gfazioli/gh-octoscope` |
| #143 | bare binaries beside the archives, for a `curl` |
| #81 | `ghcr.io/gfazioli/octoscope`, multi-arch, ~7 MB, unprivileged |
| #141 | Windows built, tested and started in CI — for the first time ever |

That last one is not an install channel, but it belongs: the Windows binary had shipped in every release without CI ever compiling it natively, and the three packages that branch on the operating system had no tests at all.

## What changed here

```
main.go                     const version -> 0.31.0
internal/ui/whatsnew.go     whatsNew031, keyed on "0.31.0"
README.md                   the curl example's VERSION
docs/index.html             hero pill fallback + an "Install" card in the marquee
docs/guide/docs.js          sidebar version fallback
docs/guide/index.html       the two new install channels
docs/guide/scripting.html   the container, alongside the flags it serves
```

## Two things checked rather than assumed

**The four version surfaces were cross-checked against each other**, not bumped one at a time and hoped over. #121 exists because that drift is silent by construction — and it is now worse than that issue describes: the `-X main.version` ldflag goreleaser passes is **inert**, because `version` is a `const` and the linker cannot patch one. Measured, and [commented on #121](https://github.com/gfazioli/octoscope/issues/121). So this constant is not a fallback for local builds; it is the only version any user ever sees.

**The `whatsNew` lookup was checked to resolve.** A missing entry does not break the tab — it renders the graceful "highlights aren't bundled" fallback, which is exactly why nobody notices. `whatsNew["0.31.0"]` exists and `const version` matches it.

## Noted, not changed

The landing carries `.install-block` CSS and a copy-button initialiser for it, and **no markup uses either**. Dead since some earlier design. Not a release-prep concern, but somebody should delete it or give the landing back its install command.

## After the tag — a one-time manual step

The first release to push the container image creates the GHCR package **private**, and a package does not inherit its repository's visibility. Until it is flipped once by hand the `docker pull` documented in the README is denied for everyone. The release workflow tries an anonymous pull and warns with the path; there is no API for the change itself.

**gfazioli's packages → `octoscope` → Package settings → Change visibility → Public.**