### PR TITLE
docs: the GraphQL ceiling is a 10-second clock, not a complexity score

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,13 +653,30 @@ one place to look.
   boundary and the UI applies its own gate before use (v0.25.0, the
   check `detailsUrl` / `targetUrl` fields).
 
-#### Complexity ceiling — what we can and can't query (since v0.10.1)
+#### The ceiling is a 10-second clock — what we can and can't query (since v0.10.1)
 
-GitHub's GraphQL gateway has a **per-request complexity budget that
-isn't documented as a hard number**. Empirically, on a real ~74-repo
-authenticated account in early 2026, these patterns hit it and got
-HTTP 502 *from the proxy* (before the request reached the GraphQL
-backend):
+This section called it a "complexity budget" from v0.10.1 until
+2026-09-06, when it was measured. It is a **clock, not a score**.
+GitHub terminates any request it cannot process within **10 seconds**
+and answers 502 or 504 from the gateway, before the request reaches the
+GraphQL backend — documented under *Timeouts* on the GraphQL
+rate-limits page. `rateLimit.cost` is **not the dial**: it read 1 for
+every query shape in that measurement, the ones that survived and the
+ones that died alike. And a timeout is not free — the same page says
+extra points are deducted from the primary rate limit for the next
+hour, so a query that flirts with the clock taxes the account on every
+refresh that loses.
+
+Two numbers to carry, both from the maintainer's 91-repo account:
+
+- the real `repoFields` query already spends **6.4–6.7 s** of the ten.
+  Any field added to the list fetch buys from a ~3.5 s budget;
+- one `history { totalCount }` per repo on top of it: **8.2–10.9 s,
+  three 502s in five runs**. The first run passed, at 9.8 s. A single
+  green run of a query near the clock proves nothing — run five.
+
+These patterns hit that clock on a ~74-repo account in early 2026 and
+again on 91 repos in September, always as HTTP 502 *from the proxy*:
 
 - A single combined query covering profile + counters + open PR/Issue
   nodes + 52-week contribution calendar + `repositories(first: 100)`
@@ -667,8 +684,11 @@ backend):
   v0.10.1 split.
 - `defaultBranchRef.target.history.totalCount` requested once per
   repo across `repositories(first: 100)` (i.e. per-item fan-out on
-  100 items). **Always 502.** This killed the original issue #4
-  plan (configurable columns + commit-count metrics).
+  100 items). **Always 502** in 2026; **3 of 5** on re-measurement
+  in September, with the first run passing — see #70. This killed
+  the original issue #4 plan (configurable columns + commit-count
+  metrics). The same field in a query of its own: 4.4–6.2 s, five
+  of five, which is why the fallback is a separate branch.
 
 **Rules of thumb derived from those scars**:
 
@@ -722,11 +742,15 @@ backend):
      connection (prone to GitHub tightening + its own transient
      5xx), so it is best-effort, while the detail query stays
      mandatory and still `cancel()`s an in-flight walk.
-4. **Adding new fields to a query**: estimate complexity first.
-   `languages(first: 10)` × 100 repos was already a meaningful
-   chunk of the budget; `defaultBranchRef.target.statusCheckRollup`
-   inline on 100 repos blew it. New nested aggregates ride on top
-   of what's already there.
+4. **Adding new fields to a query: measure the wall clock, do not
+   estimate complexity.** Run the full query with the field against
+   the busiest account available, **five times**, and read the
+   spread against 10 s — `rateLimit.cost` will say 1 either way.
+   Anything past ~7 s on the list fetch belongs in its own parallel
+   branch. `languages(first: 10)` × 100 repos is already inside the
+   6.5 s the list fetch spends; `defaultBranchRef.target.statusCheckRollup`
+   inline on 100 repos pushed it over. New nested aggregates ride on
+   top of what's already there.
 5. **If a feature needs per-repo data on the list**, surface it
    on-demand in the detail view first, then evaluate whether a
    list-level column is even necessary. The drill-in already
