### PR TITLE
ci(goreleaser): run a full snapshot, so a config regression fails a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,13 @@
 # CI workflow. Runs on every push and pull-request against main to
 # catch the obvious regressions before they reach a tag.
 #
-# Six jobs: build (compile-only sanity), test (race-checked unit suite),
-# lint (gofmt + go vet), govulncheck (known-vulnerability scan of the
-# module dependencies), windows (the same suite plus a start-up smoke on
-# a real Windows runner) and docker (builds and runs the released
-# image). All but windows share the Ubuntu runner, with caching keyed on
-# go.sum so successive runs are fast.
+# Seven jobs: build (compile-only sanity), test (race-checked unit
+# suite), lint (gofmt + go vet), govulncheck (known-vulnerability scan of
+# the module dependencies), windows (the same suite plus a start-up smoke
+# on a real Windows runner), docker (builds and runs the released image)
+# and goreleaser (a full snapshot, so a .goreleaser.yaml regression turns
+# a PR red instead of a tag). All but windows share the Ubuntu runner,
+# with caching keyed on go.sum so successive runs are fast.
 #
 # Until 2026-09 nothing here ran on Windows at all: goreleaser
 # cross-compiles the windows/amd64 binary at tag time and it was
@@ -289,3 +290,66 @@ jobs:
           echo "user: $user"
           [ -n "$user" ] && [ "$user" != "root" ] && [ "$user" != "0" ] \
             || { echo "image would run as root"; exit 1; }
