### PR TITLE
docs: release-note code blocks wrap, and can be copied

### DIFF
--- a/docs/guide/releases.html
+++ b/docs/guide/releases.html
@@ -115,8 +115,25 @@
     // Fenced blocks come out before anything else touches them, so a `**`
     // or a `|` inside a shell snippet is never read as markup.
     md = esc(md).replace(/```([a-z]*)\n([\s\S]*?)```/g, function (_, lang, code) {
-      fences.push('<pre class="rel-code" data-lang="' + (lang || "") + '"><code>' +
-                  code.replace(/\n$/, "") + "</code></pre>");
+      // Wrapper + a .copy button before the <pre>, which is exactly the
+      // shape docs.js's delegated click handler already looks for: it
+      // finds .copy, then the <pre> in the same parent. Reusing that
+      // rather than adding a second copy mechanism to this page — the
+      // hand-authored blocks elsewhere in the guide work the same way.
+      // One element per source line, because the block wraps now and a
+      // wrapped continuation would otherwise look like the next command —
+      // which for a shell snippet is a worse failure than the truncation
+      // this replaced. Each line is its own block with a hanging indent,
+      // so a continuation is visibly subordinate. innerText still yields
+      // one newline per source line and none for a soft wrap, so the copy
+      // button hands over the original (measured).
+      var lines = code.replace(/\n$/, "").split("\n").map(function (ln) {
+        return '<span class="rel-ln">' + (ln || "&#8203;") + "</span>";
+      }).join("");
+      fences.push('<div class="rel-code-wrap">' +
+                  '<button class="copy" type="button">copy</button>' +
+                  '<pre class="rel-code" data-lang="' + (lang || "") + '"><code>' +
+                  lines + "</code></pre></div>");
       return " FENCE" + (fences.length - 1) + " ";
     });
 

--- a/docs/guide/style.css
+++ b/docs/guide/style.css
@@ -269,11 +269,27 @@ body.lb-lock { overflow: hidden; }
 .rel-body h6 { font-size: 14px; margin: 18px 0 8px; color: var(--muted); }
 .rel-body p, .rel-body li { font-size: 15px; line-height: 1.75; }
 .rel-body hr { border: 0; border-top: 1px solid var(--border); margin: 22px 0; }
-.rel-code { margin: 0 0 18px; padding: 14px 16px; overflow-x: auto; background: var(--bg); border: 1px solid var(--border); border-radius: 10px; font-family: var(--mono); font-size: 13px; line-height: 1.7; color: var(--text); }
+/* position: relative is what the absolutely-positioned .copy anchors to,
+   and the wrapper is also what carries the margin now that the <pre>
+   sits inside it. */
+.rel-code-wrap { position: relative; margin: 0 0 18px; }
+.rel-code-wrap:hover .copy, .rel-code-wrap:focus-within .copy { opacity: 1; }
+/* pre-wrap rather than overflow-x: auto. These bodies carry one-liners
+   like a full `docker run … | jq` that ran off the right edge with no
+   scrollbar to say so — a command you cannot finish reading is worse
+   than one that takes two lines. Soft wraps are not newlines, so the
+   copy button still yields the original command (measured). */
+.rel-code { margin: 0; padding: 14px 16px 14px; white-space: pre-wrap; overflow-wrap: break-word; background: var(--bg); border: 1px solid var(--border); border-radius: 10px; font-family: var(--mono); font-size: 13px; line-height: 1.7; color: var(--text); }
 /* The language, when the fence declared one — many did not, and an empty
    label is worse than none. */
 .rel-code[data-lang]:not([data-lang=""])::before { content: attr(data-lang); display: block; margin: -4px 0 8px; font-size: 10.5px; letter-spacing: .06em; text-transform: uppercase; color: var(--faint); }
 .rel-code code { background: none; border: 0; padding: 0; color: inherit; font-size: inherit; }
+/* One block per source line, each with a hanging indent, so a wrapped
+   continuation is visibly subordinate instead of reading as the next
+   command. text-indent alone cannot do this on a multi-line <pre>: it
+   applies to the block's first line only, which is why the lines are
+   separate elements. */
+.rel-ln { display: block; padding-left: 2.2ch; text-indent: -2.2ch; }
 .rel-table-wrap { overflow-x: auto; margin: 0 0 18px; }
 .rel-table-wrap table { border-collapse: collapse; width: 100%; font-size: 14px; }
 .rel-table-wrap th, .rel-table-wrap td { text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }


### PR DESCRIPTION
Two things reported on the page from #148.

## Long lines were cut

`overflow-x: auto` scrolled, but nothing indicated it — the `docker run … | jq .social` one-liner just ended at the right edge. Now `white-space: pre-wrap`. A command you cannot finish reading is worse than one that takes two lines.

## There was no copy button

The guide's hand-authored blocks have one, driven by a **delegated handler already in `docs.js`**: it finds `.copy`, then the `<pre>` in the same parent. Emitting that shape reuses it whole rather than adding a second copy mechanism to this page.

## Wrapping introduced its own problem

A wrapped continuation reads as *the next command*, which for a shell snippet is worse than the truncation it replaced. So each source line is its own block with a hanging indent — `text-indent` alone cannot do this, since on a multi-line `<pre>` it applies to the block's first line only.

Before → after on the docker block:

```
before   docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest --json | jq  ← cut here
after    docker run --rm -e GITHUB_TOKEN ghcr.io/gfazioli/octoscope:latest --json | jq
           .social
```

## The measurement that mattered

`innerText` is layout-aware, so "the copy still yields the original command" is exactly the kind of claim that needs checking rather than asserting:

| block | `.rel-ln` elements | newlines in `innerText` |
| --- | --- | --- |
| one-liner that wraps | 1 | **1** — a soft wrap adds none |
| two-line snippet | 2 | **2** — real lines survive |

Plus, across the page: 61 code blocks, 61 copy buttons, no horizontal overflow on the docker block, and zero visible zero-width spaces from the placeholder that keeps blank lines tall.

Verified over HTTP with the copy button forced visible, and read back from the render.