@@ -741,12 +765,16 @@ backend):
    attempts, short backoff, retries **only** `ReasonServer`).
    New fetch paths reuse the same retry helper, and any new
    transport-level error string gets taught to `classifyErr`
-   rather than leaking raw text into the error screen.
+   rather than leaking raw text into the error screen. The retry is
+   for a *fine* query on a bad moment: a query that times out on its
+   own weight is not transient, and each retry of it deducts more
+   from the hour-long penalty. Fix the query; do not lean on the
+   retry.
 
 The principle "one GraphQL query per refresh" from v0.x.x docs is
 **superseded** — current invariant is "as many parallel branches
-as the feature shape demands, each one estimated against the
-complexity ceiling before adding fields".
+as the feature shape demands, each one measured against the
+10-second clock before adding fields".
 
 ### Testing
 

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -452,9 +452,12 @@ means nothing has improved, not that all is well.
 
 ## Architecture — tiers inside the complexity ceiling
 
-GitHub's GraphQL gateway enforces an undocumented per-request complexity
-budget, and per-item fan-out across many repositories reliably exceeds it. The
-scan is tiered accordingly.
+GitHub's GraphQL gateway terminates any request it cannot process within 10
+seconds — documented, answered as 502/504 from the proxy, and followed by a
+rate-limit penalty for the next hour — and per-item fan-out across many
+repositories reliably runs past that clock. It is a timeout, not a complexity
+score (measured 2026-09-06; `rateLimit.cost` read 1 on the queries that died).
+The scan is tiered accordingly.
 
 - **Tier A — free, on the existing dashboard fetch.** An always-on push-burst
   banner was built and then **dropped**: timing alone cannot separate a worm


### PR DESCRIPTION
Refs #70 #58 #59 #66. Docs only; no code changes.

## What was measured

The gate four July issues have been waiting on — "does a 100-repo document with per-item fan-out survive the gateway?" — was tried on 2026-09-06 on a **91-repo** account, with the real `repoFields` query.

| query | result | time |
| --- | --- | --- |
| `repoFields` as shipped | 200 × 4 | 6.4–6.7 s |
| + `history { totalCount }` per repo | **502 × 3**, 200 × 2 | 8.2–10.9 s |
| the same field in its own query | 200 × 5 | 4.4–6.2 s |
| `rateLimit.cost`, every shape above | **1** | — |

Every 502 landed at 10.7–10.9 s. [GitHub's GraphQL limits page](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#timeouts): requests over 10 seconds are terminated and "you may receive either a 502 or 504", and "additional points will be deducted from your primary rate limit for the next hour".

## What the guide got wrong

`CLAUDE.md` has said *"per-request complexity budget that isn't documented as a hard number"* since v0.10.1, and rule 4 told contributors to *"estimate complexity first"*. Both point at `rateLimit.cost` and node counts — and cost read 1 on the queries that died. The design doc called the same thing *"undocumented"*. It is documented, and it is a clock.

**The rules themselves stand** — split branches, bounded fan-out, drill-in first, best-effort degrades. What this PR changes is *why* they hold and *what to look at* before adding a field: the wall clock, five runs, against ten seconds. Two numbers nobody had are now written down: the list fetch already spends **~6.5 s** of the ten, and the first run of the fatal query **passed** at 9.8 s — a single green run near the clock proves nothing.

Rule 6 gains one sentence: the retry helper is for a *fine* query on a bad moment; a query that times out on its own weight is not transient, and each retry deducts more from the hour-long penalty.

## Verified

Every replaced passage matched exactly once before editing (the edit script asserts it), and a grep for the old wording — `complexity budget`, `estimate complexity`, `undocumented per-request` — comes back empty after. The heading was renamed; nothing links its anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vp71bMdQYQnnbYXnh9Ltv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance to describe the measured 10-second GraphQL gateway timeout and its rate-limit penalty.
  * Added measured timing data from a 91-repository account.
  * Revised query optimization guidance to emphasize wall-clock measurements across multiple runs.
  * Clarified retry behavior for timeouts and documented observed 502/504 failure rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->