### PR TITLE
docs: a release-notes page, and the hover that had nowhere to go

### DIFF
--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -32,7 +32,8 @@
     ]},
     { group: "Reference", items: [
       { id: "flags", label: "CLI flags",          href: "flags.html" },
-      { id: "keys",  label: "Keyboard shortcuts", href: "keybinds.html" }
+      { id: "keys",  label: "Keyboard shortcuts", href: "keybinds.html" },
+      { id: "releases", label: "Release notes",   href: "releases.html" }
     ]}
   ];
 

--- a/docs/guide/keybinds.html
+++ b/docs/guide/keybinds.html
@@ -108,6 +108,7 @@
 
         <div class="pager">
           <a href="flags.html"><small>Previous</small><b>← CLI flags</b></a>
+          <a class="next" href="releases.html"><small>Next</small><b>Release notes &rarr;</b></a>
         </div>
       </article>
     </main>

--- a/docs/guide/releases.html
+++ b/docs/guide/releases.html
@@ -50,7 +50,7 @@
 
   // ---- markdown: the subset these notes actually use ----
   //
-  // Scoped by measuring all thirty published bodies rather than guessing:
+  // Scoped by measuring all forty-two published bodies rather than guessing:
   // h1-h3, bullets, numbered lists, fenced code (bash / sh / shell / yaml /
   // toml and untagged), tables, rules, bold, italic, inline code, links.
   // No images, no blockquotes, no h4 - none appear, and a renderer that
@@ -80,20 +80,33 @@
             .replace(/'/g, "&#39;");
   }
 
