### PR TITLE
feat(repos): a commits-by-you column, opt-in, in its own query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -694,7 +694,7 @@ again on 91 repos in September, always as HTTP 502 *from the proxy*:
 
 1. **The dashboard fetch is N parallel branches.** Started as two
    parallel queries in v0.10.1 (`profileFields` + `repoFields`),
-   currently up to **six** as of v0.29.0:
+   currently up to **seven** as of v0.32.0:
    1. `profileFields` — profile, counters, open PR/Issue nodes,
       contribution calendar
    2. `repoFields` — `repositories(first: 100)` with full nested
@@ -713,6 +713,15 @@ again on 91 repos in September, always as HTTP 502 *from the proxy*:
       GraphQL error on a permission edge, which is the shape that
       aborts a decode — sharing a branch with anything mandatory
       would take the dashboard down with it.
+   7. `repoCommitFields` (v0.32.0, #70) — the viewer's commits per
+      owned repo over the last year, gated on config `commit_counts`
+      **and** an authenticated viewer. Best-effort like gists, for a
+      measured reason: inline on `repoFields` this field pushed the
+      list query past the 10-second clock (three 502s in five runs on
+      91 repos); standalone it took 4.4–6.2 s, so it pages at 50 and
+      a timeout costs the column for one refresh, never the dashboard.
+      `Stats.CommitsLastYearApplied` is how the UI tells counts from
+      placeholders.
    All run via goroutines + `sync.WaitGroup`. Wall-clock latency
    stays close to the slowest branch rather than their sum. See
    `internal/github/client.go` `FetchStats` for the canonical

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ with `tab` / `shift+tab`.
   cycle and surfaces failures first; "release" sort lists the most
   recently published first), `/` to filter by substring, `P` on a row to
   pin a repo to a sticky section at the top — the viewport scrolls so
-  even a 100-repo account stays navigable. Add `watch_repos = ["..."]`
+  even a 100-repo account stays navigable. Set `commit_counts = true` to
+  add a **commits** column — how many commits you authored in each repo
+  over the last year, with its own sort (v0.32.0+). Off by default: it is
+  the one column that costs a query of its own on every refresh. Add `watch_repos = ["..."]`
   to the config to monitor repositories you don't own — they appear in
   a third "Watched" section under your own list. Press `w` (v0.18.0+)
   to cycle the **work filters** — *PRs open*, *CI broken*, *stale 90d* —
@@ -751,7 +754,8 @@ theme = "octoscope"
 
 # Initial view preferences (v0.23.0+). One sort key seeds every tab
 # whose sort cycle has that column: pushed | stars | forks | name |
-# ci | release apply to the Repos tab; updated | repo | number apply
+# ci | release | commits (needs commit_counts) apply to the Repos tab;
+# updated | repo | number apply
 # to the PRs and Issues tabs. Unset keys keep the built-in defaults
 # (pushed / updated, no work filter, density sparkline).
 default_sort = "pushed"
@@ -783,6 +787,12 @@ check_for_updates = true
 # claims a clean state it hasn't verified. This is the only feature that
 # contacts a host other than api.github.com; set false to opt out.
 check_service_status = true
