### PR TITLE
fix(version): the number the binary reports could not be patched

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ Each release also carries the bare executables next to the archives, named
 `octoscope_<version>_<os>-<arch>`, for when unpacking is the awkward part:
 
 ```bash
-VERSION=0.31.0   # or whatever the latest release says
+VERSION=0.31.1   # or whatever the latest release says
 curl -fsSL -o octoscope \
   "https://github.com/gfazioli/octoscope/releases/download/v${VERSION}/octoscope_${VERSION}_linux-amd64" \
   && chmod +x octoscope

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -46,7 +46,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.31.0</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.31.1</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1298,7 +1298,7 @@
                      keeps #version-pill, which the release-API fetch
                      below writes its text into. -->
                 <a class="version-link" href="guide/releases.html">
-                    <span class="version-tag" id="version-pill">0.31.0</span>
+                    <span class="version-tag" id="version-pill">0.31.1</span>
                     <span class="version-more">what&rsquo;s new &rarr;</span>
                 </a>
             </div>

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -71,6 +71,12 @@ var whatsNew031 = whatsNewEntry{
 }
 
 var whatsNew = map[string]whatsNewEntry{
+	// 0.31.1 shows 0.31.0's highlights, on the 0.30.1 precedent below.
+	// The tab renders only the running version, and this patch is a
+	// maintenance fix — the number the binary reported came from a
+	// const the release ldflag could not patch — with nothing a reader
+	// of this tab would act on.
+	"0.31.1": whatsNew031,
 	"0.31.0": whatsNew031,
 	// 0.30.1 shows 0.30.0's highlights, deliberately. The tab renders
 	// only the running version's entry, so anyone upgrading straight from

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -363,6 +363,20 @@ const releasesURL = "https://github.com/gfazioli/octoscope/releases"
 // bundled highlights (or a fallback link) followed by a sponsor section.
 // `version` is main.version (no leading "v"); `available` is the content
 // width for wrapping.
+// HasBundledHighlights reports whether the What's new tab has an entry
+// bundled for this version. The map itself stays unexported — this is
+// the only thing outside the package that needs to know, and it exists
+// so package main can assert the running version is covered.
+//
+// The miss path is deliberately graceful: the tab renders a link to the
+// release notes rather than the previous release's highlights. That is
+// the right behaviour, and it is exactly what makes a forgotten entry
+// invisible — so the assertion has to live somewhere that runs.
+func HasBundledHighlights(version string) bool {
+	_, ok := whatsNew[version]
+	return ok
+}
+
 func renderWhatsNewTab(version string, available int) string {
 	wrapW := available
 	if wrapW > 72 {

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 // showing up only in local builds. Measured before the change:
 // `go build -ldflags "-X main.version=9.9.9-fromtag"` still printed
 // 0.31.0.
-var version = "0.31.0"
+var version = "0.31.1"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI

--- a/main.go
+++ b/main.go
@@ -15,7 +15,16 @@ import (
 	"github.com/gfazioli/octoscope/internal/ui"
 )
 
-const version = "0.31.0"
+// version is what the binary reports. It is a var and not a const, and
+// that is load-bearing: .goreleaser.yaml builds releases with
+// -X main.version={{.Version}}, and the linker cannot patch a
+// constant — it fails silently, with no warning. While this was a const
+// the ldflag did nothing, so a released binary reported THIS string
+// rather than its tag: a stale bump here shipped to everyone instead of
+// showing up only in local builds. Measured before the change:
+// `go build -ldflags "-X main.version=9.9.9-fromtag"` still printed
+// 0.31.0.
+var version = "0.31.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI

--- a/version_test.go
+++ b/version_test.go
@@ -75,7 +75,8 @@ var versionSurfaces = []versionSurface{
 }
 
 // TestVersionSurfacesAgree asserts every hand-written copy of the
-// version matches the constant the binary reports.
+// version matches main.version — the variable the binary reports,
+// and the one a release overwrites through the linker.
 func TestVersionSurfacesAgree(t *testing.T) {
 	for _, s := range versionSurfaces {
 		t.Run(s.name, func(t *testing.T) {

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/gfazioli/octoscope/internal/ui"
+)
+
+// The version number is written by hand in five places and nothing used
+// to check that they agree. Every way they can drift fails quietly:
+// nothing errors, nothing turns red, a feature just stops being there.
+// These tests are the check, and they live in package main because that
+// is where the number itself lives.
+//
+// `go test` runs with the package directory as its working directory,
+// and main is at the repo root, so the docs surfaces can be read
+// straight off disk — no build tag, no network, no fixture. Coupling a
+// Go test to files under docs/ is the point rather than a wart: the
+// assertion is only ever violated when the surfaces genuinely disagree.
+
+// TestVersionHasBundledHighlights pins the What's new tab to the running
+// version. The tab looks up whatsNew[version] and its miss path is
+// deliberately graceful — it renders a link to the release notes instead
+// of the previous release's highlights — so a forgotten entry does not
+// break anything, it just quietly stops being a feature for that
+// release. Nothing else would ever notice.
+func TestVersionHasBundledHighlights(t *testing.T) {
+	if !ui.HasBundledHighlights(version) {
+		t.Errorf("no What's new entry bundled for %q — add it to whatsNew in internal/ui/whatsnew.go "+
+			"(a patch may alias the preceding minor's entry, as 0.30.1 and 0.31.1 do)", version)
+	}
+}
+
+// versionSurface is one place outside main.go that spells the version
+// out by hand.
+type versionSurface struct {
+	name string
+	path string
+	// pat captures the version in group 1. Each is anchored on an
+	// element id or a shell assignment and never on the digits
+	// themselves, so a surface that is renamed, restructured or deleted
+	// makes this test fail rather than silently stop being checked. A
+	// check that can quietly measure nothing is the failure these tests
+	// exist to prevent, so it must not be one.
+	pat *regexp.Regexp
+	// why says what a reader sees when this surface is stale.
+	why string
+}
+
+var versionSurfaces = []versionSurface{
+	{
+		name: "docs/index.html hero pill",
+		path: "docs/index.html",
+		pat:  regexp.MustCompile(`id="version-pill"[^>]*>([^<]*)<`),
+		why:  "the landing's inline fallback, rendered whenever the Releases API fetch fails",
+	},
+	{
+		name: "docs/guide/docs.js sidebar brand",
+		path: "docs/guide/docs.js",
+		pat:  regexp.MustCompile(`id="guide-ver"[^>]*>v([^<]*)<`),
+		why:  "the guide's inline fallback, same deal as the landing's pill",
+	},
+	{
+		// The one surface here a user copy-pastes rather than merely
+		// reads, and the only one whose staleness is invisible even in
+		// the failure: the asset name embeds the version, so an old
+		// value does not 404 — it installs an old octoscope.
+		name: "README.md bare-binary curl snippet",
+		path: "README.md",
+		pat:  regexp.MustCompile(`(?m)^VERSION=(\S+)`),
+		why:  "a copy-pasteable curl that silently downloads whatever version it names",
+	},
+}
+
+// TestVersionSurfacesAgree asserts every hand-written copy of the
+// version matches the constant the binary reports.
+func TestVersionSurfacesAgree(t *testing.T) {
+	for _, s := range versionSurfaces {
+		t.Run(s.name, func(t *testing.T) {
+			b, err := os.ReadFile(s.path)
+			if err != nil {
+				t.Fatalf("reading %s: %v", s.path, err)
+			}
+			m := s.pat.FindAllStringSubmatch(string(b), -1)
+			if len(m) != 1 {
+				t.Fatalf("%s: found %d matches for %s, want exactly 1 — the surface moved or was duplicated, "+
+					"so this assertion is no longer checking anything (%s)", s.path, len(m), s.pat, s.why)
+			}
+			if got := m[0][1]; got != version {
+				t.Errorf("%s carries %q, main.version is %q — %s", s.path, got, version, s.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #121.

## The issue's premise was wrong, and in the expensive direction

#121 reasons that `.goreleaser.yaml` builds with `-X main.version={{.Version}}`, so a released binary reports the **tag** — and concludes that a stale constant "is invisible in the release and only shows up in local builds, which is the harder drift to spot".

`version` was a `const`, and the linker cannot patch one. It does not warn; it just does nothing. Measured, same build flags:

```
const  →  -ldflags "-X main.version=9.9.9-fromtag"  →  octoscope 0.31.0
var    →  the same command                          →  octoscope 9.9.9-fromtag
```

So the ldflag has never done anything, and both conclusions invert: the released binary reported this hand-written string, and a stale bump **shipped to everyone** rather than staying local.

There is a second consequence the issue does not mention. `internal/ui` passes `main.version` to `update.IsNewer` against the latest tag, so a constant behind its own tag would have shown every user of that release a permanent *a newer version is available* — pointing at the version they were already running, and no upgrade would clear it.

## It has never actually happened

Worth stating plainly rather than dramatising the fix. Every tag, against the constant at that commit:

```
for t in $(git tag --sort=v:refname); do git show "$t:main.go" | grep '^const version'; done
```

**42 tags, 42 agreements.** The manual checklist has held for every release octoscope has ever cut. What was missing is anything that checked that it did — which is the whole family this issue belongs to.

## Five surfaces, not four

#121 lists four. There is a fifth, and it is the only one a **user** copy-pastes rather than merely reads:

| surface | what a stale value does |
| --- | --- |
| `main.go` `version` | now a `var`, so releases report their tag |
| `internal/ui` `whatsNew` key | the tab silently stops being a feature for that release |
| `docs/index.html` `#version-pill` | wrong number on the landing when the Releases fetch fails |
| `docs/guide/docs.js` `#guide-ver` | same, in the guide sidebar |
| **`README.md` `VERSION=`** | **installs an old octoscope, and looks like it worked** |