+  // Code spans are split out rather than replaced in place, because
+  // markdown inside one is literal and the first version re-parsed it:
+  // `**x**` became <code><strong>x</strong></code>, and `<kbd>` written
+  // as an example became a real element inside the code. Not theoretical
+  // — 28 spans in the published notes already carry markup like that.
+  //
+  // Splitting on the capture group keeps the delimiters, so the array
+  // alternates text / code / text, and only the text parts are
+  // transformed. No placeholder token, so nothing can collide with a
+  // body that happens to contain one.
   function inline(s) {
-    return s
-      .replace(/`([^`]+)`/g, function (_, c) { return "<code>" + c + "</code>"; })
-      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-      .replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<em>$2</em>")
-      // http(s) only, every link leaves with rel/target set, and the URL
-      // class excludes quotes and backslashes as well as whitespace. The
-      // escaping above already neutralises them; this is the second layer,
-      // so a future change to either one cannot reopen the hole on its
-      // own.
-      .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s"'\\]+)\)/g,
-               '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
-      .replace(/&lt;kbd&gt;/g, "<kbd>")
-      .replace(/&lt;\/kbd&gt;/g, "</kbd>");
+    return s.split(/(`[^`]+`)/).map(function (p) {
+      if (p.length > 1 && p.charAt(0) === "`" && p.charAt(p.length - 1) === "`") {
+        return "<code>" + p.slice(1, -1) + "</code>";
+      }
+      return p
+        .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+        .replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<em>$2</em>")
+        // http(s) only, every link leaves with rel/target set, and the URL
+        // class excludes quotes and backslashes as well as whitespace. The
+        // escaping above already neutralises them; this is the second
+        // layer, so a change to either one cannot reopen the hole alone.
+        .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s"'\\]+)\)/g,
+                 '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+        .replace(/&lt;kbd&gt;/g, "<kbd>")
+        .replace(/&lt;\/kbd&gt;/g, "</kbd>");
+    }).join("");
   }
 
   function render(md) {
@@ -242,7 +255,7 @@
           "</div>";
         var content = '<div class="rel-body">' +
           (body ? render(body) : "<p><em>No notes for this release.</em></p>") + "</div>";
-        // Newest open, the rest folded: thirty full bodies in one scroll is
+        // Newest open, the rest folded: forty-two full bodies in one scroll is
         // an archive, not a page anybody reads.
         return idx === 0
           ? '<section class="rel rel-latest">' + head + content + "</section>"

--- a/docs/guide/releases.html
+++ b/docs/guide/releases.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Release notes · octoscope docs</title>
+<meta name="description" content="Every octoscope release, newest first — read live from the GitHub Releases API." />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css" />
+<script src="docs.js" defer></script>
+</head>
+<body data-page="releases" data-title="Release notes">
+<div class="layout">
+  <aside class="sidebar" id="sidebar"></aside>
+  <div class="main">
+    <header class="topbar" id="topbar"></header>
+    <main class="doc">
+      <article class="page">
+        <p class="eyebrow">Reference</p>
+        <h1>Release notes</h1>
+        <p class="lead">Every release, newest first. Read live from GitHub rather than copied here, so this page cannot fall behind the tags the way a hand-maintained changelog does.</p>
+
+        <div id="releases" class="rel-list" aria-live="polite">
+          <p class="rel-status">Loading releases from GitHub&#8230;</p>
+        </div>
+
+        <div class="pager">
+          <a href="keybinds.html"><small>Previous</small><b>&#8592; Keyboard shortcuts</b></a>
+        </div>
+      </article>
+    </main>
+  </div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // 100 is the API's maximum for one page, and there are 42 releases as
+  // of 0.31.0 — the first cut asked for 30 and quietly dropped twelve,
+  // with nothing on the page saying so. The count below is rendered for
+  // the same reason: a truncated archive and a complete one must not
+  // look identical.
+  var API = "https://api.github.com/repos/gfazioli/octoscope/releases?per_page=100";
+  var HTML_URL = "https://github.com/gfazioli/octoscope/releases";
+  var box = document.getElementById("releases");
+  if (!box) return;
+
+  // ---- markdown: the subset these notes actually use ----
+  //
+  // Scoped by measuring all thirty published bodies rather than guessing:
+  // h1-h3, bullets, numbered lists, fenced code (bash / sh / shell / yaml /
+  // toml and untagged), tables, rules, bold, italic, inline code, links.
+  // No images, no blockquotes, no h4 - none appear, and a renderer that
+  // handles constructs nobody writes is a renderer nobody has tested.
+  //
+  // Escaping happens FIRST and unconditionally, then exactly one tag is
+  // allowed back: <kbd>, which the notes use for keys. Every other
+  // angle-bracketed token in these bodies is a placeholder inside
+  // backticks and has to stay literal.
+  function esc(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function inline(s) {
+    return s
+      .replace(/`([^`]+)`/g, function (_, c) { return "<code>" + c + "</code>"; })
+      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<em>$2</em>")
+      // http(s) only, and every link leaves with rel/target set: the body
+      // is maintainer-authored, but it is still text arriving over the
+      // network at render time.
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+               '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+      .replace(/&lt;kbd&gt;/g, "<kbd>")
+      .replace(/&lt;\/kbd&gt;/g, "</kbd>");
+  }
+
+  function render(md) {
+    var out = [], fences = [], i;
+
+    // Fenced blocks come out before anything else touches them, so a `**`
+    // or a `|` inside a shell snippet is never read as markup.
+    md = esc(md).replace(/```([a-z]*)\n([\s\S]*?)```/g, function (_, lang, code) {
+      fences.push('<pre class="rel-code" data-lang="' + (lang || "") + '"><code>' +
+                  code.replace(/\n$/, "") + "</code></pre>");
+      return " FENCE" + (fences.length - 1) + " ";
+    });
+
+    var lines = md.split("\n"), list = null, table = null;
+
+    // These bodies are hard-wrapped at about 85 columns, so a paragraph
+    // arrives as four or five lines and a list item as two. Markdown joins
+    // consecutive non-blank lines and separates on a blank one; treating
+    // each source line as its own block turns every paragraph into a
+    // stack of gapped fragments, which is exactly how the first cut of
+    // this renderer read. Hence the buffer: text accumulates, and only a
+    // blank line or a different construct flushes it.
+    var buf = [];
+
+    function flush() {
+      if (!buf.length) return;
+      var text = inline(buf.join(" "));
+      out.push(list ? "<li>" + text + "</li>" : "<p>" + text + "</p>");
+      buf = [];
+    }
+    function closeList() { flush(); if (list) { out.push("</" + list + ">"); list = null; } }
+    function closeTable() { if (table) { out.push("</tbody></table></div>"); table = null; } }
+    function close() { closeList(); closeTable(); }
+
+    for (i = 0; i < lines.length; i++) {
+      var l = lines[i], m;
+
+      if (/^ FENCE\d+ $/.test(l)) {
+        close();
+        out.push(fences[parseInt(l.trim().slice(5), 10)]);
+        continue;
+      }
+      if (!l.trim()) { close(); continue; }
+
+      if ((m = l.match(/^(#{1,3})\s+(.*)$/))) {
+        close();
+        // The page's h1 is "Release notes" and each release's version is
+        // an h2, so a body's own `##` sits at h4 — one level per nesting
+        // step, rather than whatever looks biggest.
+        var lvl = Math.min(6, m[1].length + 2);
+        out.push("<h" + lvl + ">" + inline(m[2]) + "</h" + lvl + ">");
+        continue;
+      }
+      if (/^---+\s*$/.test(l)) { close(); out.push("<hr />"); continue; }
+
+      if (/^\|/.test(l)) {
+        if (/^\|[\s:|-]+\|?\s*$/.test(l)) continue;   // the |---|---| separator
+        var cells = l.replace(/^\||\|$/g, "").split("|").map(function (c) {
+          return inline(c.trim());
+        });
+        if (!table) {
+          closeList();
+          out.push('<div class="rel-table-wrap"><table><thead><tr>' +
+                   cells.map(function (c) { return "<th>" + c + "</th>"; }).join("") +
+                   "</tr></thead><tbody>");
+          table = true;
+        } else {
+          out.push("<tr>" + cells.map(function (c) { return "<td>" + c + "</td>"; }).join("") + "</tr>");
+        }
+        continue;
+      }
+      closeTable();
+
+      if ((m = l.match(/^\s*[-*]\s+(.*)$/))) {
+        flush();
+        if (list !== "ul") { if (list) { out.push("</" + list + ">"); } out.push("<ul>"); list = "ul"; }
+        buf.push(m[1]);
+        continue;
+      }
+      if ((m = l.match(/^\s*\d+\.\s+(.*)$/))) {
+        flush();
+        if (list !== "ol") { if (list) { out.push("</" + list + ">"); } out.push("<ol>"); list = "ol"; }
+        buf.push(m[1]);
+        continue;
+      }
+      // A plain line either continues the open paragraph or the open list
+      // item — an indented wrap under a bullet belongs to that bullet.
+      buf.push(l.trim());
+    }
+    close();
+    return out.join("\n");
+  }
+
+  function when(iso) {
+    var d = new Date(iso);
+    return isNaN(d.getTime()) ? "" : d.toLocaleDateString(undefined,
+      { year: "numeric", month: "long", day: "numeric" });
+  }
+
+  // Says what went wrong rather than pretending there is nothing to show.
+  // An empty page and a rate-limited one must not look the same - that is
+  // the whole habit this project keeps having to relearn.
+  function fail(msg) {
+    box.innerHTML =
+      '<div class="note"><p><b>' + esc(msg) + "</b></p>" +
+      "<p>The notes live on GitHub either way &#8212; " +
+      '<a href="' + HTML_URL + '" target="_blank" rel="noopener noreferrer">read them there</a>. ' +
+      "The unauthenticated API allows 60 requests an hour per address, which a shared " +
+      "network can exhaust without you having done anything.</p></div>";
+  }
+
+  fetch(API, { headers: { Accept: "application/vnd.github+json" } })
+    .then(function (r) {
+      if (r.status === 403 || r.status === 429) throw new Error("GitHub rate-limited this page.");
+      if (!r.ok) throw new Error("GitHub answered " + r.status + ".");
+      return r.json();
+    })
+    .then(function (list) {
+      if (!Array.isArray(list) || !list.length) throw new Error("No releases came back.");
+      var count = '<p class="rel-count">' + list.length + " releases, newest first" +
+        (list.length === 100 ? " (the first 100 &#8212; older ones are on GitHub)" : "") +
+        ". Click any version to unfold its notes.</p>";
+      box.innerHTML = count + list.map(function (rel, idx) {
+        var body = (rel.body || "").trim();
+        var head =
+          '<div class="rel-head">' +
+            '<span class="rel-ver">' + esc(rel.tag_name || rel.name || "") + "</span>" +
+            '<span class="rel-date">' + esc(when(rel.published_at)) + "</span>" +
+            (rel.prerelease ? '<span class="rel-tag">pre-release</span>' : "") +
+            '<a class="rel-link" href="' + esc(rel.html_url) + '" target="_blank" ' +
+              'rel="noopener noreferrer">on GitHub</a>' +
+          "</div>";
+        var content = '<div class="rel-body">' +
+          (body ? render(body) : "<p><em>No notes for this release.</em></p>") + "</div>";
+        // Newest open, the rest folded: thirty full bodies in one scroll is
+        // an archive, not a page anybody reads.
+        return idx === 0
+          ? '<section class="rel rel-latest">' + head + content + "</section>"
+          : '<details class="rel"><summary>' + head + "</summary>" + content + "</details>";
+      }).join("");
+    })
+    .catch(function (e) { fail(e.message || "Could not reach GitHub."); });
+})();
+</script>
+</body>
+</html>