+
+# Add a "commits by you, last year" column to the Repos tab (v0.32.0+).
+# Off by default: it is the one column that costs a query of its own on
+# every refresh — GitHub counts each repository's history on request —
+# and it needs an authenticated viewer to count for. Sortable with s.
+commit_counts = false
 
 # Optional override for just the accent slot of the active theme.
 # Hex ("#FF0080") or ANSI 256 ("201"). Leave unset to keep the

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ Each release also carries the bare executables next to the archives, named
 `octoscope_<version>_<os>-<arch>`, for when unpacking is the awkward part:
 
 ```bash
-VERSION=0.31.1   # or whatever the latest release says
+VERSION=0.32.0   # or whatever the latest release says
 curl -fsSL -o octoscope \
   "https://github.com/gfazioli/octoscope/releases/download/v${VERSION}/octoscope_${VERSION}_linux-amd64" \
   && chmod +x octoscope

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -46,7 +46,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.31.1</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.32.0</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/guide/settings.html
+++ b/docs/guide/settings.html
@@ -58,7 +58,10 @@ watch_repos   = [<span class="val">"charmbracelet/bubbletea"</span>]
 <span class="cmt"># The launch sponsor splash, the update check, and GitHub's own status.</span>
 show_sponsor         = <span class="val">true</span>
 check_for_updates    = <span class="val">true</span>
-check_service_status = <span class="val">true</span></pre>
+check_service_status = <span class="val">true</span>
+
+<span class="cmt"># A "commits by you, last year" column on the Repos tab. Costs a query per refresh.</span>
+commit_counts        = <span class="val">false</span></pre>
         </div>
 
         <h2>Key reference</h2>
@@ -69,7 +72,7 @@ check_service_status = <span class="val">true</span></pre>
             <tr><td class="k"><code>compact</code></td><td>Denser Overview cards. Default <code>false</code>.</td></tr>
             <tr><td class="k"><code>theme</code></td><td>One of the seven palettes. Default <code>"octoscope"</code>. See <a href="themes.html">Themes</a>.</td></tr>
             <tr><td class="k"><code>accent_color</code></td><td>Override just the accent — <code>#RGB</code> / <code>#RRGGBB</code> or an ANSI-256 index. Default empty (theme's own).</td></tr>
-            <tr><td class="k"><code>default_sort</code></td><td>Seed the list sort: <code>pushed · stars · forks · name · ci · release</code> (Repos) or <code>updated · repo · number</code> (PRs/Issues).</td></tr>
+            <tr><td class="k"><code>default_sort</code></td><td>Seed the list sort: <code>pushed · stars · forks · name · ci · release · commits</code> (Repos; <code>commits</code> applies only with <code>commit_counts</code> on) or <code>updated · repo · number</code> (PRs/Issues).</td></tr>
             <tr><td class="k"><code>default_work_filter</code></td><td>Seed the Repos work filter: <code>prs-open · ci-broken · stale</code>.</td></tr>
             <tr><td class="k"><code>default_star_history</code></td><td>Seed the star sparkline: <code>density</code> or <code>cumulative</code>.</td></tr>
             <tr><td class="k"><code>pinned_repos</code></td><td>Array of <code>owner/name</code> to pin atop the Repos tab. Persisted as you press <kbd>P</kbd>.</td></tr>
@@ -78,6 +81,7 @@ check_service_status = <span class="val">true</span></pre>
             <tr><td class="k"><code>show_sponsor</code></td><td>The one-time launch sponsor splash. Default <code>true</code>. (Suppressed under <code>--public-only</code>.)</td></tr>
             <tr><td class="k"><code>check_for_updates</code></td><td>The launch/hourly update check. Default <code>true</code>. octoscope never self-updates.</td></tr>
             <tr><td class="k"><code>check_service_status</code></td><td>Ask <a href="https://www.githubstatus.com">githubstatus.com</a> whether GitHub is healthy, so an outage there doesn't read as an octoscope bug. Default <code>true</code>. The only feature that contacts a host other than <code>api.github.com</code> — set <code>false</code> to keep octoscope talking to GitHub and nothing else.</td></tr>
+            <tr><td class="k"><code>commit_counts</code></td><td>Add a <b>commits</b> column to the Repos tab — commits you authored in each repo over the last 365 days — with its own sort. Default <code>false</code>: it is the one column that costs a query of its own on every refresh, and it needs an authenticated viewer to count for. Hidden on a public profile.</td></tr>
           </tbody>
         </table>
         <p>A malformed <code>pinned_*</code> or <code>watch_repos</code> entry is dropped quietly rather than failing the whole file; an invalid <code>theme</code> / <code>default_*</code> value is rejected loudly at startup with the accepted set named.</p>

--- a/docs/guide/tabs.html
+++ b/docs/guide/tabs.html
@@ -41,7 +41,7 @@
         </figure>
 
         <h2 id="repos"><kbd>2</kbd> Repos</h2>
-        <p>Every repository you own, sortable, with a CI rollup dot, stars, forks, open issues/PRs, last push and latest release. Pinned repos (<kbd>P</kbd>) ride a sticky section at the top; watched repos from your config sit below.</p>
+        <p>Every repository you own, sortable, with a CI rollup dot, stars, forks, open issues/PRs, last push and latest release — and, with <code>commit_counts = true</code> in your config, how many commits you authored in each over the last year. Pinned repos (<kbd>P</kbd>) ride a sticky section at the top; watched repos from your config sit below.</p>
         <p>Three keys shape the list: <kbd>s</kbd> cycles the <b>sort</b>, <kbd>/</kbd> <b>filters</b> by substring, and <kbd>w</kbd> cycles the <b>work filters</b> — <b>PRs&nbsp;open</b>, <b>CI&nbsp;broken</b>, <b>stale&nbsp;90&nbsp;days</b> — to narrow the tab to what actually needs attention.</p>
         <figure class="shot">
           <div class="frame">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1298,7 +1298,7 @@
                      keeps #version-pill, which the release-API fetch
                      below writes its text into. -->
                 <a class="version-link" href="guide/releases.html">
-                    <span class="version-tag" id="version-pill">0.31.1</span>
+                    <span class="version-tag" id="version-pill">0.32.0</span>
                     <span class="version-more">what&rsquo;s new &rarr;</span>
                 </a>
             </div>

--- a/internal/config/commit_counts_config_test.go
+++ b/internal/config/commit_counts_config_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCommitCountsConfigRoundTrip pins the #70 commit_counts key: off by
+// default, emitted by Save either way (a settings-panel save must not
+// drop a hand-edited key), and read back by Load.
+func TestCommitCountsConfigRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if def := Defaults(); def.CommitCounts {
+		t.Fatalf("defaults: CommitCounts=%v, want false — the column costs a query per refresh", def.CommitCounts)
+	}
+
+	if err := Save(path, Defaults()); err != nil {
+		t.Fatalf("save defaults: %v", err)
+	}
+	body, _ := os.ReadFile(path)
+	if !strings.Contains(string(body), "commit_counts = false") {
+		t.Errorf("pristine config missing commit_counts:\n%s", body)
+	}
+
+	c := Defaults()
+	c.CommitCounts = true
+	if err := Save(path, c); err != nil {
+		t.Fatalf("save opted-in: %v", err)
+	}
+	body, _ = os.ReadFile(path)
+	if !strings.Contains(string(body), "commit_counts = true") {
+		t.Errorf("opted-in config should carry commit_counts = true:\n%s", body)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !got.CommitCounts {
+		t.Error("CommitCounts should round-trip true")
+	}
+
+	// A file that never mentions the key keeps the default rather than
+	// reading the absent key as false-by-accident-of-zero-value.
+	if err := os.WriteFile(path, []byte("refresh_interval = \"1m\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = Load(path)
+	if err != nil {
+		t.Fatalf("load minimal: %v", err)
+	}
+	if got.CommitCounts {
+		t.Error("absent commit_counts must stay at the default (false)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,18 @@ type Config struct {
 	// talking to api.github.com and nothing else — this is the only
 	// feature in the tool that contacts another host.
 	CheckServiceStatus bool `toml:"check_service_status"`
+
+	// CommitCounts adds a per-repository "commits by you, last year"
+	// column to the Repos tab (#70). Off by default because it is the
+	// one column the dashboard cannot get for free: GitHub counts each
+	// repository's history on request, and asking for it inline on the
+	// list query pushed that query past the gateway's 10-second limit on
+	// a 91-repo account (three 502s in five runs). It therefore runs as
+	// its own parallel query — measured at 4–6 s over 91 repos — which
+	// is a cost every refresh pays and only some accounts want. Needs an
+	// authenticated viewer to filter by; on a public profile the column
+	// stays hidden. Hand-edit only, like the check_* keys.
+	CommitCounts bool `toml:"commit_counts"`
 }
 
 // DefaultRefreshInterval is the auto-refresh cadence used when none is
@@ -174,6 +186,7 @@ func Defaults() Config {
 		ShowSponsor:        true,
 		CheckForUpdates:    true,
 		CheckServiceStatus: true,
+		CommitCounts:       false,
 	}
 }
 
@@ -343,6 +356,7 @@ func Load(path string) (Config, error) {
 		ShowSponsor        *bool    `toml:"show_sponsor"`
 		CheckForUpdates    *bool    `toml:"check_for_updates"`
 		CheckServiceStatus *bool    `toml:"check_service_status"`
+		CommitCounts       *bool    `toml:"commit_counts"`
 	}
 	if _, err := toml.DecodeFile(path, &raw); err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
@@ -390,6 +404,9 @@ func Load(path string) (Config, error) {
 	}
 	if raw.CheckServiceStatus != nil {
 		cfg.CheckServiceStatus = *raw.CheckServiceStatus
+	}
+	if raw.CommitCounts != nil {
+		cfg.CommitCounts = *raw.CommitCounts
 	}
 
 	return cfg, nil
@@ -534,7 +551,13 @@ check_for_updates = %t
 # api.github.com — set to false to keep octoscope talking to GitHub and
 # nothing else.
 check_service_status = %t
-%s%s%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, cfg.CheckForUpdates, cfg.CheckServiceStatus, accentLine, viewPrefsLine, pinnedLine, pinnedIssuesLine, watchLine)
+
+# Add a "commits by you, last year" column to the Repos tab. Off by
+# default: it is the one column that costs a query of its own on every
+# refresh (GitHub counts each repository's history on request), and it
+# needs an authenticated viewer to count for. Sortable with s once on.
+commit_counts = %t
+%s%s%s%s%s`, cfg.RefreshInterval.String(), cfg.PublicOnly, cfg.Compact, cfg.Theme, cfg.ShowSponsor, cfg.CheckForUpdates, cfg.CheckServiceStatus, cfg.CommitCounts, accentLine, viewPrefsLine, pinnedLine, pinnedIssuesLine, watchLine)
 
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -40,6 +40,7 @@ type Client struct {
 	tokenSource   auth.Source // where the token came from — drives auth-error hints, never holds the token
 	login         string
 	publicOnly    bool
+	commitCounts  bool // config commit_counts (#70); read-only after New
 
 	// watchRepos is the live list of external "owner/name"
 	// identifiers the next FetchStats will resolve into
@@ -117,6 +118,10 @@ func (c *Client) ensureViewerID(ctx context.Context) (githubv4.ID, bool, error) 
 // default) preserves the pre-flag behaviour.
 type Options struct {
 	PublicOnly bool
+	// CommitCounts enables the seventh dashboard branch (#70): one
+	// standalone query counting the viewer's commits per owned repo
+	// over the last year. See FetchStats for why it is its own branch.
+	CommitCounts bool
 }
 
 // SocialAccount is one of the verified social links on the profile
@@ -185,6 +190,13 @@ type Repo struct {
 	// or for repos that simply haven't cut anything yet.
 	LatestReleaseTag         string
 	LatestReleasePublishedAt time.Time
+
+	// CommitsLastYear is the number of commits the authenticated viewer
+	// authored on the default branch in the last 365 days (#70). Only
+	// meaningful when Stats.CommitsLastYearApplied is true: the count
+	// comes from an opt-in branch that needs a viewer to filter by, and
+	// a zero here otherwise means "not fetched", not "none".
+	CommitsLastYear int
 }
 
 // PullRequest is one open PR authored by the user, feeding the PRs
@@ -330,6 +342,12 @@ type Stats struct {
 	// one entry per owned, non-fork repository up to the 100-repo
 	// GraphQL page limit shared with the Operational aggregates.
 	Repositories []Repo
+	// CommitsLastYearApplied is true when the opt-in commit-count branch
+	// (config commit_counts, #70) ran and succeeded this refresh. The
+	// Repos tab shows the column and offers its sort only then — the
+	// branch is best-effort, so a refresh where it timed out must not
+	// render a column of zeros that look like real counts.
+	CommitsLastYearApplied bool
 
 	// OpenPullRequests is the list of currently-open PRs the user
 	// authored, sorted newest-update first, capped at 50 entries
@@ -621,6 +639,7 @@ func New(login string, opts Options) (*Client, error) {
 		tokenSource:   tokenSrc,
 		login:         login,
 		publicOnly:    opts.PublicOnly,
+		commitCounts:  opts.CommitCounts,
 	}, nil
 }
 
@@ -897,6 +916,104 @@ type repoCIFields struct {
 	} `graphql:"repositories(first: 100, after: $ciCursor, ownerAffiliations: OWNER, isFork: false)"`
 }
 
+// repoCommitFields is the seventh dashboard branch (#70): per owned
+// repository, the number of commits the viewer authored on the default
+// branch in the last year. It is the same authoredYear field the repo
+// drill-in already uses, lifted to the list.
+//
+// It is a query of its own, and it pages at 50 rather than 100, for a
+// measured reason. GitHub counts each repository's history on request,
+// and asking for this field inline on repoFields pushed that query from
+// 6.5 s to 8–11 s on a 91-repo account — past the gateway's 10-second
+// limit three times in five. Standalone over the same 91 repos it took
+// 4.4–6.2 s, which is 44–62 % of the limit at 100 per page; halving the
+// page keeps each request well clear of the clock as accounts grow. A
+// timeout is also not free (GitHub docks the rate limit for the next
+// hour after one), so this branch prefers more small requests to one
+// that flirts with the cut-off.
+type repoCommitFields struct {
+	Repositories struct {
+		Nodes []struct {
+			NameWithOwner    githubv4.String
+			DefaultBranchRef struct {
+				Target struct {
+					Commit struct {
+						AuthoredYear struct {
+							TotalCount githubv4.Int
+						} `graphql:"authoredYear: history(since: $since, author: $authorFilter)"`
+					} `graphql:"... on Commit"`
+				}
+			}
+		}
+		PageInfo struct {
+			HasNextPage githubv4.Boolean
+			EndCursor   githubv4.String
+		}
+	} `graphql:"repositories(first: 50, after: $commitsCursor, ownerAffiliations: OWNER, isFork: false)"`
+}
+
+// maxRepoCommitPages bounds the commit-count walk. Twice maxRepoPages
+// because this query pages at 50, so the two walks cover the same 500
+// repositories.
+const maxRepoCommitPages = 2 * maxRepoPages
+
+// fetchRepoCommitFieldsPaged walks repoCommitFields with the viewer's
+// node ID as the author filter. Callers gate on ensureViewerID first:
+// an empty CommitAuthor is rejected by GitHub as invalid input, and the
+// count is meaningless without a viewer to attribute commits to.
+func (c *Client) fetchRepoCommitFieldsPaged(ctx context.Context, viewerID githubv4.ID) (repoCommitFields, rateLimitFields, error) {
+	var acc repoCommitFields
+	var lastRL rateLimitFields
+	var cursor *githubv4.String
+	totalCost := 0
+
+	since := githubv4.GitTimestamp{Time: time.Now().Add(-365 * 24 * time.Hour)}
+	id := viewerID
+	authorFilter := githubv4.CommitAuthor{ID: &id}
+
+	for page := 0; page < maxRepoCommitPages; page++ {
+		var (
+			cf  repoCommitFields
+			rl  rateLimitFields
+			err error
+		)
+		vars := map[string]interface{}{
+			"commitsCursor": cursor,
+			"since":         since,
+			"authorFilter":  authorFilter,
+		}
+		if c.login == "" {
+			var q struct {
+				Viewer    repoCommitFields
+				RateLimit rateLimitFields
+			}
+			err = c.gql.Query(ctx, &q, vars)
+			cf, rl = q.Viewer, q.RateLimit
+		} else {
+			var q struct {
+				User      repoCommitFields `graphql:"user(login: $login)"`
+				RateLimit rateLimitFields
+			}
+			vars["login"] = githubv4.String(c.login)
+			err = c.gql.Query(ctx, &q, vars)
+			cf, rl = q.User, q.RateLimit
+		}
+		if err != nil {
+			return repoCommitFields{}, rateLimitFields{}, err
+		}
+		acc.Repositories.Nodes = append(acc.Repositories.Nodes, cf.Repositories.Nodes...)
+		lastRL = rl
+		totalCost += int(rl.Cost)
+		if !bool(cf.Repositories.PageInfo.HasNextPage) {
+			break
+		}
+		next := cf.Repositories.PageInfo.EndCursor
+		cursor = &next
+	}
+	lastRL.Cost = githubv4.Int(totalCost)
+	return acc, lastRL, nil
+}
+
 // maxRepoPages bounds repositories pagination. Pages are sequential
 // (each needs the previous page's endCursor), so the page count
 // multiplies the dashboard-fetch wall-clock against the 30s timeout in