That last one is the worst of the five. The asset name embeds the version, so a stale value does not 404 — the prose right below the snippet says exactly why `releases/latest/` cannot be used there. It downloads an old binary successfully.

## What the tests do, and how I know they bite

`version_test.go`, package `main` — `go test` runs with the repo root as its working directory, so the docs surfaces are read straight off disk. No build tag, no network, no fixture. The coupling to `docs/` is the point: the assertion is only ever violated when the surfaces genuinely disagree.

Each pattern anchors on the **element id or the assignment, never on the digits**, and requires exactly one match. A surface that is renamed, restructured or deleted therefore fails the test instead of quietly no longer being checked — a check that can silently measure nothing is precisely the failure this issue is about.

The `whatsNew` map stays unexported; `ui.HasBundledHighlights(version)` is the only new API surface, which is the shape #121 asked for.

Mutation-tested, restoring between each:

| mutation | result |
| --- | --- |
| bump `version` alone | all four assertions fail |
| rename `#version-pill` → `#version-badge` | `found 0 matches for id="version-pill"…, want exactly 1` |
| `VERSION=` left behind | only its own subtest fails |

## Out of scope, deliberately

Constant versus git tag still cannot be a unit test — the tag does not exist when the tests run. With `version` now a `var` it also stops mattering for releases: the binary takes the tag. What remains is the *release-prep* bump, and the whatsNew assertion is what forces the map entry to follow it.

## Release prep

Second commit bumps to **0.31.1**. The What's new tab shows 0.31.0's highlights on the 0.30.1 precedent — the tab renders only the running version, and there is nothing here a reader of it would act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vp71bMdQYQnnbYXnh9Ltv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bundled “What’s New” highlights for version 0.31.1, reusing the previous release’s highlights where applicable.
  * Added support for release-time version updates in the distributed binary.

* **Documentation**
  * Updated the binary download example, documentation sidebar, and homepage version badge to 0.31.1.

* **Tests**
  * Added checks to keep the displayed version consistent across documentation and bundled release highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->