--- a/docs/guide/releases.html
+++ b/docs/guide/releases.html
@@ -60,8 +60,24 @@
   // allowed back: <kbd>, which the notes use for keys. Every other
   // angle-bracketed token in these bodies is a placeholder inside
   // backticks and has to stay literal.
+  // Quotes are escaped too, and that is not belt-and-braces — without
+  // them this was injectable. Every rendered string ends up inside an
+  // attribute somewhere (the href below, rel.html_url in the head), and
+  // `<`/`>` alone do not close an attribute. Measured, because the first
+  // version looked safe: the URL pattern rejects whitespace, so
+  // `https://a" onmouseover=...` does not match — but `/` separates
+  // attributes just as well in the HTML tokenizer, and
+  //
+  //   [x](https://a"/onmouseover="alert(1))
+  //
+  // rendered as <a href="https://a"/onmouseover="alert(1" ...>. Three of
+  // four probe payloads injected a handler.
   function esc(s) {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return s.replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
   }
 
   function inline(s) {
@@ -69,10 +85,12 @@
       .replace(/`([^`]+)`/g, function (_, c) { return "<code>" + c + "</code>"; })
       .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
       .replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<em>$2</em>")
-      // http(s) only, and every link leaves with rel/target set: the body
-      // is maintainer-authored, but it is still text arriving over the
-      // network at render time.
-      .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+      // http(s) only, every link leaves with rel/target set, and the URL
+      // class excludes quotes and backslashes as well as whitespace. The
+      // escaping above already neutralises them; this is the second layer,
+      // so a future change to either one cannot reopen the hole on its
+      // own.
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s"'\\]+)\)/g,
                '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
       .replace(/&lt;kbd&gt;/g, "<kbd>")
       .replace(/&lt;\/kbd&gt;/g, "</kbd>");
@@ -187,8 +205,22 @@
       "network can exhaust without you having done anything.</p></div>";
   }
 
-  fetch(API, { headers: { Accept: "application/vnd.github+json" } })
+  // Bounded, because a fetch that never settles leaves this page saying
+  // "Loading releases from GitHub…" for as long as the tab is open — a
+  // stall that reads exactly like a slow network and never resolves into
+  // either an answer or an error.
+  var ctl = window.AbortController ? new AbortController() : null;
+  var timer = setTimeout(function () {
+    if (ctl) ctl.abort();
+    else fail("GitHub did not answer in time.");
+  }, 10000);
+
+  fetch(API, {
+    headers: { Accept: "application/vnd.github+json" },
+    signal: ctl ? ctl.signal : undefined
+  })
     .then(function (r) {
+      clearTimeout(timer);
       if (r.status === 403 || r.status === 429) throw new Error("GitHub rate-limited this page.");
       if (!r.ok) throw new Error("GitHub answered " + r.status + ".");
       return r.json();
@@ -217,7 +249,12 @@
           : '<details class="rel"><summary>' + head + "</summary>" + content + "</details>";
       }).join("");
     })
-    .catch(function (e) { fail(e.message || "Could not reach GitHub."); });
+    .catch(function (e) {
+      clearTimeout(timer);
+      fail(e && e.name === "AbortError"
+        ? "GitHub did not answer in time."
+        : (e && e.message) || "Could not reach GitHub.");
+    });
 })();
 </script>
 </body>

--- a/docs/guide/style.css
+++ b/docs/guide/style.css
@@ -229,3 +229,53 @@ body.lb-lock { overflow: hidden; }
   .menu-btn { display: inline-flex; }
   main.doc { padding: 32px 20px 80px; }
 }
+
+/* ---------- release notes (releases.html) ---------- */
+/* The bodies are rendered from markdown at load time, so these styles
+   dress elements this stylesheet does not otherwise see inside .page:
+   a fenced block that is a bare <pre> rather than a .code wrapper, and
+   tables coming from a | grid. Newest release is a <section>, the rest
+   are <details> the reader unfolds. */
+.rel-status { color: var(--muted); font-family: var(--mono); font-size: 14px; }
+
+.rel { margin: 0 0 14px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); box-shadow: var(--shadow); }
+.rel-latest { border-color: var(--border-strong); }
+.rel > summary { cursor: pointer; padding: 14px 18px; list-style: none; border-radius: 12px; transition: background .15s ease; }
+.rel > summary::-webkit-details-marker { display: none; }
+.rel > summary:hover { background: var(--surface-2); }
+.rel > summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+/* The caret is the only affordance saying a folded entry opens, so it
+   turns rather than disappearing. */
+.rel > summary .rel-head::before { content: "\25B8"; color: var(--faint); margin-right: 4px; transition: transform .15s ease; display: inline-block; }
+.rel[open] > summary .rel-head::before { transform: rotate(90deg); }
+
+.rel-head { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.rel-latest > .rel-head { padding: 16px 18px 0; }
+.rel-ver { font-family: var(--mono); font-weight: 700; font-size: 16px; color: var(--accent-ink); }
+.rel-date { color: var(--muted); font-size: 13px; }
+.rel-tag { font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--accent); border: 1px solid var(--accent); border-radius: 5px; padding: 1px 6px; }
+.rel-link { margin-left: auto; font-size: 12.5px; color: var(--muted); }
+.rel-link:hover { color: var(--accent-ink); }
+
+.rel-body { padding: 2px 18px 6px; }
+.rel-body > *:first-child { margin-top: 12px; }
+/* A body's own `##` lands on h4 (page h1 -> version h2 -> body h3/h4/h5),
+   so the sizes are set by what the notes actually contain rather than by
+   the tag name: `##` is the section heading in 141 places and has to read
+   as one, `###` in 96 is a sub-point. */
+.rel-body h3 { font-size: 18px; margin: 28px 0 10px; }
+.rel-body h4 { font-size: 16px; margin: 26px 0 10px; color: var(--text); }
+.rel-body h5 { font-size: 14.5px; margin: 20px 0 8px; color: var(--muted); text-transform: none; letter-spacing: 0; }
+.rel-body h6 { font-size: 14px; margin: 18px 0 8px; color: var(--muted); }
+.rel-body p, .rel-body li { font-size: 15px; line-height: 1.75; }
+.rel-body hr { border: 0; border-top: 1px solid var(--border); margin: 22px 0; }
+.rel-code { margin: 0 0 18px; padding: 14px 16px; overflow-x: auto; background: var(--bg); border: 1px solid var(--border); border-radius: 10px; font-family: var(--mono); font-size: 13px; line-height: 1.7; color: var(--text); }
+/* The language, when the fence declared one — many did not, and an empty
+   label is worse than none. */
+.rel-code[data-lang]:not([data-lang=""])::before { content: attr(data-lang); display: block; margin: -4px 0 8px; font-size: 10.5px; letter-spacing: .06em; text-transform: uppercase; color: var(--faint); }
+.rel-code code { background: none; border: 0; padding: 0; color: inherit; font-size: inherit; }
+.rel-table-wrap { overflow-x: auto; margin: 0 0 18px; }
+.rel-table-wrap table { border-collapse: collapse; width: 100%; font-size: 14px; }
+.rel-table-wrap th, .rel-table-wrap td { text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+.rel-table-wrap th { color: var(--muted); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: .04em; }
+.rel-count { color: var(--muted); font-size: 13.5px; margin: 0 0 16px; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -190,6 +190,37 @@
             letter-spacing: 0.02em;
         }
 
+        /* The pill sits inside a link since 0.31.0, so the global
+           `a:hover { underline }` would land on a badge — where an
+           underline reads as a mistake. Border and colour carry the
+           hover instead, and the label beside it carries the invitation. */
+        .version-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            text-decoration: none;
+        }
+        .version-link:hover { text-decoration: none; }
+        .version-more {
+            font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            font-size: 0.78rem;
+            letter-spacing: 0.02em;
+            color: var(--muted);
+            transition: color 0.15s ease;
+        }
+        .version-link:hover .version-more,
+        .version-link:focus-visible .version-more { color: var(--accent); }
+        .version-link:hover .version-tag,
+        .version-link:focus-visible .version-tag {
+            color: var(--text);
+            border-color: var(--accent);
+        }
+        .version-link:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 4px;
+            border-radius: 999px;
+        }
+
         .version-tag::before {
             content: "v";
             color: var(--accent);
@@ -402,6 +433,14 @@
            the reduced-motion block). */
         .glance-marquee {
             position: relative;
+            /* Headroom for the cards' hover lift and focus outline.
+               `align-items: stretch` grows every card to the band's full
+               height, so the container's own clip used to remove exactly
+               the 3px the hover raises — measured, card and container
+               shared both edges to the decimal. Padding sits inside the
+               clip region, so 8px covers the lift plus the 2px outline at
+               3px offset. */
+            padding: 8px 0;
             overflow-x: auto;            /* default (no-JS / pre-JS / reduced-motion): a manually scrollable band */
             -webkit-mask-image: linear-gradient(to right, transparent 0, #000 5%, #000 95%, transparent 100%);
                     mask-image: linear-gradient(to right, transparent 0, #000 5%, #000 95%, transparent 100%);
@@ -1251,7 +1290,17 @@
         <div class="container">
             <img src="logo/logo-lettering.png" alt="octoscope" class="logo" />
             <div>
-                <span class="version-tag" id="version-pill">0.31.0</span>
+                <!-- The version is the only place on this page a reader
+                     looks to ask "what changed?", so it leads to the
+                     notes. The label beside it is not decoration: a badge
+                     that silently became a link announces nothing, and
+                     nobody hovers a thing they read as static. The pill
+                     keeps #version-pill, which the release-API fetch
+                     below writes its text into. -->
+                <a class="version-link" href="guide/releases.html">
+                    <span class="version-tag" id="version-pill">0.31.0</span>
+                    <span class="version-more">what&rsquo;s new &rarr;</span>
+                </a>
             </div>
             <h1>Your GitHub &mdash; or anyone else's &mdash; at a glance</h1>
             <p class="tagline">
@@ -1543,10 +1592,11 @@
         <section id="docs">
             <h2>Documentation</h2>
             <p style="color: var(--muted);">
-                The full guide is screenshot-forward and covers everything: getting started, a page per tab, the drill-ins and the integrity scan, themes, configuration and the settings panel, scripting with <code class="inline">--plain</code> / <code class="inline">--json</code>, and a keyboard cheat-sheet.
+                The full guide is screenshot-forward and covers everything: getting started, a page per tab, the drill-ins and the integrity scan, themes, configuration and the settings panel, scripting with <code class="inline">--plain</code> / <code class="inline">--json</code>, a keyboard cheat-sheet, and the release notes for every version.
             </p>
             <div class="cta-row" style="margin-top: 2rem;">
                 <a href="guide/index.html" class="btn btn-primary">Read the docs &rarr;</a>
+                <a href="guide/releases.html" class="btn btn-secondary">Release notes</a>
                 <a href="https://github.com/gfazioli/octoscope#readme" class="btn btn-secondary">README on GitHub</a>
             </div>
         </section>


### PR DESCRIPTION
Three reports from the maintainer, each measured before being fixed.

## 1. The at-a-glance hover was clipped

`align-items: stretch` grows every card to the band's full height, and `.glance-marquee.is-live` clips at that edge — so the 3px the hover raises had nowhere to go, and the focus outline (2px at 3px offset) was invisible entirely.

Measured rather than eyeballed, by injecting a probe and reading the rects:

```
before   marquee top=1544.9 bottom=1945.8   card top=1544.9 bottom=1945.8   slack 0.0px
after    slack above = 8.0px                CLIP after hover = 0.0px
```

8px of block padding, which sits **inside** the clip region.

## 2. Nothing on the landing led to what changed

The version pill is the only place on that page a reader looks to ask it, so it links to the notes — **with a visible "what's new →" beside it**. A badge that silently became a link announces nothing, and nobody hovers a thing they read as static; the first cut did exactly that and the rendered hero was indistinguishable from before.

Plus a button in the Documentation section and a mention in its prose.

## 3. `guide/releases.html`

Read **live** from the Releases API rather than copied here. The maintainer offered a plain redirect to GitHub as the alternative — worth saying why this isn't duplication: nothing is copied, so there is no second surface to drift, and the page's own failure path *is* that redirect.

### The renderer, and how its subset was chosen

By measuring all 42 published bodies, not by guessing:

| construct | count | handled |
| --- | --- | --- |
| `##` / `###` / `#` | 141 / 96 / 3 | ✅ |
| bullets / numbered | 228 / 7 | ✅ |
| fenced code | 122 (bash, sh, shell, yaml, toml, untagged) | ✅ |
| tables | 24 rows | ✅ |
| bold / italic / inline code / links | 214 / 51 / 518 / 24 | ✅ |
| images / blockquotes / h4 | **0** | not written |

Escaping is unconditional and first; then exactly one tag is allowed back — `<kbd>`, used 14 times. Every other angle-bracketed token in these bodies is a placeholder inside backticks (`octoscope_<version>_<os>-<arch>`) and has to stay literal.

### Two defects it had before it was believed

Both found by **counting the render against the source**, not by looking at it:

- **Every source line became its own paragraph.** The bodies are wrapped at ~85 columns, so one paragraph arrived as five gapped fragments. Visible in the first render and easy to miss in a skim.
- **It asked for 30 releases when there are 42**, dropping twelve with nothing on the page saying so.

After both:

```
42 releases | h4=141 | h5=96 | kbd=14 | tables=4 | empty <p>=0 | escaping artefacts=0
```

141 and 96 are exactly the `##` and `###` counts outside fenced blocks in the source. Exact matches are the only reason to believe the renderer is complete rather than plausible.

## Wiring

Per the guide's own rules: the page loads its own fonts, is in `NAV` under Reference, and the pager chain is closed at **both** ends (`keybinds → releases`, `releases → keybinds`).

## Verification

Rendered over HTTP rather than `file://`, so the API fetch behaves as deployed · sidebar, headings, code blocks, tables and links read back from screenshots · the hover fix confirmed both by measurement and by a forced-hover render · `HTMLParser` clean on every touched file · every CSS variable used exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Release notes page displaying published releases, release details, loading status, and error messages.
  * Added Release notes links throughout the documentation, including the version indicator, navigation, keyboard shortcuts page, and Documentation section.
  * Added expandable release entries and improved presentation for release metadata, Markdown content, code blocks, and tables.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->