@@ -1061,6 +1178,9 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		errRR            error
 		gists            []Gist
 		gistsTotal       int
+		repoCommits      repoCommitFields
+		rlH              rateLimitFields
+		commitsApplied   bool
 	)
 
 	watchRefs := c.WatchRepos()
@@ -1070,6 +1190,10 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 	// is inherently personal — there's no point asking GitHub
 	// for someone else's inbox.
 	wantReviewRequests := c.authenticated && c.login == ""
+	// The commit-count column (#70) is opt-in (config commit_counts) and
+	// needs a viewer to attribute commits to, so it is skipped outright
+	// for an unauthenticated client rather than counted for nobody.
+	wantCommits := c.commitCounts && c.authenticated
 
 	var wg sync.WaitGroup
 	wg.Add(4) // profile, repos, repo CI, gists
@@ -1077,6 +1201,9 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		wg.Add(1)
 	}
 	if wantReviewRequests {
+		wg.Add(1)
+	}
+	if wantCommits {
 		wg.Add(1)
 	}
 
@@ -1163,6 +1290,31 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		}()
 	}
 
+	// Seventh parallel branch — per-repo commit counts (#70), opt-in.
+	// **Best-effort by construction**, like gists: it is the one branch
+	// that legitimately runs close to GitHub's 10-second gateway limit
+	// on a large account, and a timeout there must cost the user the
+	// column for one refresh, never the dashboard. Its rate-limit
+	// envelope is still folded in, because the points are real either
+	// way. CommitsLastYearApplied tells the UI whether the numbers in
+	// Repo.CommitsLastYear are counts or placeholders.
+	if wantCommits {
+		go func() {
+			defer wg.Done()
+			viewerID, hasAuthor, err := c.ensureViewerID(ctx)
+			if err != nil || !hasAuthor {
+				return
+			}
+			rc, rl, err := c.fetchRepoCommitFieldsPaged(ctx, viewerID)
+			rlH = rl
+			if err != nil {
+				return
+			}
+			repoCommits = rc
+			commitsApplied = true
+		}()
+	}
+
 	wg.Wait()
 
 	// Surface the first error — all three queries serve the same
@@ -1182,8 +1334,9 @@ func (c *Client) FetchStats(ctx context.Context) (*Stats, error) {
 		return nil, errRR
 	}
 
-	stats := c.extractStats(profile, repos, repoCI)
-	stats.RateLimit = mergeRateLimit3(rlP, rlR, rlC)
+	stats := c.extractStats(profile, repos, repoCI, repoCommits)
+	stats.CommitsLastYearApplied = commitsApplied
+	stats.RateLimit = mergeRateLimitAll(rlP, rlR, rlC, rlH)
 	stats.WatchedRepos = watched
 	stats.WatchedSkipped = watchedSkipped
 	stats.ReviewRequests = reviewRequests