+
+  # Nothing exercised .goreleaser.yaml until a tag pushed, and that
+  # already cost a release: v0.31.0 died during goreleaser's *defaulting*
+  # because the bare binaries added two artifacts per os/arch and the
+  # Homebrew tap generator refuses to guess between them. Nothing had
+  # published, so the damage was a deleted-and-recreated public tag —
+  # but every local snapshot run while developing that change had used
+  # `--skip=homebrew`, the one pipe that would have failed.
+  #
+  # So this job runs the real thing with NOTHING skipped. In snapshot
+  # mode goreleaser builds every artifact, renders the formula and builds
+  # the images without publishing anything, which is precisely the
+  # coverage that was missing.
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # goreleaser needs the tag history to compute a version.
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      # dockers_v2 issues one multi-platform buildx build, and the
+      # default docker driver can only export those when the daemon runs
+      # the containerd image store. GitHub's runners use overlay2, so the
+      # container driver this installs is what makes it possible at all.
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver-opts: network=host
+
+      - name: goreleaser release --snapshot, nothing skipped
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
+        # Deliberately no HOMEBREW_TAP_TOKEN and no GITHUB_TOKEN: a
+        # snapshot publishes nothing, and a job that needs the real
+        # secrets could not run on a fork's pull request. If goreleaser
+        # evaluates the token template even when not publishing, this
+        # step is where that shows up.
+
+      - name: The pipes that can only fail at tag time actually ran
+        run: |
+          set -euo pipefail
+          echo "--- dist/ ---"; ls -la dist/
+
+          # The Homebrew formula is the artifact whose absence cost
+          # v0.31.0. Rendering it is the whole point of not skipping.
+          formula=$(find dist -name 'octoscope.rb' -print -quit)
+          [ -n "$formula" ] || { echo "no Homebrew formula rendered — the brews pipe did not run"; exit 1; }
+          echo "--- $formula ---"; cat "$formula"
+
+          # Five bare binaries and four archives, the same set a release
+          # publishes. A count catches an archives entry that silently
+          # stopped matching.
+          bare=$(find dist -maxdepth 1 -type f -name 'octoscope_*-*' ! -name '*.tar.gz' ! -name '*.zip' | wc -l | tr -d ' ')
+          arch=$(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
+          echo "bare=$bare archives=$arch"
+          [ "$bare" -eq 5 ] || { echo "want 5 bare binaries, got $bare"; exit 1; }
+          [ "$arch" -eq 4 ] || { echo "want 4 archives, got $arch"; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,19 @@ jobs:
   # mode goreleaser builds every artifact, renders the formula and builds
   # the images without publishing anything, which is precisely the
   # coverage that was missing.
+  #
+  # Two limits, both measured on the first run rather than assumed, so
+  # nobody reads more coverage into this job than it has:
+  #
+  #   - it needs NO secrets. `brews` carries a .Env.HOMEBREW_TAP_TOKEN
+  #     template and goreleaser does not evaluate it while not
+  #     publishing — it lands in the formula's config verbatim. That is
+  #     what lets this job run on a fork's pull request.
+  #   - it does NOT exercise the multi-platform manifest. A snapshot
+  #     builds one image per platform (`:...-amd64`, `:...-arm64`) and
+  #     assembles nothing, so the containerd-versus-overlay2 export
+  #     question never arises here. The `docker` job above is what covers
+  #     that, by pushing a real manifest to a local registry.
   goreleaser:
     runs-on: ubuntu-latest
     steps:
@@ -315,14 +328,6 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      # dockers_v2 issues one multi-platform buildx build, and the
-      # default docker driver can only export those when the daemon runs
-      # the containerd image store. GitHub's runners use overlay2, so the
-      # container driver this installs is what makes it possible at all.
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        with:
-          driver-opts: network=host
-
       - name: goreleaser release --snapshot, nothing skipped
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -337,19 +342,40 @@ jobs:
       - name: The pipes that can only fail at tag time actually ran
         run: |
           set -euo pipefail
-          echo "--- dist/ ---"; ls -la dist/
+          # dist/artifacts.json is goreleaser's own manifest. Counting
+          # files by name instead was the first version of this step and
+          # it was wrong twice over: the archives are five, not four
+          # (Windows ships a zip), and the bare binaries are not files in
+          # dist/ at all — `formats: [binary]` registers an upload *name*
+          # while the path still points into the build output directory.
+          echo "--- artifacts by type ---"
+          jq -r '.[] | "\(.type)\t\(.extra.ID // "-")"' dist/artifacts.json | sort | uniq -c
 
-          # The Homebrew formula is the artifact whose absence cost
-          # v0.31.0. Rendering it is the whole point of not skipping.
-          formula=$(find dist -name 'octoscope.rb' -print -quit)
-          [ -n "$formula" ] || { echo "no Homebrew formula rendered — the brews pipe did not run"; exit 1; }
-          echo "--- $formula ---"; cat "$formula"
+          count() { jq "[.[] | select($1)] | length" dist/artifacts.json; }
 
-          # Five bare binaries and four archives, the same set a release
-          # publishes. A count catches an archives entry that silently
-          # stopped matching.
-          bare=$(find dist -maxdepth 1 -type f -name 'octoscope_*-*' ! -name '*.tar.gz' ! -name '*.zip' | wc -l | tr -d ' ')
-          arch=$(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
-          echo "bare=$bare archives=$arch"
-          [ "$bare" -eq 5 ] || { echo "want 5 bare binaries, got $bare"; exit 1; }
-          [ "$arch" -eq 4 ] || { echo "want 4 archives, got $arch"; exit 1; }
+          # The formula is the artifact whose absence cost v0.31.0: two
+          # artifacts per os/arch and the tap generator refuses to guess.
+          n=$(count '.type == "Homebrew Formula"')
+          [ "$n" -eq 1 ] || { echo "want 1 rendered formula, got $n — the brews pipe did not run"; exit 1; }
+          echo "--- dist/homebrew/Formula/octoscope.rb ---"; cat dist/homebrew/Formula/octoscope.rb
+
+          # Five archives (four tarballs plus the Windows zip) and five
+          # bare binaries, which are Binary artifacts carrying the
+          # separate `binary` archive id.
+          n=$(count '.type == "Archive"')
+          [ "$n" -eq 5 ] || { echo "want 5 archives, got $n"; exit 1; }
+          n=$(count '.type == "Binary" and .extra.ID == "binary"')
+          [ "$n" -eq 5 ] || { echo "want 5 bare binaries, got $n"; exit 1; }
+
+          n=$(count '.type == "Checksum"')
+          [ "$n" -eq 1 ] || { echo "want a checksums file, got $n"; exit 1; }
+
+          # Both architectures were built. Snapshot mode does NOT
+          # assemble the multi-platform manifest — it builds one image
+          # per platform and pushes nothing — so this asserts what the
+          # snapshot actually covers, and the `docker` job above is what
+          # covers the manifest.
+          for want in linux/amd64 linux/arm64; do
+            n=$(jq --arg p "$want" '[.[] | select(.type == "Docker Image" and (.extra.Platforms // []) == [$p])] | length' dist/artifacts.json)
+            [ "$n" -ge 1 ] || { echo "no image built for $want"; exit 1; }
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,12 +292,19 @@ jobs:
             || { echo "image would run as root"; exit 1; }
 
   # Nothing exercised .goreleaser.yaml until a tag pushed, and that
-  # already cost a release: v0.31.0 died during goreleaser's *defaulting*
-  # because the bare binaries added two artifacts per os/arch and the
-  # Homebrew tap generator refuses to guess between them. Nothing had
-  # published, so the damage was a deleted-and-recreated public tag —
-  # but every local snapshot run while developing that change had used
-  # `--skip=homebrew`, the one pipe that would have failed.
+  # already cost a release: v0.31.0 died because the bare binaries gave
+  # goreleaser two artifacts per os/arch and the Homebrew tap generator
+  # refuses to guess between them. Nothing had published, so the damage
+  # was a deleted-and-recreated public tag — but every local snapshot run
+  # while developing that change had used `--skip=homebrew`, the one pipe
+  # that would have failed.
+  #
+  # Measured here rather than assumed, by reintroducing the collision on
+  # purpose: goreleaser does NOT refuse during defaulting. It sets
+  # defaults, builds all five targets, archives them, checksums them, and
+  # only then refuses while *rendering* the formula — a minute in. The
+  # conclusion still holds, because publishing comes after that, but a
+  # regression of this class costs the full build before it says so.
   #
   # So this job runs the real thing with NOTHING skipped. In snapshot
   # mode goreleaser builds every artifact, renders the formula and builds


### PR DESCRIPTION
Closes #147.

## Why

Nothing exercised `.goreleaser.yaml` until a tag was pushed, and that already cost a release. v0.31.0 died because the bare binaries gave goreleaser two artifacts per os/arch and the Homebrew tap generator refuses to guess between them. Nothing published, so the damage was a deleted-and-recreated public tag.

The actionable half is why nothing caught it: every local snapshot run while developing that change used `--skip=homebrew` — the one pipe that would have failed — and CI did not run goreleaser at all. This job runs it with **nothing skipped**.

## The proof that it bites

A green job is not evidence it can go red, so the collision was reintroduced on purpose and the branch then reset. Both runs stand as the receipt:

| | run | outcome |
| --- | --- | --- |
| baseline | [34020826841](https://github.com/gfazioli/octoscope/actions/runs/34020826841) | green — all counts match |
| `ids: [default]` removed | [34020964943](https://github.com/gfazioli/octoscope/actions/runs/34020964943) | **red**, with the tag's own error |

```
⨯ release failed after 1m10s
  error=one tap can handle only one archive of an OS/Arch combination.
        Consider using ids in the brew section
```

Byte-identical to what killed v0.31.0. The two proof commits are deliberately **not** in this branch — a commit that breaks the config plus its revert is permanent noise on `main`, and what #147 asks for is the run, which outlives the commit.

## What the first run measured, and what it contradicted

#147 left three questions open. None was guessed at.

**Runtime — it stays in `ci`.** 1m35s for goreleaser (1m24s of it cross-compiling five targets), ~2m for the job. In line with `windows` (1m27s) and `docker` (1m2s), both already on every PR.

**No secrets needed.** The formula rendered with `token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"` left verbatim in its config, so goreleaser does not evaluate that template while not publishing. The job can therefore run on a fork's pull request.

**The multi-platform question does not arise** — and this contradicted the job's first draft. A snapshot logs `snapshot build: will not push any images` and builds one image *per platform* (`:…-amd64`, `:…-arm64`), assembling no manifest. So the containerd-versus-overlay2 export problem never comes up here, the `setup-buildx` step I had added was doing nothing, and its comment claimed coverage this job does not have. Removed, and the limit is written down instead: the `docker` job covers the manifest by pushing a real one to a local registry.

**And a fourth thing, which #147 states and gets wrong.** The issue says goreleaser "refuses during *defaulting*, before building". It does not. The red run traces:

```
setting defaults → snapshotting → building binaries (five targets, ~1m)
→ archives → calculating checksums → homebrew formula → ⨯
```

It refuses while *rendering* the formula, a minute in. The conclusion survives — nothing publishes, because publishing comes after that point — but the mechanism was wrong and a regression of this class costs the full build before it reports. Corrected in the job comment and on the issue.

## The assertions are on the manifest, not on filenames

The first version counted files in `dist/` and was wrong twice: archives are **five**, not four (Windows ships a zip), and the bare binaries are not files in `dist/` at all — `formats: [binary]` registers an upload *name* while the path still points into the build output directory. It failed on its own bad expectation rather than on anything goreleaser did.

`dist/artifacts.json` is goreleaser's own manifest and is now the source. Measured census, which the job both prints and asserts:

```
5 Archive           default
5 Binary            binary      ← the bare uploads
5 Binary            octoscope   ← the build outputs
1 Checksum
4 Docker Image      octoscope
1 Homebrew Formula
```

## Also confirmed in passing, for #142

The `brews` deprecation warning fires on every run and does not fail it. Whether `goreleaser check` exits non-zero — the claim #142 actually rests on — is **not** settled here and remains that issue's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vp71bMdQYQnnbYXnh9Ltv