@@ -1230,15 +1383,22 @@ func mergeRateLimit(a, b rateLimitFields) *RateLimit {
 // non-zero-Limit envelope rather than the smallest
 // Remaining one.
 func mergeRateLimit3(a, b, c rateLimitFields) *RateLimit {
-	cost := int(a.Cost) + int(b.Cost) + int(c.Cost)
+	return mergeRateLimitAll(a, b, c)
+}
 
-	// pick is the most pessimistic envelope seen so far. nil
-	// means we haven't seen any valid one yet (Limit==0 on all
-	// three is an "every query returned an empty rateLimit"
-	// state — rare but possible on heavily-cached responses).
+// mergeRateLimitAll is the N-way generalisation introduced with the
+// seventh dashboard branch (#70): cost sums across every envelope, and
+// Limit / Remaining / ResetAt come from the most pessimistic envelope
+// that actually carries a Limit. Envelopes with Limit==0 are skipped
+// — a branch that was gated off, or a query that returned an empty
+// rateLimit — so an unused branch can pass its zero value and never
+// drag Remaining down to 0.
+func mergeRateLimitAll(envs ...rateLimitFields) *RateLimit {
+	cost := 0
 	var pick *rateLimitFields
-	for _, cand := range []rateLimitFields{a, b, c} {
-		cand := cand
+	for i := range envs {
+		cand := envs[i]
+		cost += int(cand.Cost)
 		if int(cand.Limit) == 0 {
 			continue
 		}
@@ -1246,7 +1406,6 @@ func mergeRateLimit3(a, b, c rateLimitFields) *RateLimit {
 			pick = &cand
 		}
 	}
-
 	out := &RateLimit{Cost: cost}
 	if pick != nil {
 		out.Limit = int(pick.Limit)
@@ -1377,7 +1536,7 @@ func MissingScopes(err error) []string {
 // flags. Lives downstream of FetchStats's parallel goroutines so
 // the data merge happens in one place rather than scattered
 // across the call sites.
-func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *Stats {
+func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields, commits repoCommitFields) *Stats {
 	// Build two lookups from the repoCIFields payload — one
 	// for the CI rollup state (v0.13.0), one for the latest
 	// release header (v0.14.0). Both keyed on the canonical
@@ -1390,6 +1549,15 @@ func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *S
 		publishedAt time.Time
 	}
 	releaseByNameWithOwner := make(map[string]releaseSummary, len(ci.Repositories.Nodes))
+	// Third lookup, same key, from the opt-in commit-count branch (#70).
+	// Empty when the branch did not run; the UI reads
+	// Stats.CommitsLastYearApplied rather than inferring from zeros.
+	commitsByNameWithOwner := make(map[string]int, len(commits.Repositories.Nodes))
+	for _, n := range commits.Repositories.Nodes {
+		if key := string(n.NameWithOwner); key != "" {
+			commitsByNameWithOwner[key] = int(n.DefaultBranchRef.Target.Commit.AuthoredYear.TotalCount)
+		}
+	}
 	for _, n := range ci.Repositories.Nodes {
 		key := string(n.NameWithOwner)
 		if key == "" {
@@ -1525,6 +1693,7 @@ func (c *Client) extractStats(p profileFields, r repoFields, ci repoCIFields) *S
 			CIState:                  Sanitize(ciByNameWithOwner[key]),
 			LatestReleaseTag:         Sanitize(rel.tag),
 			LatestReleasePublishedAt: rel.publishedAt,
+			CommitsLastYear:          commitsByNameWithOwner[key],
 		})
 
 		for _, e := range repo.Languages.Edges {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -999,7 +999,13 @@ func (c *Client) fetchRepoCommitFieldsPaged(ctx context.Context, viewerID github
 			cf, rl = q.User, q.RateLimit
 		}
 		if err != nil {
-			return repoCommitFields{}, rateLimitFields{}, err
+			// Unlike the mandatory walks, a failure here does not abort
+			// the dashboard — so the pages that already succeeded were
+			// already charged, and their cost has to reach the footer.
+			// Return the accumulated envelope with the error rather than
+			// a zero one; the caller folds it in either way.
+			lastRL.Cost = githubv4.Int(totalCost)
+			return repoCommitFields{}, lastRL, err
 		}
 		acc.Repositories.Nodes = append(acc.Repositories.Nodes, cf.Repositories.Nodes...)
 		lastRL = rl

--- a/internal/github/commit_counts_fetch_test.go
+++ b/internal/github/commit_counts_fetch_test.go
@@ -1,0 +1,95 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// commitRoutes wraps statsRoutes with the two queries the commit-count
+// branch (#70) adds: the viewer-id lookup ensureViewerID runs first, and
+// the paged commit query. pageTwoFails makes the second page 500 so the
+// best-effort branch degrades; the first page always succeeds and is
+// charged cost 2, which is what the rate-limit assertion is about.
+func commitRoutes(pageTwoFails bool) func(string) (int, string) {
+	base := statsRoutes(false)
+	calls := 0
+	return func(q string) (int, string) {
+		switch {
+		case strings.Contains(q, "viewer{id}"), strings.Contains(q, "viewer { id }"):
+			return 200, `{"data":{"viewer":{"id":"MDQ6VXNlcjE="}}}`
+		case strings.Contains(q, "$commitsCursor"):
+			calls++
+			if calls == 1 {
+				return 200, `{"data":{"viewer":{"repositories":{"nodes":[{"nameWithOwner":"octocat/proj","defaultBranchRef":{"target":{"authoredYear":{"totalCount":7}}}}],"pageInfo":{"hasNextPage":true,"endCursor":"c1"}}},"rateLimit":{"limit":5000,"remaining":4980,"cost":2,"resetAt":"2026-06-01T00:00:00Z"}}}`
+			}
+			if pageTwoFails {
+				return 500, `{"errors":[{"message":"boom"}]}`
+			}
+			return 200, `{"data":{"viewer":{"repositories":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"limit":5000,"remaining":4978,"cost":2,"resetAt":"2026-06-01T00:00:00Z"}}}`
+		}
+		return base(q)
+	}
+}
+
+func TestFetchStatsCommitCountsMergeAndApply(t *testing.T) {
+	c := newRoutingGQLClient(t, commitRoutes(false))
+	c.commitCounts = true
+
+	stats, err := c.FetchStats(context.Background())
+	if err != nil {
+		t.Fatalf("FetchStats: %v", err)
+	}
+	if !stats.CommitsLastYearApplied {
+		t.Fatal("both pages succeeded — CommitsLastYearApplied should be true")
+	}
+	if got := stats.Repositories[0].CommitsLastYear; got != 7 {
+		t.Errorf("octocat/proj CommitsLastYear = %d, want 7 (merged by NameWithOwner)", got)
+	}
+	if stats.RateLimit.Cost != 4 {
+		t.Errorf("cost = %d, want 4 (two commit pages at 2 each; the other branches report no cost)", stats.RateLimit.Cost)
+	}
+}
+
+// TestFetchStatsCommitCountsDegradeKeepsCost pins the Codex finding on
+// PR #154: when page two fails, page one was still charged, and its
+// cost must reach the footer even though the branch delivered nothing.
+func TestFetchStatsCommitCountsDegradeKeepsCost(t *testing.T) {
+	c := newRoutingGQLClient(t, commitRoutes(true))
+	c.commitCounts = true
+
+	stats, err := c.FetchStats(context.Background())
+	if err != nil {
+		t.Fatalf("a best-effort branch failure must not fail FetchStats, got %v", err)
+	}
+	if stats.CommitsLastYearApplied {
+		t.Error("page two failed — CommitsLastYearApplied must be false")
+	}
+	if got := stats.Repositories[0].CommitsLastYear; got != 0 {
+		t.Errorf("partial pages must not leak counts: got %d", got)
+	}
+	if stats.RateLimit.Cost != 2 {
+		t.Errorf("cost = %d, want 2 — the successful first page was charged and must be reported", stats.RateLimit.Cost)
+	}
+}
+
+// And the gate: with no viewer to attribute commits to, the branch never
+// runs at all — no query, no cost, no column.
+func TestFetchStatsCommitCountsSkippedUnauthenticated(t *testing.T) {
+	c := newRoutingGQLClient(t, func(q string) (int, string) {
+		if strings.Contains(q, "$commitsCursor") {
+			return 500, `{"errors":[{"message":"the commit branch must not run unauthenticated"}]}`
+		}
+		return statsRoutes(false)(q)
+	})
+	c.commitCounts = true
+	c.authenticated = false
+
+	stats, err := c.FetchStats(context.Background())
+	if err != nil {
+		t.Fatalf("FetchStats: %v", err)
+	}
+	if stats.CommitsLastYearApplied {
+		t.Error("unauthenticated: the branch is gated off, Applied must be false")
+	}
+}

--- a/internal/github/commit_counts_fetch_test.go
+++ b/internal/github/commit_counts_fetch_test.go
@@ -10,17 +10,24 @@ import (
 // branch (#70) adds: the viewer-id lookup ensureViewerID runs first, and
 // the paged commit query. pageTwoFails makes the second page 500 so the
 // best-effort branch degrades; the first page always succeeds and is
-// charged cost 2, which is what the rate-limit assertion is about.
-func commitRoutes(pageTwoFails bool) func(string) (int, string) {
+// charged cost 2.
+//
+// The returned counter is how many times the commit query was served.
+// The cost assertions below are only meaningful together with it: the
+// base routes report no cost at all, so a cost of 2 or 4 can come from
+// nowhere but these pages — but that is a property of the fixture, and
+// the counter is what pins the branch to having actually run (Codex,
+// PR #154, second pass).
+func commitRoutes(pageTwoFails bool) (func(string) (int, string), *int) {
 	base := statsRoutes(false)
-	calls := 0
+	calls := new(int)
 	return func(q string) (int, string) {
 		switch {
 		case strings.Contains(q, "viewer{id}"), strings.Contains(q, "viewer { id }"):
 			return 200, `{"data":{"viewer":{"id":"MDQ6VXNlcjE="}}}`
 		case strings.Contains(q, "$commitsCursor"):
-			calls++
-			if calls == 1 {
+			*calls++
+			if *calls == 1 {
 				return 200, `{"data":{"viewer":{"repositories":{"nodes":[{"nameWithOwner":"octocat/proj","defaultBranchRef":{"target":{"authoredYear":{"totalCount":7}}}}],"pageInfo":{"hasNextPage":true,"endCursor":"c1"}}},"rateLimit":{"limit":5000,"remaining":4980,"cost":2,"resetAt":"2026-06-01T00:00:00Z"}}}`
 			}
 			if pageTwoFails {
@@ -29,11 +36,12 @@ func commitRoutes(pageTwoFails bool) func(string) (int, string) {
 			return 200, `{"data":{"viewer":{"repositories":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"limit":5000,"remaining":4978,"cost":2,"resetAt":"2026-06-01T00:00:00Z"}}}`
 		}
 		return base(q)
-	}
+	}, calls
 }
 
 func TestFetchStatsCommitCountsMergeAndApply(t *testing.T) {
-	c := newRoutingGQLClient(t, commitRoutes(false))
+	routes, calls := commitRoutes(false)
+	c := newRoutingGQLClient(t, routes)
 	c.commitCounts = true
 
 	stats, err := c.FetchStats(context.Background())
@@ -46,6 +54,9 @@ func TestFetchStatsCommitCountsMergeAndApply(t *testing.T) {
 	if got := stats.Repositories[0].CommitsLastYear; got != 7 {
 		t.Errorf("octocat/proj CommitsLastYear = %d, want 7 (merged by NameWithOwner)", got)
 	}
+	if *calls != 2 {
+		t.Errorf("commit query served %d times, want 2 (one page with hasNextPage, one without)", *calls)
+	}
 	if stats.RateLimit.Cost != 4 {
 		t.Errorf("cost = %d, want 4 (two commit pages at 2 each; the other branches report no cost)", stats.RateLimit.Cost)
 	}
@@ -55,7 +66,8 @@ func TestFetchStatsCommitCountsMergeAndApply(t *testing.T) {
 // PR #154: when page two fails, page one was still charged, and its
 // cost must reach the footer even though the branch delivered nothing.
 func TestFetchStatsCommitCountsDegradeKeepsCost(t *testing.T) {
-	c := newRoutingGQLClient(t, commitRoutes(true))
+	routes, calls := commitRoutes(true)
+	c := newRoutingGQLClient(t, routes)
 	c.commitCounts = true
 
 	stats, err := c.FetchStats(context.Background())
@@ -68,6 +80,9 @@ func TestFetchStatsCommitCountsDegradeKeepsCost(t *testing.T) {
 	if got := stats.Repositories[0].CommitsLastYear; got != 0 {
 		t.Errorf("partial pages must not leak counts: got %d", got)
 	}
+	if *calls != 2 {
+		t.Errorf("commit query served %d times, want 2 (page one ok, page two 500)", *calls)
+	}
 	if stats.RateLimit.Cost != 2 {
 		t.Errorf("cost = %d, want 2 — the successful first page was charged and must be reported", stats.RateLimit.Cost)
 	}
@@ -76,8 +91,10 @@ func TestFetchStatsCommitCountsDegradeKeepsCost(t *testing.T) {
 // And the gate: with no viewer to attribute commits to, the branch never
 // runs at all — no query, no cost, no column.
 func TestFetchStatsCommitCountsSkippedUnauthenticated(t *testing.T) {
+	commitCalls := 0
 	c := newRoutingGQLClient(t, func(q string) (int, string) {
 		if strings.Contains(q, "$commitsCursor") {
+			commitCalls++
 			return 500, `{"errors":[{"message":"the commit branch must not run unauthenticated"}]}`
 		}
 		return statsRoutes(false)(q)
@@ -91,5 +108,10 @@ func TestFetchStatsCommitCountsSkippedUnauthenticated(t *testing.T) {
 	}
 	if stats.CommitsLastYearApplied {
 		t.Error("unauthenticated: the branch is gated off, Applied must be false")
+	}
+	// Applied=false alone would also be true of a branch that ran and
+	// failed. The counter is the assertion: no viewer, no query.
+	if commitCalls != 0 {
+		t.Errorf("commit query served %d times unauthenticated, want 0", commitCalls)
 	}
 }

--- a/internal/github/commit_counts_test.go
+++ b/internal/github/commit_counts_test.go
@@ -1,0 +1,140 @@
+package github
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// The commit-count branch (#70) is opt-in, best-effort and keyed by
+// NameWithOwner like the CI branch. These tests pin the three things a
+// refactor could quietly break: the merge, the rate-limit fold and the
+// query's shape.
+
+func TestExtractStatsMergesCommitCountsByNameWithOwner(t *testing.T) {
+	var r repoFields
+	for _, nwo := range []string{"alice/alpha", "alice/beta"} {
+		var n struct {
+			Name            githubv4.String
+			NameWithOwner   githubv4.String
+			URL             githubv4.String `graphql:"url"`
+			IsPrivate       githubv4.Boolean
+			PushedAt        githubv4.DateTime
+			PrimaryLanguage struct {
+				Name  githubv4.String
+				Color githubv4.String
+			}
+			StargazerCount githubv4.Int
+			ForkCount      githubv4.Int
+			Issues         struct {
+				TotalCount githubv4.Int
+			} `graphql:"issues(states: OPEN)"`
+			PullRequests struct {
+				TotalCount githubv4.Int
+			} `graphql:"pullRequests(states: OPEN)"`
+			Languages struct {
+				Edges []struct {
+					Size githubv4.Int
+					Node struct {
+						Name  githubv4.String
+						Color githubv4.String
+					}
+				}
+			} `graphql:"languages(first: 10, orderBy: {field: SIZE, direction: DESC})"`
+		}
+		n.Name = githubv4.String(strings.SplitN(nwo, "/", 2)[1])
+		n.NameWithOwner = githubv4.String(nwo)
+		r.Repositories.Nodes = append(r.Repositories.Nodes, n)
+	}
+
+	var c repoCommitFields
+	var cn struct {
+		NameWithOwner    githubv4.String
+		DefaultBranchRef struct {
+			Target struct {
+				Commit struct {
+					AuthoredYear struct {
+						TotalCount githubv4.Int
+					} `graphql:"authoredYear: history(since: $since, author: $authorFilter)"`
+				} `graphql:"... on Commit"`
+			}
+		}
+	}
+	cn.NameWithOwner = "alice/alpha"
+	cn.DefaultBranchRef.Target.Commit.AuthoredYear.TotalCount = 42
+	c.Repositories.Nodes = append(c.Repositories.Nodes, cn)
+
+	stats := (&Client{}).extractStats(profileFields{}, r, repoCIFields{}, c)
+	if len(stats.Repositories) != 2 {
+		t.Fatalf("repos = %d, want 2", len(stats.Repositories))
+	}
+	byName := map[string]int{}
+	for _, repo := range stats.Repositories {
+		byName[repo.Name] = repo.CommitsLastYear
+	}
+	if byName["alpha"] != 42 {
+		t.Errorf("alpha CommitsLastYear = %d, want 42 (merged by NameWithOwner)", byName["alpha"])
+	}
+	if byName["beta"] != 0 {
+		t.Errorf("beta CommitsLastYear = %d, want 0 (absent from the commit branch)", byName["beta"])
+	}
+	if stats.CommitsLastYearApplied {
+		t.Error("extractStats must not set CommitsLastYearApplied — only FetchStats knows whether the branch ran")
+	}
+}
+
+func TestMergeRateLimitAllIgnoresUnusedBranches(t *testing.T) {
+	// A gated-off branch contributes its zero value. It must neither
+	// drag Remaining to 0 nor be counted as the pessimistic envelope.
+	got := mergeRateLimitAll(envelope(5000, 4800, 1), envelope(5000, 4500, 2), rateLimitFields{}, envelope(5000, 4700, 3))
+	if got.Remaining != 4500 || got.Limit != 5000 {
+		t.Errorf("remaining/limit = %d/%d, want 4500/5000", got.Remaining, got.Limit)
+	}
+	if got.Cost != 6 {
+		t.Errorf("cost = %d, want 6 (sums across every envelope)", got.Cost)
+	}
+	if all := mergeRateLimitAll(); all.Cost != 0 || all.Limit != 0 {
+		t.Errorf("no envelopes: %+v, want zero RateLimit", all)
+	}
+	// The 3-way helper is now a thin wrapper; its table test elsewhere
+	// keeps passing, and this pins that it really delegates.
+	a, b, c := envelope(5000, 4900, 3), envelope(5000, 4800, 5), envelope(5000, 4950, 2)
+	if x, y := mergeRateLimit3(a, b, c), mergeRateLimitAll(a, b, c); *x != *y {
+		t.Errorf("mergeRateLimit3 diverged from mergeRateLimitAll: %+v vs %+v", *x, *y)
+	}
+}
+
+// TestRepoCommitQueryShape pins the parts of the query that were chosen
+// by measurement rather than taste: it pages at 50 (a 100-repo page sat
+// at 44–62 % of GitHub's 10-second limit on a 91-repo account), it
+// carries its own cursor variable, and the history field is filtered by
+// $since and $authorFilter. A drive-by "make it 100 like the others"
+// would fail here, with the reason in the tag.
+func TestRepoCommitQueryShape(t *testing.T) {
+	f, ok := reflect.TypeOf(repoCommitFields{}).FieldByName("Repositories")
+	if !ok {
+		t.Fatal("repoCommitFields.Repositories missing")
+	}
+	tag := f.Tag.Get("graphql")
+	for _, want := range []string{"first: 50", "after: $commitsCursor", "ownerAffiliations: OWNER", "isFork: false"} {
+		if !strings.Contains(tag, want) {
+			t.Errorf("repositories tag %q lacks %q", tag, want)
+		}
+	}
+	nodes := f.Type.Field(0)
+	if nodes.Name != "Nodes" {
+		t.Fatalf("first field = %s, want Nodes", nodes.Name)
+	}
+	commit, _ := nodes.Type.Elem().FieldByName("DefaultBranchRef")
+	target, _ := commit.Type.FieldByName("Target")
+	commitT, _ := target.Type.FieldByName("Commit")
+	year, _ := commitT.Type.FieldByName("AuthoredYear")
+	if got := year.Tag.Get("graphql"); !strings.Contains(got, "since: $since") || !strings.Contains(got, "author: $authorFilter") {
+		t.Errorf("authoredYear tag %q must filter by $since and $authorFilter", got)
+	}
+	if maxRepoCommitPages != 2*maxRepoPages {
+		t.Errorf("maxRepoCommitPages = %d, want 2×maxRepoPages so both walks cover the same 500 repos", maxRepoCommitPages)
+	}
+}

--- a/internal/github/sponsors_test.go
+++ b/internal/github/sponsors_test.go
@@ -181,12 +181,12 @@ func TestIncomeIsReadOnlyForTheViewer(t *testing.T) {
 	p.Login = "octocat"
 	p.MonthlySponsorsIncomeCents = 2500
 
-	viewer := (&Client{login: ""}).extractStats(p, repoFields{}, repoCIFields{})
+	viewer := (&Client{login: ""}).extractStats(p, repoFields{}, repoCIFields{}, repoCommitFields{})
 	if viewer.MonthlySponsorsIncomeCents != 2500 {
 		t.Errorf("viewer income = %d, want 2500", viewer.MonthlySponsorsIncomeCents)
 	}
 
-	other := (&Client{login: "someone-else"}).extractStats(p, repoFields{}, repoCIFields{})
+	other := (&Client{login: "someone-else"}).extractStats(p, repoFields{}, repoCIFields{}, repoCommitFields{})
 	if other.MonthlySponsorsIncomeCents != 0 {
 		t.Errorf("income = %d for another account — GitHub answers 0 there, so any "+
 			"non-zero value could only come from reading it where it means nothing",

--- a/internal/report/commit_counts_test.go
+++ b/internal/report/commit_counts_test.go
@@ -1,0 +1,46 @@
+package report
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// TestCommitsLastYearInReport pins #70's JSON contract: the field is
+// present (even at 0) when the branch ran, absent when it did not, and
+// never attached to watched repos, which the branch does not cover.
+func TestCommitsLastYearInReport(t *testing.T) {
+	s := &github.Stats{
+		Login:                  "alice",
+		CommitsLastYearApplied: true,
+		Repositories: []github.Repo{
+			{Name: "alpha", URL: "https://github.com/alice/alpha", CommitsLastYear: 12},
+			{Name: "beta", URL: "https://github.com/alice/beta", CommitsLastYear: 0},
+		},
+		WatchedRepos: []github.Repo{{Name: "tea", URL: "https://github.com/charm/tea", CommitsLastYear: 99}},
+	}
+	r := FromStats(s, "0.32.0", time.Unix(0, 0).UTC(), false)
+	if r.Repositories[0].CommitsLastYear == nil || *r.Repositories[0].CommitsLastYear != 12 {
+		t.Fatalf("alpha commits_last_year = %v, want 12", r.Repositories[0].CommitsLastYear)
+	}
+	if r.Repositories[1].CommitsLastYear == nil || *r.Repositories[1].CommitsLastYear != 0 {
+		t.Errorf("beta commits_last_year = %v, want an explicit 0 when applied", r.Repositories[1].CommitsLastYear)
+	}
+	if r.WatchedRepos[0].CommitsLastYear != nil {
+		t.Errorf("watched repo carries commits_last_year = %v; the branch never counts watched repos", *r.WatchedRepos[0].CommitsLastYear)
+	}
+	b, _ := json.Marshal(r.Repositories[1])
+	if !strings.Contains(string(b), `"commits_last_year":0`) {
+		t.Errorf("applied zero must serialise explicitly: %s", b)
+	}
+
+	s.CommitsLastYearApplied = false
+	r = FromStats(s, "0.32.0", time.Unix(0, 0).UTC(), false)
+	b, _ = json.Marshal(r.Repositories[0])
+	if strings.Contains(string(b), "commits_last_year") {
+		t.Errorf("not applied: field must be omitted entirely: %s", b)
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -155,6 +155,10 @@ type Repo struct {
 	Private       bool         `json:"private"`
 	CIState       string       `json:"ci_state,omitempty"`
 	LatestRelease *ReleaseInfo `json:"latest_release,omitempty"`
+	// CommitsLastYear is present only when the opt-in commit_counts
+	// branch ran (#70): a pointer, so "0 commits" and "not fetched" stay
+	// distinguishable in the JSON rather than both reading as 0.
+	CommitsLastYear *int `json:"commits_last_year,omitempty"`
 }
 
 // ReleaseInfo is the most recent release on a repo. Nil when the repo has
@@ -245,7 +249,7 @@ func FromStats(s *github.Stats, octoscopeVersion string, generatedAt time.Time, 
 			OpenPRs:       s.OpenPRs,
 		},
 		Languages:        toLanguages(s.Languages),
-		Repositories:     toRepos(s.Repositories),
+		Repositories:     toRepos(s.Repositories, s.CommitsLastYearApplied),
 		OpenPullRequests: toPRs(s.OpenPullRequests),
 		OpenIssuesList:   toIssues(s.OpenIssuesList),
 		ReviewRequests:   toPRs(s.ReviewRequests),
@@ -258,7 +262,7 @@ func FromStats(s *github.Stats, octoscopeVersion string, generatedAt time.Time, 
 		SponsoringTotal:            s.SponsoringTotal,
 		HasSponsorsListing:         s.HasSponsorsListing,
 		MonthlySponsorsIncomeCents: s.MonthlySponsorsIncomeCents,
-		WatchedRepos:               toRepos(s.WatchedRepos),
+		WatchedRepos:               toRepos(s.WatchedRepos, false),
 		WatchedSkipped:             nonNilStrings(s.WatchedSkipped),
 	}
 	if s.RateLimit != nil {
@@ -288,7 +292,7 @@ func toLanguages(in []github.Language) []Language {
 	return out
 }
 
-func toRepos(in []github.Repo) []Repo {
+func toRepos(in []github.Repo, commitsApplied bool) []Repo {
 	out := make([]Repo, 0, len(in))
 	for _, r := range in {
 		repo := Repo{
@@ -308,6 +312,10 @@ func toRepos(in []github.Repo) []Repo {
 				Tag:         r.LatestReleaseTag,
 				PublishedAt: r.LatestReleasePublishedAt,
 			}
+		}
+		if commitsApplied {
+			n := r.CommitsLastYear
+			repo.CommitsLastYear = &n
 		}
 		out = append(out, repo)
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -87,6 +87,12 @@ func TestFromStatsMapping(t *testing.T) {
 	if r.Repositories[0].LatestRelease == nil || r.Repositories[0].LatestRelease.Tag != "v0.23.0" {
 		t.Errorf("repo[0].latest_release = %+v", r.Repositories[0].LatestRelease)
 	}
+	// commits_last_year is a pointer that exists only when the opt-in
+	// branch ran (#70): absent here because the fixture never set
+	// CommitsLastYearApplied, so 0 and "not fetched" stay distinct.
+	if r.Repositories[0].CommitsLastYear != nil {
+		t.Errorf("repo[0].commits_last_year = %v, want absent when not applied", *r.Repositories[0].CommitsLastYear)
+	}
 	if r.Repositories[1].LatestRelease != nil {
 		t.Errorf("repo[1] with no release must have nil latest_release")
 	}

--- a/internal/ui/commit_counts_test.go
+++ b/internal/ui/commit_counts_test.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// The commits column (#70) is opt-in, and present only when the branch
+// delivered. Three surfaces have to agree about that: the s cycle, the
+// sort actually applied, and the table. Each is pinned here.
+
+func TestNextSortSkipsCommitsUnlessConfigured(t *testing.T) {
+	off := ReposModel{sort: ReposSortRelease}
+	if got := off.nextSort(); got != ReposSortPushed {
+		t.Errorf("off: after release want pushed (commits skipped), got %v", got)
+	}
+	on := ReposModel{sort: ReposSortRelease, commitCounts: true}
+	if got := on.nextSort(); got != ReposSortCommits {
+		t.Errorf("on: after release want commits, got %v", got)
+	}
+	if got := (ReposModel{sort: ReposSortCommits, commitCounts: true}).nextSort(); got != ReposSortPushed {
+		t.Errorf("on: after commits want pushed (wraps), got %v", got)
+	}
+	// Every mode is reachable when on, and commits is never reached when off.
+	seen := map[ReposSort]bool{}
+	m := ReposModel{commitCounts: false}
+	for i := 0; i < len(reposSortLabels)*2; i++ {
+		m.sort = m.nextSort()
+		seen[m.sort] = true
+	}
+	if seen[ReposSortCommits] {
+		t.Error("off: the cycle reached commits")
+	}
+	if len(seen) != len(reposSortLabels)-1 {
+		t.Errorf("off: cycle visits %d modes, want %d", len(seen), len(reposSortLabels)-1)
+	}
+}
+
+func TestEffectiveSortFallsBackWhenCountsMissing(t *testing.T) {
+	rm := ReposModel{sort: ReposSortCommits, commitCounts: true}
+	if got := rm.effectiveSort(false); got != ReposSortPushed {
+		t.Errorf("not applied: want pushed, got %v", got)
+	}
+	if got := rm.effectiveSort(true); got != ReposSortCommits {
+		t.Errorf("applied: want commits, got %v", got)
+	}
+	if got := (ReposModel{sort: ReposSortStars}).effectiveSort(false); got != ReposSortStars {
+		t.Errorf("other modes must pass through, got %v", got)
+	}
+}
+
+func TestSortReposByCommits(t *testing.T) {
+	a := mkRepo("alice", "alpha", 1)
+	a.CommitsLastYear = 3
+	b := mkRepo("alice", "beta", 1)
+	b.CommitsLastYear = 30
+	c := mkRepo("alice", "gamma", 1)
+	c.CommitsLastYear = 3
+	got := sortRepos([]github.Repo{a, b, c}, ReposSortCommits)
+	want := []string{"beta", "alpha", "gamma"} // desc, then name
+	for i, w := range want {
+		if got[i].Name != w {
+			t.Fatalf("order = %v, want %v", repoNames(got), want)
+		}
+	}
+}
+
+func repoNames(rs []github.Repo) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func TestReposTableShowsCommitsOnlyWhenApplied(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+	r := mkRepo("alice", "alpha", 5)
+	r.CommitsLastYear = 1234
+
+	with := ansi.Strip(renderReposTable([]github.Repo{r}, 0, ReposSortPushed, 0, 0, true))
+	if !strings.Contains(with, "Commits") {
+		t.Errorf("showCommits=true: header lacks Commits:\n%s", with)
+	}
+	if !strings.Contains(with, formatCompact(1234)) {
+		t.Errorf("showCommits=true: row lacks the count %q:\n%s", formatCompact(1234), with)
+	}
+
+	without := ansi.Strip(renderReposTable([]github.Repo{r}, 0, ReposSortPushed, 0, 0, false))
+	if strings.Contains(without, "Commits") || strings.Contains(without, formatCompact(1234)) {
+		t.Errorf("showCommits=false: column or count leaked:\n%s", without)
+	}
+
+	// Header width must stay consistent between the two, minus the
+	// column: a stray separator would misalign every row under it.
+	wl, wol := strings.Split(with, "\n")[0], strings.Split(without, "\n")[0]
+	if len([]rune(wl))-len([]rune(wol)) != 7+2 { // commitsW + "  "
+		t.Errorf("header width delta = %d, want 9 (commitsW + separator)", len([]rune(wl))-len([]rune(wol)))
+	}
+}
+
+func TestReposHeaderChipReportsEffectiveSort(t *testing.T) {
+	_ = applyTheme("octoscope", "")
+	stats := &github.Stats{Repositories: []github.Repo{mkRepo("alice", "alpha", 1)}}
+	rm := ReposModel{sort: ReposSortCommits, commitCounts: true}
+
+	// Configured, but this refresh did not deliver: the chip must not
+	// claim "commits" while the rows are sorted by pushed.
+	out := ansi.Strip(rm.renderReposTab(stats, 120, 40, nil))
+	if strings.Contains(out, "commits ↓") {
+		t.Errorf("chip says commits while counts are not applied:\n%s", out)
+	}
+	if !strings.Contains(out, "pushed ↓") {
+		t.Errorf("chip should fall back to pushed:\n%s", out)
+	}
+
+	stats.CommitsLastYearApplied = true
+	out = ansi.Strip(rm.renderReposTab(stats, 120, 40, nil))
+	if !strings.Contains(out, "commits ↓") || !strings.Contains(out, "Commits") {
+		t.Errorf("applied: chip and column should both show commits:\n%s", out)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -479,6 +479,12 @@ type Options struct {
 	DefaultWorkFilter  string
 	DefaultStarHistory string
 
+	// CommitCounts mirrors config commit_counts (#70): the Repos tab's
+	// sort cycle offers "commits" only when set. The column itself
+	// appears per refresh, when Stats.CommitsLastYearApplied says the
+	// opt-in branch actually delivered.
+	CommitCounts bool
+
 	// PinnedRepos is the persisted list of "owner/name" identifiers
 	// that the Repos tab renders in a sticky section at the top.
 	// Already sanitised (see config.SanitizeRepoList) by the
@@ -560,7 +566,7 @@ func NewModel(client *github.Client, version string, opts Options) Model {
 		// (#35). A missing/empty key hits the maps' zero values —
 		// i.e. each tab's built-in default; main.go already rejected
 		// invalid non-empty values.
-		repos:           ReposModel{sort: reposSortKeys[opts.DefaultSort], work: workFilterKeys[opts.DefaultWorkFilter]},
+		repos:           ReposModel{sort: reposSortKeys[opts.DefaultSort], work: workFilterKeys[opts.DefaultWorkFilter], commitCounts: opts.CommitCounts},
 		prs:             PRsModel{sort: listSortKeys[opts.DefaultSort].prs},
 		issues:          IssuesModel{sort: listSortKeys[opts.DefaultSort].issues},
 		starModeDefault: starHistoryKeys[opts.DefaultStarHistory],

--- a/internal/ui/repos.go
+++ b/internal/ui/repos.go
@@ -26,6 +26,7 @@ const (
 	ReposSortName
 	ReposSortCI      // v0.13.0 — surface failing CI first
 	ReposSortRelease // v0.14.0 — most recent release first
+	ReposSortCommits // v0.32.0 — commits by you, last year (#70); only when the column is on
 )
 
 // reposSortLabels is the human-readable name for each sort mode,
@@ -37,6 +38,7 @@ var reposSortLabels = [...]string{
 	ReposSortName:    "name",
 	ReposSortCI:      "CI",
 	ReposSortRelease: "release",
+	ReposSortCommits: "commits",
 }
 
 // reposSortChevron is the arrow glyph drawn next to the sorted
@@ -50,6 +52,7 @@ var reposSortChevron = [...]string{
 	ReposSortName:    "↑",
 	ReposSortCI:      "↑",
 	ReposSortRelease: "↓",
+	ReposSortCommits: "↓",
 }
 
 // ReposModel is the Repos-tab sub-state: cursor position, sort mode,
@@ -62,6 +65,11 @@ type ReposModel struct {
 	query        string // case-insensitive substring match on repo name
 	searchActive bool   // true while the user is typing in the search box
 	work         WorkFilter
+	// commitCounts mirrors the config's commit_counts key (#70): the
+	// sort cycle offers "commits" only when the column is configured.
+	// Whether the numbers actually arrived this refresh is a separate
+	// question, answered per render by Stats.CommitsLastYearApplied.
+	commitCounts bool
 }
 
 // WorkFilter is the preset row filter cycled with `w` in the Repos
@@ -153,7 +161,8 @@ func (rm ReposModel) selectedRepo(stats *github.Stats, pinned []string) (github.
 	if stats == nil {
 		return github.Repo{}, false
 	}
-	rows, _, _, _ := visibleReposPartitioned(stats.Repositories, stats.WatchedRepos, rm.query, rm.work, rm.sort, pinned)
+	mode := rm.effectiveSort(stats.CommitsLastYearApplied)
+	rows, _, _, _ := visibleReposPartitioned(stats.Repositories, stats.WatchedRepos, rm.query, rm.work, mode, pinned)
 	if len(rows) == 0 {
 		return github.Repo{}, false
 	}
@@ -333,7 +342,8 @@ func (rm ReposModel) Update(msg tea.Msg, stats *github.Stats, pinned []string) (
 	// can never disagree on which repo lives at index N.
 	var rows []github.Repo
 	if stats != nil {
-		rows, _, _, _ = visibleReposPartitioned(stats.Repositories, stats.WatchedRepos, rm.query, rm.work, rm.sort, pinned)
+		mode := rm.effectiveSort(stats.CommitsLastYearApplied)
+		rows, _, _, _ = visibleReposPartitioned(stats.Repositories, stats.WatchedRepos, rm.query, rm.work, mode, pinned)
 	}
 	n := len(rows)
 
@@ -353,7 +363,7 @@ func (rm ReposModel) Update(msg tea.Msg, stats *github.Stats, pinned []string) (
 			rm.cursor = n - 1
 		}
 	case "s":
-		rm.sort = (rm.sort + 1) % ReposSort(len(reposSortLabels))
+		rm.sort = rm.nextSort()
 		rm.cursor = 0
 	case "/":
 		rm.searchActive = true
@@ -478,6 +488,30 @@ func filterRepos(repos []github.Repo, query string) []github.Repo {
 	return out
 }
 
+// nextSort advances the sort cycle, skipping the commits column when it
+// is not configured — a mode the user cannot see would otherwise sit in
+// the cycle as a dead press of s.
+func (rm ReposModel) nextSort() ReposSort {
+	n := ReposSort(len(reposSortLabels))
+	next := (rm.sort + 1) % n
+	if next == ReposSortCommits && !rm.commitCounts {
+		next = (next + 1) % n
+	}
+	return next
+}
+
+// effectiveSort is the sort actually applied this render. A commits
+// sort seeded from config (default_sort = "commits") or left over from
+// a refresh where the branch succeeded falls back to the default when
+// the counts did not arrive: sorting by numbers that are all zero would
+// silently reorder the list by name and call it "commits".
+func (rm ReposModel) effectiveSort(commitsApplied bool) ReposSort {
+	if rm.sort == ReposSortCommits && !commitsApplied {
+		return ReposSortPushed
+	}
+	return rm.sort
+}
+
 // sortRepos returns a fresh slice sorted according to `mode`. Never
 // mutates the input so the caller can keep rendering the original
 // order elsewhere if it ever wants to.
@@ -501,6 +535,10 @@ func sortRepos(repos []github.Repo, mode ReposSort) []github.Repo {
 			ar, br := ciSortRank(a.CIState), ciSortRank(b.CIState)
 			if ar != br {
 				return ar < br // failures (low rank) first
+			}
+		case ReposSortCommits:
+			if a.CommitsLastYear != b.CommitsLastYear {
+				return a.CommitsLastYear > b.CommitsLastYear
 			}
 		case ReposSortRelease:
 			// Repos with no release sort to the bottom (zero time
@@ -567,8 +605,13 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 	// and action menu — which both walk visibleReposPartitioned — keep
 	// operating on the now-invisible watched rows. That paint/cursor
 	// desync is the bug this ordering guards against.
+	// mode is the sort actually applied: "commits" only while this
+	// refresh delivered real counts, else the default. Every consumer
+	// below — partition, table, header label — reads this one value so
+	// the rows, the chevron and the "sort …" chip can never disagree.
+	mode := rm.effectiveSort(stats.CommitsLastYearApplied)
 	rows, pinCount, restCount, watchCount := visibleReposPartitioned(
-		stats.Repositories, stats.WatchedRepos, rm.query, rm.work, rm.sort, pinned,
+		stats.Repositories, stats.WatchedRepos, rm.query, rm.work, mode, pinned,
 	)
 	_ = restCount // currently only the divider positions need it
 
@@ -659,7 +702,7 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 	// present — otherwise it undercounts M (and could read "3 of 0"
 	// in the empty-owned case).
 	total := len(stats.Repositories) + len(stats.WatchedRepos)
-	headerLine := rm.renderHeaderLine(len(rows), total, offset, end)
+	headerLine := rm.renderHeaderLine(len(rows), total, offset, end, mode)
 
 	// Search-prompt or filter-indicator line sits between the header
 	// and the table so the eye picks it up without scanning.
@@ -678,7 +721,7 @@ func (rm ReposModel) renderReposTab(stats *github.Stats, available, availableHei
 	// owned (rest) row. Watched-repo section sits at the bottom.
 	watchStart := pinCount + restCount
 	_ = watchCount // count is implicit from len(rows) - watchStart
-	table := renderReposTable(rows[offset:end], cursor-offset, rm.sort, pinCount-offset, watchStart-offset)
+	table := renderReposTable(rows[offset:end], cursor-offset, mode, pinCount-offset, watchStart-offset, stats.CommitsLastYearApplied)
 
 	hint := keyHints(
 		"↑↓", "move",
@@ -727,13 +770,13 @@ func renderWatchedSkippedLine(skipped []string, available int) string {
 // a–b of N · s cycle" line. Shows both the filtered and total counts
 // when any filter (substring or work preset) is active so the user
 // knows how much they've narrowed down to.
-func (rm ReposModel) renderHeaderLine(visible, total, offset, end int) string {
+func (rm ReposModel) renderHeaderLine(visible, total, offset, end int, mode ReposSort) string {
 	countLabel := fmt.Sprintf("%d repositories", visible)
 	if (rm.query != "" || rm.work != WorkFilterNone) && visible != total {
 		countLabel = fmt.Sprintf("%d of %d repositories", visible, total)
 	}
 
-	sortLabel := reposSortLabels[rm.sort] + " " + reposSortChevron[rm.sort]
+	sortLabel := reposSortLabels[mode] + " " + reposSortChevron[mode]
 
 	parts := []string{
 		mutedStyle.Render(countLabel),
@@ -762,7 +805,7 @@ func (rm ReposModel) renderHeaderLine(visible, total, offset, end int) string {
 //
 // Order matters: pinDivider must be ≤ watchDivider; the
 // pinned segment always comes first.
-func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pinDivider, watchDivider int) string {
+func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pinDivider, watchDivider int, showCommits bool) string {
 	nameW := len("Name")
 	langW := len("Lang")
 	for _, r := range repos {
@@ -797,8 +840,12 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		forksW  = 6
 		issuesW = 6
 		prsW    = 5
-		pushedW = 10 // "Xd ago" / "Xw ago" / "Xmo ago"
-		cursorW = 2  // "▸ " / "  "
+		// commitsW fits the "Commits" header and a compact count
+		// ("1.2k"). The column exists only while showCommits is
+		// true — the opt-in branch ran and its numbers are real.
+		commitsW = 7
+		pushedW  = 10 // "Xd ago" / "Xw ago" / "Xmo ago"
+		cursorW  = 2  // "▸ " / "  "
 	)
 	// reposReleaseW (package-level, see below) is the width of
 	// the Release column; kept out of the local block so
@@ -841,9 +888,14 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		decorate("⑂", ReposSortForks, forksW, "right"),
 		mutedStyle.Render(padLeft("⚠", issuesW)),
 		mutedStyle.Render(padLeft("⎇", prsW)),
+	}
+	if showCommits {
+		headerCells = append(headerCells, decorate("Commits", ReposSortCommits, commitsW, "right"))
+	}
+	headerCells = append(headerCells,
 		decorate("Pushed", ReposSortPushed, pushedW, "left"),
 		decorate("Release", ReposSortRelease, releaseW, "left"),
-	}
+	)
 	header := strings.Join(headerCells, "  ")
 
 	rule := tabRuleStyle.Render(strings.Repeat("─", lipgloss.Width(header)))
@@ -892,6 +944,10 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		prs := padLeftStr(formatCompact(r.OpenPRs), prsW)
 		pushed := padRight(formatRelativeAgo(r.PushedAt), pushedW)
 		release := padRight(formatLatestRelease(r.LatestReleaseTag, r.LatestReleasePublishedAt), releaseW)
+		commits := ""
+		if showCommits {
+			commits = padLeftStr(formatCompact(r.CommitsLastYear), commitsW) + "  "
+		}
 
 		if !active {
 			// Dim non-selected secondary columns so the active row
@@ -902,6 +958,9 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 			prs = mutedStyle.Render(prs)
 			pushed = mutedStyle.Render(pushed)
 			release = mutedStyle.Render(release)
+			if showCommits {
+				commits = mutedStyle.Render(commits)
+			}
 		}
 
 		// Pad the dot to the full CI column width so the row
@@ -910,7 +969,7 @@ func renderReposTable(repos []github.Repo, cursorRow int, sortMode ReposSort, pi
 		// after the styled glyph rather than inside the escape.
 		ci := padRightRaw(ciDot(r.CIState), 2)
 
-		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+pushed+"  "+release)
+		out = append(out, marker+ci+"  "+name+"  "+lang+"  "+stars+"  "+forks+"  "+issues+"  "+prs+"  "+commits+pushed+"  "+release)
 
 		// Insert the section dividers exactly once each, after the last
 		// row of the pinned and rest segments. Reuses the single `rule`

--- a/internal/ui/viewprefs.go
+++ b/internal/ui/viewprefs.go
@@ -20,6 +20,7 @@ var reposSortKeys = map[string]ReposSort{
 	"name":    ReposSortName,
 	"ci":      ReposSortCI,
 	"release": ReposSortRelease,
+	"commits": ReposSortCommits, // #70; applied only while the column is on
 }
 
 // listSortKeys maps the sort keys shared by the PRs and Issues tabs

--- a/internal/ui/viewprefs_test.go
+++ b/internal/ui/viewprefs_test.go
@@ -11,7 +11,7 @@ import (
 // default_sort / default_work_filter / default_star_history — the
 // contract main.go validates against at startup.
 func TestViewPrefKeyValidation(t *testing.T) {
-	for _, k := range []string{"pushed", "stars", "forks", "name", "ci", "release", "updated", "repo", "number"} {
+	for _, k := range []string{"pushed", "stars", "forks", "name", "ci", "release", "commits", "updated", "repo", "number"} {
 		if !IsValidSortKey(k) {
 			t.Errorf("IsValidSortKey(%q) = false, want true", k)
 		}
@@ -37,7 +37,7 @@ func TestViewPrefKeyValidation(t *testing.T) {
 	}
 
 	// Key lists feed the startup error messages — sorted and complete.
-	wantSort := []string{"ci", "forks", "name", "number", "pushed", "release", "repo", "stars", "updated"}
+	wantSort := []string{"ci", "commits", "forks", "name", "number", "pushed", "release", "repo", "stars", "updated"}
 	if got := SortKeys(); !reflect.DeepEqual(got, wantSort) {
 		t.Errorf("SortKeys() = %v, want %v", got, wantSort)
 	}

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -70,7 +70,22 @@ var whatsNew031 = whatsNewEntry{
 	},
 }
 
+var whatsNew032 = whatsNewEntry{
+	headline: "A column that had to be measured before it could exist.",
+	items: []whatsNewItem{
+		{
+			title: "Commits by you, per repo, last year",
+			desc:  "Set commit_counts = true and the Repos tab gains a commits column with its own sort — which of your repositories you actually commit to most, in one ordering across the list. Off by default: it is the one column that costs a query of its own on every refresh.",
+		},
+		{
+			title: "Why it is opt-in, in numbers",
+			desc:  "Asked for inline on the list query, this field pushed it past GitHub's 10-second limit three times in five on a 91-repo account. In a query of its own it takes 4–6 seconds. So it runs alone, pages at 50, and if it ever times out you lose the column for one refresh, not the dashboard.",
+		},
+	},
+}
+
 var whatsNew = map[string]whatsNewEntry{
+	"0.32.0": whatsNew032,
 	// 0.31.1 shows 0.31.0's highlights, on the 0.30.1 precedent below.
 	// The tab renders only the running version, and this patch is a
 	// maintenance fix — the number the binary reported came from a

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 // showing up only in local builds. Measured before the change:
 // `go build -ldflags "-X main.version=9.9.9-fromtag"` still printed
 // 0.31.0.
-var version = "0.31.1"
+var version = "0.32.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI
@@ -127,7 +127,8 @@ func main() {
 	}
 
 	client, err := github.New(userLogin, github.Options{
-		PublicOnly: cfg.PublicOnly,
+		PublicOnly:   cfg.PublicOnly,
+		CommitCounts: cfg.CommitCounts,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "octoscope: %v\n", err)
@@ -160,6 +161,7 @@ func main() {
 		ShowSponsor:        cfg.ShowSponsor,
 		CheckForUpdates:    cfg.CheckForUpdates,
 		CheckServiceStatus: cfg.CheckServiceStatus,
+		CommitCounts:       cfg.CommitCounts,
 		NoColor:            noColor,
 	})
 	p := tea.NewProgram(model, tea.WithAltScreen())


### PR DESCRIPTION
Closes #70.

## The gate, finally run

#70 said *"never actually tried"* about the one test it was waiting on. Tried on 2026-09-06, on a 91-repo account, with the real `repoFields` query:

| query | result | time |
| --- | --- | --- |
| `repoFields` as shipped | 200 × 4 | 6.4–6.7 s |
| + `history { totalCount }` per repo | **502 × 3**, 200 × 2 | 8.2–10.9 s |
| the same field in a query of its own | 200 × 5 | 4.4–6.2 s |
| `rateLimit.cost`, every shape above | **1** | — |

The first run of the fatal shape passed at 9.8 s — a single green run near the clock proves nothing. Every 502 landed at 10.7–10.9 s: [GitHub's 10-second processing timeout](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#timeouts), which also docks the rate limit for the next hour. So the combined document is dead, and **the fallback the issue itself proposed is what ships.**

## What ships

`commit_counts = true` (config, off by default, hand-edit like the `check_*` keys) adds a **Commits** column to the Repos tab — commits you authored on each repo's default branch in the last 365 days — with a `commits` sort in the `s` cycle and in `default_sort`.

- **A seventh parallel branch**, `repoCommitFields`: the same `authoredYear` field the repo drill-in already uses, lifted to the list, paged at **50** — at 100 the standalone query sat at 44–62 % of the clock on this account.
- **Best-effort by construction**, like gists: a timeout costs the column for one refresh, never the dashboard. Its rate-limit envelope is still folded in; `mergeRateLimit3` now delegates to an N-way `mergeRateLimitAll` whose existing table test passes unchanged.
- **Needs a viewer to count for**: skipped outright when unauthenticated, so a public profile never shows a column of zeros.
- **`Stats.CommitsLastYearApplied`** is the one flag the UI reads. Column and sort exist only when this refresh delivered real counts; a `commits` sort left over from a refresh that succeeded — or seeded from config — falls back to `pushed`, and the header chip *says* pushed, because partition, table and chip now read one effective mode instead of `rm.sort` three times.
- **`--json`**: `commits_last_year` is a pointer — an explicit `0` when the branch ran, absent when it did not, never on watched repos.

## Verified

**Live**, against the maintainer's account: 91 repos, 64 with commits, **sum 6 529** — the `gh api` probe hours earlier measured 6 524 — in 6.7 s, `cost=5` for the whole dashboard fetch. The smoke test was deleted before committing, per the house rule.

**Eight mutations**, each restored by byte copy (not `git checkout`), each failing the test that names it:

| mutation | test that caught it |
| --- | --- |
| merge key dropped in `extractStats` | `TestExtractStatsMergesCommitCountsByNameWithOwner` |
| page size 50 → 100 | `TestRepoCommitQueryShape` |
| unused envelope no longer skipped | `TestMergeRateLimitAllIgnoresUnusedBranches` |
| report field attached unconditionally | `TestCommitsLastYearInReport` |
| `Save` stops emitting the key | `TestCommitCountsConfigRoundTrip` |
| `s` cycle stops skipping commits when off | `TestNextSortSkipsCommitsUnlessConfigured` |
| fallback to pushed removed | `TestEffectiveSortFallsBack…` + `…HeaderChipReportsEffectiveSort` |
| column rendered unconditionally | `TestReposTableShowsCommitsOnlyWhenApplied` |

The first commit is green on its own (checked in a separate worktree); the second is the 0.32.0 release prep, kept apart so the feature diff reads clean.

## Deliberately not done

- **No landing "At a glance" card.** The checklist reserves those for headline features; this is opt-in and costs a query per refresh, so it is documented in the README's Repos bullet, the guide's Settings and Tabs pages, and the What's new entry — not sold on the hero.
- **Hero screenshot** refresh is the post-merge, pre-tag step, as for every minor.
- **No settings-panel toggle**: `check_for_updates` and `check_service_status` are hand-edit only too, and a fetch-cost knob belongs with them.

## Also in this PR

The contributor guide's parallel-branch list goes from six to seven, with the measurement that decided the seventh's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vp71bMdQYQnnbYXnh9Ltv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Repos-tab column showing your commits from the past year.
  * Added commit-count sorting when the feature is enabled and data is available.
  * Added JSON report support for per-repository commit totals.

* **Documentation**
  * Documented the `commit_counts` setting, sorting option, query behavior, and version 0.32.0 updates.

* **Bug Fixes**
  * Commit sorting now falls back to pushed-date sorting when counts are unavailable.
  * Commit-count failures no longer prevent the dashboard from loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->