### PR TITLE
feat(scan): the dependency install surface (#108, all seven steps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,25 @@ direct shortcut you can press from inside the menu to skip selection.
   one file octoscope writes on its own — `scan-baselines.json`, beside
   your config; deleting it just starts a fresh baseline.
 
+  It also compares the **dependency install surface** (v0.33.0+) — the
+  subset of your npm dependencies that run code at install time, read
+  from `package-lock.json` / `npm-shrinkwrap.json` on the default branch.
+  A dependency that did not run code at install and now does is a
+  finding; the **same version shipping different content** is a stronger
+  one, because no upgrade explains it. An ordinary version bump is
+  inventory and scores nothing. It records the subset rather than the
+  file because the file churns and the subset does not — measured over
+  57 lockfile revisions of `axios/axios`, `npm/cli` and `nodejs/undici`,
+  the subset moved twice and the same version was never republished.
+  npm only, and the report says so: pnpm dropped its build declaration
+  at lockfileVersion 9 and Yarn never had one, so a repository whose
+  only lockfile is theirs gets an explicit line saying its dependency
+  surface was **not** compared — as does one with no lockfile, one whose
+  lockfile is too large to read, and one whose schema octoscope has not
+  measured. octoscope never looks at the registry: the claim is that
+  your dependencies' auto-execute surface changed, never that a
+  dependency is malicious.
+
   It also reports your **capability footprint** (v0.27.0+) — what a
   compromise of the repo could reach. Workflow permissions and triggers are read from
   the files it already fetched, plus self-hosted runners, write deploy

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -155,11 +155,18 @@ the claim is exactly *your dependencies' auto-execute surface changed*, never
 A missing `integrity` (git and `link:` dependencies) falls back to `resolved`,
 and failing that to a stable sentinel: an absent value must compare equal to
 itself across scans, or an unchanged dependency would be reported as
-republished. Where one `name@version` appears at two install locations with
-*different* integrity, every value is recorded as a sorted composite rather
-than one of them, so a change at any location still moves it — keeping only the
-lowest was deterministic and silently dropped exactly the republish this axis
-exists to catch.
+republished. **A republish is only ever scored when both sides are content
+hashes** — a `resolved` URL says where a dependency came *from*, so a registry
+or mirror change is reported as a move at weight 0 rather than as the heaviest
+claim this axis makes, on evidence that cannot carry it.
+
+Where one `name@version` appears at two install locations with *different*
+integrity, every distinct value is recorded as a sorted composite rather than
+one of them: keeping only the lowest was deterministic and silently dropped a
+change confined to any other location.
+
+The composite is a **set**, so it discards which location held which value —
+see Honest gaps.
 
 ### What is read, and what that costs
 
@@ -214,6 +221,15 @@ A reader told nothing assumes coverage.
   tens of thousands of packages — enough to bury every other axis under this
   one's output. Past `maxDepFindingsPerPath` the count is stated and the rest
   are not listed.
+
+  **The cap keeps the most serious, not the first alphabetically**, and that is
+  load-bearing rather than tidy. Cutting a key-ordered list let the lockfile
+  choose which findings survived: twenty-five weight-0 bumps named early in the
+  alphabet pushed a republish named late out of the report *and out of the
+  score*, since a finding dropped before it is recorded never contributes its
+  weight. The ordering is by case severity rather than by weight, because a
+  stale baseline weighs every case 0 and the sharpest line is still the one to
+  show first.
 
 ## Axis 2 — blob anomaly
 
@@ -703,7 +719,18 @@ what I looked at", and the report has to say what that was.
   Honest gap, documented, not detected.
 - **A lockfile past the blob scan cap reads as "not compared"** — correct, and
   most likely to be hit by exactly the large monorepos that would benefit most.
-  A follow-up rather than a cap raise.
+  A follow-up rather than a cap raise
+  ([#159](https://github.com/gfazioli/octoscope/issues/159)).
+- **Two install locations of one `name@version` swapping their contents is
+  invisible.** The ambiguous case records the sorted *set* of values, so
+  `A: aaa→bbb` while `B: bbb→aaa` reduces to the same composite. Recording the
+  location instead would key on the install path, and hoisting rearranges those
+  constantly for entirely ordinary reasons — trading a rare miss for routine
+  noise is the trade this axis exists to refuse. Pinned by a test, so it stays
+  a decision rather than becoming a discovery.
+- **A workspace entry is keyed by its install path**, so moving a workspace
+  reads as one dependency starting to run code at install and another stopping
+  ([#158](https://github.com/gfazioli/octoscope/issues/158)).
 - **The Axis-1 catalog is a moving target** by nature. It ships as a
   maintained data table, and the scan leans on Axes 2–4 — which do not depend
   on the catalog being exhaustive — for variants using an ignition point

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -72,6 +72,149 @@ One lesson from running the scan against real repositories: AI-agent
 `.windsurfrules`, `AGENTS.md`) are weight-0 inventory. Only code-executing
 hooks carry weight.
 
+## Axis 1b — dependency install surface
+
+**Shipped in 0.33.0** ([#108](https://github.com/gfazioli/octoscope/issues/108)).
+
+Axis 1 enumerates what auto-executes *in the repository's own source*. It
+cannot see a dependency that starts executing on install: that is not a new
+file and not a code change, it is a lockfile diff — and a lockfile diff is the
+one part of a pull request nobody reads line by line, which branch protection
+and required reviews do nothing about, because there is nothing in it a
+reviewer would recognise as suspicious.
+
+It needs no scope the scan does not already have. The lockfile is a blob in the
+repository's own tree.
+
+### npm only, and that is a measurement
+
+Per format, measured 2026-09-08 against real repositories:
+
+| Format | Declares install-time execution? | Evidence |
+|---|---|---|
+| `package-lock.json` v2/v3 | **yes** — `"hasInstallScript": true` per entry | `axios/axios`: 684 packages, 2 flagged |
+| `package-lock.json` v1 | no — no `packages` map | format |
+| `npm-shrinkwrap.json` | yes — same schema | format |
+| `pnpm-lock.yaml` v6 | yes — `requiresBuild: true` | `vitejs/vite` @ `v4.5.0`: 95 occurrences |
+| `pnpm-lock.yaml` v9 | **no** — `requiresBuild` is gone | `vitejs/vite` @ `main`: 0, and 80 `hasBin` |
+| `yarn.lock` (v1 and berry) | no per-entry flag | `facebook/react`, `babel/babel` |
+| `go.sum` | not applicable | the Go toolchain runs no install scripts |
+
+pnpm is absent *because* it once had the field and dropped it: building on
+`requiresBuild` would ship a rule that decays. `hasBin` is not a substitute — a
+bin entry runs when the developer chooses to run it, which is not this threat.
+The version is checked rather than merely decoded, so a future schema carrying
+a `packages` map is declined with its number named rather than answered from a
+field nobody has verified still means what it meant.
+
+### The subset, not the file
+
+The delta records `name@version → integrity` for the dependencies that carry an
+install script, and nothing else. Fingerprinting the lockfile's own blob OID
+would fire on every dependency bump, which is the noise this axis exists to
+avoid.
+
+The bet, and how far it holds — the last 20 lockfile revisions of each
+repository, newest first, diffing the install-script subset between consecutive
+revisions:
+
+| Repo | Revisions | Subset changed | New | Removed | Bumps | Same version, changed `integrity` |
+|---|---|---|---|---|---|---|
+| `axios/axios` | 19 | **0** | 0 | 0 | 0 | 0 |
+| `npm/cli` | 19 | **0** | 0 | 0 | 0 | 0 |
+| `nodejs/undici` | 19 | **2** | 1 | 1 | 2 | 0 |
+| **Total** | **57** | **2 (3.5 %)** | 1 | 1 | 2 | **0** |
+
+Roughly thirty times quieter than the file it lives in. `npm/cli` is the
+strongest case: a large lockfile that churns constantly, whose install-script
+set did not move once in 19 revisions.
+
+The second reading is the one that sets the weights. **Zero republish events in
+57 revisions** is a measured base rate of false positives, not evidence the
+signal fires — and it is what lets the sharpest case carry real weight instead
+of training the reader to skip the axis.
+
+Caveats kept deliberately: three repositories, all popular JavaScript projects,
+and the diff is *per commit* while octoscope diffs *per scan*. A scan spans many
+commits, so the measured rate is a lower bound on what a scan will see.
+
+### Three cases, because the key is `name@version`
+
+| Case | Meaning | Weight |
+|---|---|---|
+| a name that carried no install script now does | a dependency began executing code at install | `wDeltaNewInstallScript` = 2 |
+| same `name@version`, different recorded content | that version was republished | `wDeltaRepublishedDep` = 4 |
+| a known install-script package at a new version | an ordinary bump | 0 — inventory |
+| an install-script package disappeared | an improvement | 0 — inventory |
+
+4 lands on `watch` alone and reaches `suspicious` only with corroboration — the
+same posture as `wDeltaNewIgnition`. octoscope never looks at the registry, so
+the claim is exactly *your dependencies' auto-execute surface changed*, never
+*this dependency is malicious*.
+
+A missing `integrity` (git and `link:` dependencies) falls back to `resolved`,
+and failing that to a stable sentinel: an absent value must compare equal to
+itself across scans, or an unchanged dependency would be reported as
+republished. Where one `name@version` appears at two install locations with
+*different* integrity, every value is recorded as a sorted composite rather
+than one of them, so a change at any location still moves it — keeping only the
+lowest was deterministic and silently dropped exactly the republish this axis
+exists to catch.
+
+### What is read, and what that costs
+
+- **The default branch only.** A dependency change that matters lands there; on
+  side branches this would mostly re-report the open pull requests, once per
+  branch, against a baseline recorded from the default branch.
+- **Its own fetch budget** — `maxLockfileFetches`, counted separately from the
+  Axis-2 blob budget and spent *before* it. Axis 2 is the axis that catches the
+  payload, and a lockfile is one file per branch on any JavaScript repository;
+  sharing the budget would have starved it. That the Axis-2 budget is
+  arithmetically unchanged is a test, not a comment.
+- **The budget counts candidates, not successful reads**, which is what makes
+  ranking a choice rather than a preference. npm ignores `package-lock.json`
+  when `npm-shrinkwrap.json` is present, so an unreadable shrinkwrap leaves the
+  question unanswered rather than answered about a file npm never installs
+  from.
+- Real lockfiles measured 343 KB (`axios/axios`) and 437 KB (`npm/cli`), well
+  under the blob scan cap. Large monorepo lockfiles do exceed it, and over the
+  cap the file is **declared unread**, not silently skipped.
+
+A lockfile is exempt from Axis 2 entirely. It is hundreds of kilobytes of
+base64 integrity hashes, which is precisely the shape that axis scores — without
+the exemption every ordinary JavaScript repository would have been flagged for
+being ordinary.
+
+### Everything it did not compare says so
+
+Every one of these is weight 0, and every one exists because the alternative is
+silence — which is indistinguishable from *nothing here runs code at install*.
+A reader told nothing assumes coverage.
+
+- a lockfile seen and not read, with the reason recorded at the moment it was
+  known: oversized, unfetchable, or the file npm itself ignores;
+- a lockfile read with something to declare: a schema that cannot answer,
+  content that would not decode, an ambiguous duplicate;
+- a lockfile from a package manager this scan does not read. These are
+  deliberately *not* in the Axis-1 catalog — a catalog row is a claim that a
+  path auto-executes, and they make no such claim — so the tree walk observes
+  them separately. A pnpm or Yarn repository is the likeliest place for this
+  axis to look like coverage when it is not;
+- an npm project committing no lockfile at all. Common rather than anomalous:
+  `eslint/eslint` and `expressjs/express` are both in that state. It needs a
+  `package.json` to fire, because *no npm lockfile* on a Go repository is not a
+  disclosure, and it stays quiet when a foreign lockfile is present, which has
+  just said the same thing more precisely;
+- a baseline recorded before this axis existed, a lockfile read now and not
+  last time, and a surface recorded before and not measured now — that last one
+  because nothing else would notice: a lockfile is weight 0, so its path never
+  enters the ignition fingerprint;
+- more changes than the report will list. The lockfile is attacker-controlled
+  and bounded only by the blob scan cap, which at a minimal entry apiece is
+  tens of thousands of packages — enough to bury every other axis under this
+  one's output. Past `maxDepFindingsPerPath` the count is stated and the rest
+  are not listed.
+
 ## Axis 2 — blob anomaly
 
 Whatever it is called, a payload has physical tells, all readable cheaply
@@ -380,6 +523,15 @@ bury real signal under the maintainer's own commits. Nor is a path on a branch
 the baseline never saw — that is new work, not an appearance, or every feature
 branch would alarm.
 
+**The fingerprint carries a second record** (0.33.0): the dependency install
+surface of the default branch's lockfile, as `name@version → integrity` for the
+subset that runs code at install. It sits beside the ignition OIDs rather than
+inside them because the two say different things about the same file — a
+lockfile's OID moves on every bump, and its install-script subset does not. See
+[Axis 1b](#axis-1b--dependency-install-surface). A recorded *empty* set means
+the file was read and nothing in it runs code at install; *no entry at all*
+means the comparison did not happen, and the two never render alike.
+
 **The three questions the issue left open, and how they were answered:**
 
 - **Where it lives.** A sibling JSON file, `scan-baselines.json`, next to
@@ -541,6 +693,17 @@ what I looked at", and the report has to say what that was.
 - **Self-hosted runners, deploy keys and webhooks need elevated scope**, so
   they are best-effort — and the report declares what the token could not
   reach, rather than omitting it silently.
+- **The dependency install surface is npm-only**, and a repository whose only
+  lockfile is `pnpm-lock.yaml` or `yarn.lock` gets an explicit weight-0 line
+  saying its dependency surface was *not* compared. The measurement behind that
+  choice is in [Axis 1b](#axis-1b--dependency-install-surface); if pnpm restores
+  a build declaration, one catalog row and one parser branch adds it.
+- **`--ignore-scripts` is not detected.** A user who installs with it, or an
+  `.npmrc` octoscope does not read, is not exposed the way Axis 1b assumes.
+  Honest gap, documented, not detected.
+- **A lockfile past the blob scan cap reads as "not compared"** — correct, and
+  most likely to be hit by exactly the large monorepos that would benefit most.
+  A follow-up rather than a cap raise.
 - **The Axis-1 catalog is a moving target** by nature. It ships as a
   maintained data table, and the scan leans on Axes 2–4 — which do not depend
   on the catalog being exhaustive — for variants using an ignition point

--- a/docs/guide/drill-ins.html
+++ b/docs/guide/drill-ins.html
@@ -83,6 +83,21 @@
           <p>This is the one thing octoscope writes on its own: <code>scan-baselines.json</code>, next to your config file. Deleting it is harmless — the next scan simply starts a new baseline.</p>
         </div>
 
+        <h3>What your dependencies started running</h3>
+        <p>Since v0.33.0. The delta above sees what auto-executes in <i>your</i> source. It cannot see a dependency that starts executing on <code>npm install</code> — that is not a new file and not a code change, it is a lockfile diff, and a lockfile diff is the one part of a pull request nobody reads line by line.</p>
+        <p>So the scan reads <code>package-lock.json</code> / <code>npm-shrinkwrap.json</code> on the default branch and records the subset of dependencies that carry an install script, keyed by <code>name@version</code>:</p>
+        <ul>
+          <li>A dependency that <b>did not</b> run code at install and now does.</li>
+          <li>The <b>same version shipping different content</b> — no upgrade explains that one, so it weighs more.</li>
+          <li>An ordinary version bump, or a dependency that stopped running code at install: listed, never scored.</li>
+        </ul>
+        <p>It records the subset rather than the file because the file churns and the subset does not. Measured over the last 20 lockfile revisions of <code>axios/axios</code>, <code>npm/cli</code> and <code>nodejs/undici</code> — 57 in all — the subset moved twice, and the same version was never republished once. That measured base rate is what lets the sharp case carry weight instead of teaching you to skip it.</p>
+        <ul>
+          <li><b>npm only, and it says so.</b> pnpm dropped its build declaration at lockfileVersion 9 and Yarn never had one, so building on them would ship a rule that decays. A repository whose only lockfile is theirs gets an explicit line saying its dependency surface was <b>not</b> compared.</li>
+          <li>The same goes for no lockfile at all, one too large to read, and a schema octoscope has not measured. Silence would look exactly like nothing running code at install.</li>
+          <li>octoscope never looks at the registry. The claim is that your dependencies' auto-execute surface <i>changed</i> — never that a dependency is malicious.</li>
+        </ul>
+
         <h3>What a compromise could reach</h3>
         <p>The scan also reads your <b>capability footprint</b>: what permissions and triggers your workflows declare, plus self-hosted runners, write-access deploy keys and webhooks delivering off GitHub.</p>
         <p>Holding power is not itself a finding. A release workflow asking for <code>contents: write</code> and reading secrets is completely normal — only someone who can already push a tag can trigger it, so it stays inventory. What scores is power reachable from <b>untrusted input</b>: a <code>pull_request_target</code> workflow holding the repository's secrets, or a self-hosted runner that an outsider's pull request can reach.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1572,7 +1572,7 @@
                 <div class="feature w-m">
                     <div class="feature-label">Integrity over time</div>
                     <h3>Notices what changed, not just what's there</h3>
-                    <p>The supply-chain scan records a fingerprint of what auto-executes in a repo, then reports what moved since: a file that appeared, one whose contents changed, a branch tip that stopped being signed. It also maps what a compromise could reach — workflow permissions and triggers, self-hosted runners, deploy keys, off-platform webhooks — and says which checks your token couldn't run.</p>
+                    <p>The supply-chain scan records a fingerprint of what auto-executes in a repo, then reports what moved since: a file that appeared, one whose contents changed, a branch tip that stopped being signed, a dependency that started running code at <code class="inline">npm install</code> &mdash; or the same version of one shipping different content. It also maps what a compromise could reach — workflow permissions and triggers, self-hosted runners, deploy keys, off-platform webhooks — and says which checks your token couldn't run.</p>
                 </div>
                 <div class="feature w-l">
                     <div class="feature-label">Workflow chains</div>

--- a/internal/config/baseline.go
+++ b/internal/config/baseline.go
@@ -54,6 +54,24 @@ type BaselineFingerprint struct {
 	// one entry per version, which is its edit history — the unavoidable
 	// price of being able to recognise a return to any of them.
 	Seen map[string]map[string]time.Time `json:"seen,omitempty"`
+
+	// Deps is the recorded dependency install surface: for each lockfile
+	// path a scan actually read, "name@version" → integrity for the
+	// subset of dependencies that run code at install. See
+	// github.ScanFingerprint.Deps for why it is the subset and not the
+	// file, and why an empty inner map is not the same as a missing key.
+	//
+	// omitempty on purpose, in both directions. A store written before
+	// this field existed loads with Deps nil, which the delta reports as
+	// "first comparison of the dependency install surface" rather than
+	// as "nothing changed"; and a store written now stays readable by an
+	// older binary, which simply ignores the key.
+	//
+	// Growth is the subset, not the file: 2-4 entries per repository in
+	// the measured sample at roughly 110 bytes each, so a pathological
+	// 200-install-script monorepo is about 22 KB. Stated rather than
+	// compacted — the same decision as Seen.
+	Deps map[string]map[string]string `json:"deps,omitempty"`
 }
 
 // Baselines is the whole store, keyed by "owner/name".

--- a/internal/config/baseline_test.go
+++ b/internal/config/baseline_test.go
@@ -23,6 +23,13 @@ func TestBaselineRoundTrip(t *testing.T) {
 			Verdict:    "clean",
 			Ignition:   map[string]string{"main\x00.claude/settings.json": "abc123"},
 			Signed:     map[string]bool{"main": true},
+			Deps: map[string]map[string]string{
+				"main\x00package-lock.json": {"fsevents@2.3.3": "sha512-a"},
+				// A lockfile read and found to carry nothing. It must
+				// survive the round trip as present-and-empty: encoding
+				// it away would turn a measurement into a silence.
+				"main\x00npm-shrinkwrap.json": {},
+			},
 		},
 	}}
 	if err := SaveBaselines(path, in); err != nil {
@@ -45,6 +52,38 @@ func TestBaselineRoundTrip(t *testing.T) {
 	}
 	if !fp.Signed["main"] {
 		t.Error("signed state not preserved")
+	}
+	if got := fp.Deps["main\x00package-lock.json"]["fsevents@2.3.3"]; got != "sha512-a" {
+		t.Errorf("dependency install surface not preserved: %+v", fp.Deps)
+	}
+	if set, ok := fp.Deps["main\x00npm-shrinkwrap.json"]; !ok || set == nil || len(set) != 0 {
+		t.Errorf("an empty-but-read surface must survive as present and empty, got %v (present=%v)", set, ok)
+	}
+}
+
+// A store written before Deps existed has no "deps" key at all. It must
+// load as nil rather than as an empty map: nil is what the delta reads
+// as "there is nothing recorded to diff against", and an empty map would
+// read as "the last scan found no dependency running code at install" —
+// a claim about a repository nobody ever measured.
+func TestAStoreWrittenBeforeDepsLoadsWithNoSurface(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan-baselines.json")
+	old := `{"repos":{"gfazioli/octoscope":{` +
+		`"captured_at":"2026-08-01T09:30:00Z","verdict":"clean",` +
+		`"ignition":{"main\u0000.claude/settings.json":"abc123"},"signed":{"main":true}}}}`
+	if err := os.WriteFile(path, []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fp, ok := LoadBaselines(path).Repos["gfazioli/octoscope"]
+	if !ok {
+		t.Fatal("an older store must still load")
+	}
+	if fp.Ignition["main\x00.claude/settings.json"] != "abc123" {
+		t.Errorf("the rest of the older store must survive: %+v", fp)
+	}
+	if fp.Deps != nil {
+		t.Errorf("Deps = %v, want nil — nothing was recorded, which is not the same as nothing being there", fp.Deps)
 	}
 }
 

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -254,6 +254,35 @@ func packageNameFromPath(path string) string {
 	return path
 }
 
+// foreignLockfiles are the lockfiles of the other JavaScript package
+// managers. They are deliberately NOT in ignitionCatalog — a catalog row
+// is a claim that a path auto-executes, and these carry no such claim,
+// which is why TestMatchIgnition asserts they do not match.
+//
+// They are observed anyway, and only for this: the difference between an
+// explicit "this repository's dependency install surface was not
+// compared" and silence. Silence is the failure mode this whole axis is
+// built to avoid, and a pnpm or Yarn repository is the single most
+// likely place to hit it.
+//
+// The list is JavaScript-only because install scripts are an
+// npm-ecosystem concept; go.sum and Cargo.lock belong to toolchains that
+// run nothing at install, so naming them would be noise rather than
+// disclosure.
+var foreignLockfiles = map[string]string{
+	"pnpm-lock.yaml": "pnpm",
+	"yarn.lock":      "Yarn",
+	"bun.lockb":      "Bun",
+	"bun.lock":       "Bun",
+}
+
+// isForeignLockfile reports whether a repo-root-relative path is a
+// lockfile from an ecosystem this scan does not read.
+func isForeignLockfile(p string) bool {
+	_, ok := foreignLockfiles[p]
+	return ok
+}
+
 // lockfileReadOrder keeps the lockfile matches of one branch, most
 // authoritative first, and drops everything that is not a lockfile.
 //

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -56,6 +56,55 @@ const (
 // with a real single value.
 const ambiguousSep = " + "
 
+// maxAmbiguousListed bounds how many ambiguous keys one disclosure
+// names. See the note it builds for why a bound is needed at all.
+const maxAmbiguousListed = 10
+
+// oneLine flattens the whitespace a lockfile can smuggle into a package
+// name, version or integrity value.
+//
+// Sanitize strips terminal-control escapes but deliberately keeps
+// newlines and tabs, which is right for a commit message and wrong here:
+// these strings are interpolated into a line-oriented report, so a name
+// containing "\n" forges an extra visual finding. Flattened at the parse
+// boundary rather than at each use, so nothing downstream has to
+// remember.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// integrityAlgs are the Subresource Integrity prefixes npm writes. A
+// recorded value carrying one is a content hash; anything else is a
+// resolved URL or the no-integrity sentinel, and those say where a
+// dependency came FROM rather than what it contains.
+var integrityAlgs = [...]string{"sha512-", "sha384-", "sha256-", "sha1-"}
+
+// isIntegrity reports whether a recorded value is a content hash — every
+// part of it, since an ambiguous key records a composite.
+//
+// It exists because the republish finding is a claim about *bytes*, and
+// only a hash supports that claim. A `resolved` fallback changing from
+// one registry mirror to another says the source moved, which is not the
+// same sentence and must not carry the same weight.
+func isIntegrity(v string) bool {
+	if v == "" || v == noIntegrity {
+		return false
+	}
+	for _, part := range strings.Split(v, ambiguousSep) {
+		ok := false
+		for _, alg := range integrityAlgs {
+			if strings.HasPrefix(part, alg) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // noIntegrity marks a package whose lockfile entry carries neither an
 // integrity hash nor a resolved URL — git and `link:` dependencies,
 // mainly.
@@ -172,8 +221,17 @@ func parseLockfile(content []byte) lockfileFacts {
 	// as this first did — hides every change confined to the others. Two
 	// locations at aaa and bbb still reduce to aaa after bbb becomes
 	// zzz, so the sharpest case this axis has would be dropped in
-	// silence. The reduction is the sorted set instead, which moves
-	// whenever any location moves.
+	// silence. The reduction is the sorted SET instead.
+	//
+	// A set, and therefore not lossless — this comment claimed it was,
+	// and that was wrong. The set discards which location held which
+	// value, so two locations SWAPPING their contents (A: aaa→bbb while
+	// B: bbb→aaa) reduces to the same composite and is invisible.
+	// Recording the location instead would key on the install path, and
+	// hoisting rearranges those constantly for entirely ordinary
+	// reasons — trading a rare miss for routine noise, which is the
+	// trade this axis exists to refuse. The miss is documented rather
+	// than fixed; see docs/design/supply-chain-scan.md, Honest gaps.
 	values := map[string]map[string]bool{}
 
 	for path, p := range doc.Packages {
@@ -187,18 +245,18 @@ func parseLockfile(content []byte) lockfileFacts {
 		if path == "" {
 			continue
 		}
-		name := packageNameFromPath(path)
+		name := oneLine(packageNameFromPath(path))
 		if name == "" {
 			continue
 		}
-		key := name + "@" + p.Version
+		key := name + "@" + oneLine(p.Version)
 
-		value := p.Integrity
+		value := oneLine(p.Integrity)
 		if value == "" {
 			// A git or link dependency has no integrity hash. `resolved`
 			// still pins content for the git case (it carries the commit
 			// SHA), so it is the better fallback; the sentinel is last.
-			value = p.Resolved
+			value = oneLine(p.Resolved)
 		}
 		if value == "" {
 			value = noIntegrity
@@ -229,9 +287,20 @@ func parseLockfile(content []byte) lockfileFacts {
 
 	if len(ambiguous) > 0 {
 		sort.Strings(ambiguous)
+		// Capped, and the cap is not tidiness. The note becomes one
+		// finding's text, and this list is the one place a lockfile with
+		// thousands of ambiguous keys could still write an unbounded
+		// line into the report — the per-path finding cap does not reach
+		// inside a single Reason.
+		shown := ambiguous
+		extra := ""
+		if len(shown) > maxAmbiguousListed {
+			extra = fmt.Sprintf(" and %d more", len(shown)-maxAmbiguousListed)
+			shown = shown[:maxAmbiguousListed]
+		}
 		f.Note = "the same version appears at more than one install location with different integrity (" +
-			strings.Join(ambiguous, ", ") + "); every value is recorded, joined by \"" + ambiguousSep +
-			"\", so the entry is a composite rather than an integrity to quote — and a change at any one location still moves it"
+			strings.Join(shown, ", ") + extra + "); every distinct value is recorded, joined by \"" + ambiguousSep +
+			"\", so the entry is a composite rather than an integrity to quote"
 	}
 
 	return f

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -204,3 +204,52 @@ func packageNameFromPath(path string) string {
 	}
 	return path
 }
+
+// lockfileReadOrder keeps the lockfile matches of one branch, most
+// authoritative first, and drops everything that is not a lockfile.
+//
+// The order decides which file the scan sees, because
+// maxLockfileFetches bounds how many are read — and npm's own answer to
+// a repository carrying both is unambiguous: "If both package-lock.json
+// and npm-shrinkwrap.json are present in the root of a project,
+// npm-shrinkwrap.json will take precedence and package-lock.json will
+// be ignored" (docs.npmjs.com/cli/v11/configuring-npm/package-lock-json,
+// read 2026-09-08). Reading the ignored file would describe an install
+// surface npm never uses.
+//
+// The tie-break on path is not decoration. Tree order is GitHub's to
+// choose, and a pick that flipped between two scans would replace the
+// recorded dependency set wholesale — manufacturing a republish finding
+// for every entry in it, which is the one false positive this axis is
+// weighted to avoid.
+func lockfileReadOrder(matches []ignitionMatch) []ignitionMatch {
+	var out []ignitionMatch
+	for _, m := range matches {
+		if m.Rule.Class == classLockfile {
+			out = append(out, m)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := lockfileRank(out[i].Path), lockfileRank(out[j].Path)
+		if ri != rj {
+			return ri < rj
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+
+// lockfileRank orders the known lockfile names by npm's own precedence.
+// A name with no rank sorts last rather than silently outranking a file
+// npm would actually use — so adding a catalog row without thinking
+// about precedence degrades to "read after the ones we understand"
+// instead of to a wrong answer.
+func lockfileRank(p string) int {
+	switch p {
+	case "npm-shrinkwrap.json":
+		return 0
+	case "package-lock.json":
+		return 1
+	}
+	return 2
+}

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -1,0 +1,206 @@
+package github
+
+// Axis 1b — the dependency install surface (#108).
+//
+// The delta axis notices when something that auto-executes *in the
+// repository's own source* changes. It cannot see a dependency that
+// starts executing on install: that is not a code change and not a new
+// file, it is a lockfile diff — the one part of a pull request nobody
+// reads line by line, and one that branch protection and required
+// reviews do nothing about, because there is nothing a reviewer would
+// recognise as suspicious.
+//
+// Like workflow.go, this file only *extracts facts*. The scoring lives
+// in evaluateScan with the other axes, so the same pure-function
+// discipline applies.
+//
+// npm only, and that is a measured decision rather than a starting
+// point nobody revisited (2026-09-08):
+//
+//   - package-lock.json v2/v3 and npm-shrinkwrap.json declare the signal
+//     themselves, per entry, beside the resolved version and integrity
+//     hash: "hasInstallScript": true.
+//   - package-lock.json v1 has no packages map and no such flag.
+//   - pnpm-lock.yaml carried `requiresBuild` at lockfileVersion 6 and
+//     **dropped it at 9**, so building on it would ship a rule that
+//     decays. `hasBin` is not a substitute: a bin entry runs when the
+//     developer chooses to run it, which is not this threat.
+//   - yarn.lock (v1 and berry) declares nothing equivalent;
+//     dependenciesMeta.built is a package.json opt-out, not a
+//     declaration.
+//   - go.sum is not applicable: the Go toolchain runs no install scripts.
+//
+// The report must therefore say npm, and never read as ecosystem-agnostic
+// coverage.
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// noIntegrity marks a package whose lockfile entry carries neither an
+// integrity hash nor a resolved URL — git and `link:` dependencies,
+// mainly.
+//
+// It is a stable non-empty sentinel on purpose. The delta compares these
+// values for equality, so "no integrity recorded" must compare equal to
+// itself across scans; an empty string would work today and invites the
+// first refactor that treats "" as absent to manufacture a republish
+// finding out of a dependency that never moved.
+const noIntegrity = "-"
+
+// lockfileFacts is what one lockfile says about which dependencies run
+// code at install time.
+//
+// Supported and Unparsed are separate because they are different claims
+// and only one of them is a failure. A v1 lockfile is a file we read
+// correctly and whose schema cannot answer the question; a malformed one
+// is a file we could not read at all. Both mean "not compared", and
+// neither may be allowed to render as "nothing found" — the honesty
+// contract workflowFacts.Unparsed carries for Axis 4.
+type lockfileFacts struct {
+	// Packages maps "name@version" to the integrity of each dependency
+	// that carries an install script.
+	//
+	// The key holds the version because that is what separates an
+	// ordinary bump from a republish. Same key, different integrity, is
+	// the same version shipping different content — the sharp case. A
+	// new key for a name that had none is a dependency that started
+	// executing. A new key for a name already present is a bump, which
+	// is ordinary churn.
+	Packages map[string]string
+
+	// Supported reports whether this file's schema can express install
+	// scripts at all.
+	Supported bool
+
+	// Unparsed reports that the content could not be decoded, so the
+	// report can say the file was not understood rather than imply it
+	// was checked and found clean.
+	Unparsed bool
+
+	// Note is the one-line reason, for the disclosure the report owes
+	// the reader whenever Supported is false, Unparsed is true, or the
+	// file was ambiguous. Empty when there is nothing to disclose.
+	Note string
+}
+
+// lockPackage is one entry of the v2/v3 `packages` map. Only the four
+// fields this axis reads are declared; everything else in a real entry
+// is ignored by encoding/json.
+type lockPackage struct {
+	Version          string `json:"version"`
+	Resolved         string `json:"resolved"`
+	Integrity        string `json:"integrity"`
+	HasInstallScript bool   `json:"hasInstallScript"`
+}
+
+// lockfileDoc is the subset of the lockfile schema this axis decodes.
+type lockfileDoc struct {
+	LockfileVersion int                    `json:"lockfileVersion"`
+	Packages        map[string]lockPackage `json:"packages"`
+}
+
+// parseLockfile extracts the install-script surface from one npm
+// lockfile.
+//
+// Callers must cap the content length before calling — the scan already
+// does, via maxBlobScanBytes — because this hands attacker-controlled
+// bytes to a JSON decoder.
+func parseLockfile(content []byte) lockfileFacts {
+	f := lockfileFacts{Packages: map[string]string{}}
+
+	var doc lockfileDoc
+	if err := json.Unmarshal(content, &doc); err != nil {
+		f.Unparsed = true
+		f.Note = "the lockfile could not be decoded as JSON, so the dependency install surface was not compared"
+		return f
+	}
+
+	// v1 (npm 6) has a `dependencies` tree and no per-entry flag. The
+	// file is fine; the schema cannot answer the question. Reported as
+	// such rather than as an empty result, which would read as "no
+	// dependency runs code at install" — a claim this file cannot make.
+	if doc.Packages == nil {
+		f.Note = "this lockfile format does not declare install-time execution (lockfileVersion 1 or an unrecognised schema), so the dependency install surface was not compared"
+		return f
+	}
+	f.Supported = true
+
+	// A key can repeat as name@version at two different install
+	// locations — a nested duplicate, or the same version resolved from
+	// two registries. Where their integrity disagrees the pair is
+	// genuinely ambiguous, and the resolution has to be *deterministic*
+	// rather than merely defensible: Go randomises map iteration, so
+	// letting the last write win would make consecutive scans of an
+	// unchanged lockfile disagree and manufacture a republish finding.
+	// The smallest value wins, and the ambiguity is disclosed.
+	ambiguous := map[string]bool{}
+
+	for path, p := range doc.Packages {
+		if !p.HasInstallScript {
+			continue
+		}
+		// The root entry ("") is the *scanned* repository's own
+		// package.json, not a dependency. Its lifecycle scripts are Axis
+		// 1's business already, through the "package.json" row of
+		// ignitionCatalog.
+		if path == "" {
+			continue
+		}
+		name := packageNameFromPath(path)
+		if name == "" {
+			continue
+		}
+		key := name + "@" + p.Version
+
+		value := p.Integrity
+		if value == "" {
+			// A git or link dependency has no integrity hash. `resolved`
+			// still pins content for the git case (it carries the commit
+			// SHA), so it is the better fallback; the sentinel is last.
+			value = p.Resolved
+		}
+		if value == "" {
+			value = noIntegrity
+		}
+
+		if prev, seen := f.Packages[key]; seen && prev != value {
+			ambiguous[key] = true
+			if prev < value {
+				value = prev
+			}
+		}
+		f.Packages[key] = value
+	}
+
+	if len(ambiguous) > 0 {
+		keys := make([]string, 0, len(ambiguous))
+		for k := range ambiguous {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		f.Note = "the same version appears at more than one install location with different integrity (" +
+			strings.Join(keys, ", ") + "); the lowest was recorded, so a change here is reported conservatively"
+	}
+
+	return f
+}
+
+// packageNameFromPath turns a lockfile entry path into the package name.
+//
+// Entries are keyed by install location, so a nested copy reads as
+// "node_modules/playwright/node_modules/fsevents" and the name is what
+// follows the last node_modules segment. A workspace entry
+// ("packages/cli") has no such segment and is its own name — it is local
+// source rather than a fetched dependency, and it is kept, because a
+// workspace package that gains an install script is exactly as
+// interesting as a fetched one.
+func packageNameFromPath(path string) string {
+	const seg = "node_modules/"
+	if i := strings.LastIndex(path, seg); i >= 0 {
+		return path[i+len(seg):]
+	}
+	return path
+}

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -35,9 +35,26 @@ package github
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 )
+
+// The lockfile schema versions whose per-entry hasInstallScript flag has
+// actually been measured (2026-09-08); npm 11 writes 3. A `packages` map
+// is necessary but not sufficient to trust the flag, so the version is
+// checked rather than merely decoded.
+const (
+	lockfileVersionMin = 2
+	lockfileVersionMax = 3
+)
+
+// ambiguousSep joins the conflicting values of one ambiguous key. It
+// cannot occur inside an integrity — a space-separated list of
+// `alg-base64` tokens, none of which is a bare "+" — nor inside a
+// resolved URL, so the composite stays splittable and can never collide
+// with a real single value.
+const ambiguousSep = " + "
 
 // noIntegrity marks a package whose lockfile entry carries neither an
 // integrity hash nor a resolved URL — git and `link:` dependencies,
@@ -126,17 +143,38 @@ func parseLockfile(content []byte) lockfileFacts {
 		f.Note = "this lockfile format does not declare install-time execution (lockfileVersion 1 or an unrecognised schema), so the dependency install surface was not compared"
 		return f
 	}
+	// A `packages` map is necessary but not sufficient. hasInstallScript
+	// was measured at lockfileVersion 2 and 3 and nowhere else, so a
+	// future schema that happens to carry a packages map would decode
+	// cleanly here and be answered from a field nobody has checked still
+	// means what it meant. Declining a version we have not measured
+	// costs a disclosure the reader can act on; accepting one costs a
+	// silent wrong answer, and this axis is built on never trading the
+	// second for the first.
+	if doc.LockfileVersion < lockfileVersionMin || doc.LockfileVersion > lockfileVersionMax {
+		f.Note = fmt.Sprintf(
+			"lockfileVersion %d is not one this scan has measured (it reads %d and %d), so the dependency install surface was not compared",
+			doc.LockfileVersion, lockfileVersionMin, lockfileVersionMax)
+		return f
+	}
 	f.Supported = true
 
 	// A key can repeat as name@version at two different install
 	// locations — a nested duplicate, or the same version resolved from
-	// two registries. Where their integrity disagrees the pair is
-	// genuinely ambiguous, and the resolution has to be *deterministic*
-	// rather than merely defensible: Go randomises map iteration, so
-	// letting the last write win would make consecutive scans of an
-	// unchanged lockfile disagree and manufacture a republish finding.
-	// The smallest value wins, and the ambiguity is disclosed.
-	ambiguous := map[string]bool{}
+	// two registries. Every distinct value is collected first and the
+	// key reduced afterwards, for two separate reasons.
+	//
+	// Determinism: Go randomises map iteration, so letting the last
+	// write win would make consecutive scans of an unchanged lockfile
+	// disagree and manufacture a republish finding out of nothing.
+	//
+	// Fidelity: keeping only ONE of the conflicting values — the lowest,
+	// as this first did — hides every change confined to the others. Two
+	// locations at aaa and bbb still reduce to aaa after bbb becomes
+	// zzz, so the sharpest case this axis has would be dropped in
+	// silence. The reduction is the sorted set instead, which moves
+	// whenever any location moves.
+	values := map[string]map[string]bool{}
 
 	for path, p := range doc.Packages {
 		if !p.HasInstallScript {
@@ -166,23 +204,34 @@ func parseLockfile(content []byte) lockfileFacts {
 			value = noIntegrity
 		}
 
-		if prev, seen := f.Packages[key]; seen && prev != value {
-			ambiguous[key] = true
-			if prev < value {
-				value = prev
-			}
+		if values[key] == nil {
+			values[key] = map[string]bool{}
 		}
-		f.Packages[key] = value
+		values[key][value] = true
+	}
+
+	var ambiguous []string
+	for key, set := range values {
+		if len(set) == 1 {
+			for v := range set {
+				f.Packages[key] = v
+			}
+			continue
+		}
+		vs := make([]string, 0, len(set))
+		for v := range set {
+			vs = append(vs, v)
+		}
+		sort.Strings(vs)
+		f.Packages[key] = strings.Join(vs, ambiguousSep)
+		ambiguous = append(ambiguous, key)
 	}
 
 	if len(ambiguous) > 0 {
-		keys := make([]string, 0, len(ambiguous))
-		for k := range ambiguous {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
+		sort.Strings(ambiguous)
 		f.Note = "the same version appears at more than one install location with different integrity (" +
-			strings.Join(keys, ", ") + "); the lowest was recorded, so a change here is reported conservatively"
+			strings.Join(ambiguous, ", ") + "); every value is recorded, joined by \"" + ambiguousSep +
+			"\", so the entry is a composite rather than an integrity to quote — and a change at any one location still moves it"
 	}
 
 	return f

--- a/internal/github/lockfile_delta_test.go
+++ b/internal/github/lockfile_delta_test.go
@@ -282,3 +282,88 @@ func TestTheDependencyDeltaIsBytewiseDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// --- the second review round --------------------------------------------
+
+// The cap decides which findings survive, so a lockfile must not be able
+// to decide it. Twenty-five weight-0 bumps named early in the alphabet
+// used to push a republish named late out of the report — and out of the
+// SCORE, because a finding dropped before add() never contributes its
+// weight. That is an attacker-orderable suppression of the verdict.
+func TestTheCapCannotBeUsedToSuppressTheVerdict(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	prev := map[string]string{"zzz@1.0.0": "sha512-old"}
+	cur := map[string]string{"zzz@1.0.0": "sha512-NEW"} // the republish
+	for i := 0; i < maxDepFindingsPerPath; i++ {
+		// Ordinary bumps, weight 0, every one of them lexically before
+		// "zzz" — which is exactly how an attacker would order them.
+		prev[fmt.Sprintf("aaa%03d@1.0.0", i)] = "sha512-a"
+		cur[fmt.Sprintf("aaa%03d@2.0.0", i)] = "sha512-a"
+	}
+
+	s := evaluateScan(depsInput(cur,
+		depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{key: prev}), now))
+
+	var republish *Finding
+	for i, f := range deltaFindings(s) {
+		if strings.Contains(f.Reason, "not an upgrade") {
+			republish = &deltaFindings(s)[i]
+		}
+	}
+	if republish == nil {
+		t.Fatal("the republish was dropped by the cap — a lockfile can hide the only finding that mattered")
+	}
+	if republish.Weight != wDeltaRepublishedDep {
+		t.Errorf("republish weight = %d, want %d", republish.Weight, wDeltaRepublishedDep)
+	}
+	if s.Score < wDeltaRepublishedDep {
+		t.Errorf("score = %d; a capped report must still carry the weight it showed", s.Score)
+	}
+	// And it is the FIRST line, not buried among the bumps.
+	if got := deltaFindings(s)[0]; !strings.Contains(got.Reason, "not an upgrade") {
+		t.Errorf("the sharpest finding must lead, got %q", got.Reason)
+	}
+}
+
+// A recorded value is an integrity hash, a `resolved` URL, or the
+// no-integrity sentinel. Only the first supports the claim "this version
+// shipped different bytes". A registry or mirror change used to score 4
+// — the heaviest thing this axis says, on evidence that cannot carry it.
+func TestASourceChangeIsNotARepublish(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	got := deltaFindings(evaluateScan(depsInput(
+		map[string]string{"tool@1.0.0": "https://mirror.example.com/tool-1.0.0.tgz"},
+		depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{
+			key: {"tool@1.0.0": "https://registry.npmjs.org/tool/-/tool-1.0.0.tgz"},
+		}), now)))
+
+	if len(got) != 1 {
+		t.Fatalf("findings = %+v, want one", got)
+	}
+	if got[0].Weight != 0 {
+		t.Errorf("weight = %d, want 0: neither side is a hash, so nothing here says the content changed", got[0].Weight)
+	}
+	if !strings.Contains(got[0].Reason, "moved, not that its content did") {
+		t.Errorf("the finding must say what it can and cannot claim, got %q", got[0].Reason)
+	}
+}
+
+// ...and the mirror image: with a hash on both sides it still scores.
+func TestAHashChangeStillScoresARepublish(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	got := deltaFindings(evaluateScan(depsInput(
+		map[string]string{"tool@1.0.0": "sha512-NEW"},
+		depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{
+			key: {"tool@1.0.0": "sha512-old"},
+		}), now)))
+
+	if len(got) != 1 || got[0].Weight != wDeltaRepublishedDep {
+		t.Fatalf("findings = %+v, want one at weight %d", got, wDeltaRepublishedDep)
+	}
+}

--- a/internal/github/lockfile_delta_test.go
+++ b/internal/github/lockfile_delta_test.go
@@ -1,0 +1,280 @@
+package github
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// depsInput builds a scan of one repository whose default branch carries
+// one lockfile. Passing nil facts is "the lockfile was not read", which
+// is a different input from "read and empty".
+func depsInput(nowPkgs map[string]string, baseline *ScanFingerprint, now time.Time) scanInput {
+	var lf *lockfileFacts
+	if nowPkgs != nil {
+		lf = &lockfileFacts{Supported: true, Packages: nowPkgs}
+	}
+	br, blobs := lockBranch("main", true, "l1", lf)
+	return scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 1,
+		Branches: []scanBranch{br}, Blobs: blobs, Now: now, Baseline: baseline,
+	}
+}
+
+func depsBaseline(capturedAt time.Time, deps map[string]map[string]string) *ScanFingerprint {
+	return &ScanFingerprint{
+		CapturedAt: capturedAt,
+		Verdict:    VerdictClean.String(),
+		Ignition:   map[string]string{},
+		Signed:     map[string]bool{"main": true},
+		Deps:       deps,
+	}
+}
+
+func TestTheDependencyInstallSurfaceDelta(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	fresh := now.Add(-48 * time.Hour)
+	ancient := now.Add(-120 * 24 * time.Hour)
+	key := fingerprintKey("main", "package-lock.json")
+
+	tests := []struct {
+		name        string
+		in          scanInput
+		wantCount   int
+		wantWeight  int
+		wantContain string
+	}{
+		{
+			// The headline case: something in the dependency tree began
+			// executing code at install time.
+			name: "a dependency that did not run code at install now does",
+			in: depsInput(map[string]string{"fsevents@2.3.3": "sha512-a"},
+				depsBaseline(fresh, map[string]map[string]string{key: {}}), now),
+			wantCount:   1,
+			wantWeight:  wDeltaNewInstallScript,
+			wantContain: "runs code at install and did not at the last scan",
+		},
+		{
+			// The sharp one. No upgrade explains it, and the measured
+			// base rate is zero in 57 lockfile revisions.
+			name: "the same version shipping different content",
+			in: depsInput(map[string]string{"fsevents@2.3.3": "sha512-EVIL"},
+				depsBaseline(fresh, map[string]map[string]string{key: {"fsevents@2.3.3": "sha512-a"}}), now),
+			wantCount:   1,
+			wantWeight:  wDeltaRepublishedDep,
+			wantContain: "not an upgrade",
+		},
+		{
+			// A known install-script package moving version is what
+			// every dependency bot does all day. Inventory, weight 0 —
+			// scoring it is how an axis becomes noise.
+			name: "an ordinary bump is inventory, not a signal",
+			in: depsInput(map[string]string{"fsevents@2.3.4": "sha512-b"},
+				depsBaseline(fresh, map[string]map[string]string{key: {"fsevents@2.3.3": "sha512-a"}}), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "already ran code at install",
+		},
+		{
+			name: "a dependency that stopped running code at install",
+			in: depsInput(map[string]string{},
+				depsBaseline(fresh, map[string]map[string]string{key: {"fsevents@2.3.3": "sha512-a"}}), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "no longer runs code at install",
+		},
+		{
+			name: "an unchanged surface says nothing",
+			in: depsInput(map[string]string{"fsevents@2.3.3": "sha512-a"},
+				depsBaseline(fresh, map[string]map[string]string{key: {"fsevents@2.3.3": "sha512-a"}}), now),
+			wantCount:  0,
+			wantWeight: 0,
+		},
+		{
+			// A baseline that predates the axis. The repo has a history,
+			// this axis does not, and saying nothing would read as "your
+			// dependency surface did not change".
+			name: "a baseline recorded before this axis existed",
+			in: depsInput(map[string]string{"fsevents@2.3.3": "sha512-a"},
+				depsBaseline(fresh, nil), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "first comparison of the dependency install surface",
+		},
+		{
+			// ...but only when there was something to compare. A repo
+			// with no lockfile must not carry that line on every scan
+			// forever; that is how a reader learns to skip an axis.
+			name:       "nothing measured on either side says nothing",
+			in:         depsInput(nil, depsBaseline(fresh, nil), now),
+			wantCount:  0,
+			wantWeight: 0,
+		},
+		{
+			// The staleness gate is shared with every other delta case:
+			// past the window the finding is still reported, and still
+			// carries no weight.
+			name: "a stale baseline reports without scoring",
+			in: depsInput(map[string]string{"fsevents@2.3.3": "sha512-EVIL"},
+				depsBaseline(ancient, map[string]map[string]string{key: {"fsevents@2.3.3": "sha512-a"}}), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "without affecting the verdict",
+		},
+		{
+			// A lockfile read now and not last time. Diffing it against
+			// nothing would report every install-script dependency in it
+			// as newly arrived.
+			name: "a path compared for the first time",
+			in: depsInput(map[string]string{"fsevents@2.3.3": "sha512-a"},
+				depsBaseline(fresh, map[string]map[string]string{
+					fingerprintKey("main", "npm-shrinkwrap.json"): {},
+				}), now),
+			wantCount:   2, // the first comparison, plus the vanished shrinkwrap
+			wantWeight:  0,
+			wantContain: "was not compared at the last scan",
+		},
+		{
+			// Nothing else notices a lockfile going unread: it is weight
+			// 0, so its path is not in Ignition and its disappearance
+			// leaves no trace there.
+			name: "a surface recorded before and not measured now",
+			in: depsInput(nil,
+				depsBaseline(fresh, map[string]map[string]string{key: {"fsevents@2.3.3": "sha512-a"}}), now),
+			wantCount:   1,
+			wantWeight:  0,
+			wantContain: "was not compared this time",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deltaFindings(evaluateScan(tt.in))
+			if len(got) != tt.wantCount {
+				t.Fatalf("delta findings = %d, want %d: %+v", len(got), tt.wantCount, got)
+			}
+			weight := 0
+			joined := ""
+			for _, f := range got {
+				weight += f.Weight
+				joined += f.Reason + "\n"
+			}
+			if weight != tt.wantWeight {
+				t.Errorf("delta weight = %d, want %d (%s)", weight, tt.wantWeight, joined)
+			}
+			if tt.wantContain != "" && !strings.Contains(joined, tt.wantContain) {
+				t.Errorf("no finding mentions %q; got:\n%s", tt.wantContain, joined)
+			}
+		})
+	}
+}
+
+// A scoped name carries an "@" of its own, so splitting the key on the
+// first one would name the package "" and make every scoped dependency
+// look like the same package at different versions.
+func TestSplitDepKeyHandlesAScopedName(t *testing.T) {
+	tests := map[string][2]string{
+		"fsevents@2.3.3":     {"fsevents", "2.3.3"},
+		"@scope/pkg@1.0.0":   {"@scope/pkg", "1.0.0"},
+		"packages/cli@0.4.0": {"packages/cli", "0.4.0"},
+		"noversion@":         {"noversion", ""},
+	}
+	for key, want := range tests {
+		name, version := splitDepKey(key)
+		if name != want[0] || version != want[1] {
+			t.Errorf("splitDepKey(%q) = (%q, %q), want (%q, %q)", key, name, version, want[0], want[1])
+		}
+	}
+}
+
+// A scoped package gaining an install script must read as one arrival,
+// not as an arrival plus a departure — which is what a first-"@" split
+// produces, since every scoped name reduces to "".
+func TestAScopedDependencyIsTrackedByItsRealName(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	got := deltaFindings(evaluateScan(depsInput(
+		map[string]string{"@scope/tool@2.0.0": "sha512-b"},
+		depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{
+			key: {"@scope/tool@1.0.0": "sha512-a"},
+		}), now)))
+
+	if len(got) != 1 {
+		t.Fatalf("a scoped bump must be one finding, got %d: %+v", len(got), got)
+	}
+	if got[0].Weight != 0 {
+		t.Errorf("a bump of a known install-script package must not score, got %d: %s", got[0].Weight, got[0].Reason)
+	}
+	if !strings.Contains(got[0].Reason, "@scope/tool") {
+		t.Errorf("the finding must name the scoped package, got %q", got[0].Reason)
+	}
+}
+
+// The lockfile is attacker-controlled and bounded only by
+// maxBlobScanBytes, which is tens of thousands of minimal entries — more
+// than enough to bury every other axis under this one's output.
+func TestOneLockfileCannotFloodTheReport(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	pkgs := map[string]string{}
+	for i := 0; i < maxDepFindingsPerPath*4; i++ {
+		pkgs[fmt.Sprintf("pkg%03d@1.0.0", i)] = "sha512-a"
+	}
+	got := deltaFindings(evaluateScan(depsInput(pkgs,
+		depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{key: {}}), now)))
+
+	// The cap, plus the one line that states how many were left out.
+	if len(got) != maxDepFindingsPerPath+1 {
+		t.Fatalf("findings = %d, want %d capped plus one summary", len(got), maxDepFindingsPerPath+1)
+	}
+	last := got[len(got)-1]
+	if last.Weight != 0 || !strings.Contains(last.Reason, "not listed") {
+		t.Errorf("the last finding must be the weight-0 remainder line, got %+v", last)
+	}
+	// Silence about the remainder would be the real failure: a report
+	// that shows 25 of 100 changes and does not say so is worse than one
+	// that shows none.
+	if !strings.Contains(last.Reason, fmt.Sprintf("%d further", maxDepFindingsPerPath*3)) {
+		t.Errorf("the remainder line must state how many were left out, got %q", last.Reason)
+	}
+}
+
+// Go randomises map iteration and the delta walks three maps. A report
+// whose findings shuffle between two runs of the same scan cannot be
+// diffed by eye, and the shuffle would land hardest on exactly the
+// repositories with the most to read.
+func TestTheDependencyDeltaIsBytewiseDeterministic(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	in := func() scanInput {
+		return depsInput(
+			map[string]string{
+				"alpha@1.0.0": "sha512-NEW", // republished
+				"beta@2.0.0":  "sha512-b",   // bumped
+				"gamma@1.0.0": "sha512-c",   // arrived
+				"delta@1.0.0": "sha512-d",   // arrived
+			},
+			depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{
+				key: {
+					"alpha@1.0.0":   "sha512-a",
+					"beta@1.0.0":    "sha512-b0",
+					"epsilon@1.0.0": "sha512-e", // departed
+				},
+			}), now)
+	}
+
+	first := deltaFindings(evaluateScan(in()))
+	if len(first) < 5 {
+		t.Fatalf("fixture produced %d findings; it must exercise every case", len(first))
+	}
+	for i := 0; i < 30; i++ {
+		if got := deltaFindings(evaluateScan(in())); !reflect.DeepEqual(got, first) {
+			t.Fatalf("run %d disagrees:\n got %+v\nwant %+v", i, got, first)
+		}
+	}
+}

--- a/internal/github/lockfile_delta_test.go
+++ b/internal/github/lockfile_delta_test.go
@@ -12,11 +12,15 @@ import (
 // one lockfile. Passing nil facts is "the lockfile was not read", which
 // is a different input from "read and empty".
 func depsInput(nowPkgs map[string]string, baseline *ScanFingerprint, now time.Time) scanInput {
-	var lf *lockfileFacts
+	// nil packages means the repository has no lockfile at all, not one
+	// that went unread — those are different inputs and step 6
+	// deliberately says different things about them.
+	br := scanBranch{Prov: provBranch("main", true)}
+	blobs := map[string]blobAnalysis{}
 	if nowPkgs != nil {
-		lf = &lockfileFacts{Supported: true, Packages: nowPkgs}
+		br, blobs = lockBranch("main", true, "l1",
+			&lockfileFacts{Supported: true, Packages: nowPkgs})
 	}
-	br, blobs := lockBranch("main", true, "l1", lf)
 	return scanInput{
 		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 1,
 		Branches: []scanBranch{br}, Blobs: blobs, Now: now, Baseline: baseline,

--- a/internal/github/lockfile_disclosure_test.go
+++ b/internal/github/lockfile_disclosure_test.go
@@ -188,3 +188,42 @@ func TestIsForeignLockfile(t *testing.T) {
 		}
 	}
 }
+
+// npm-shrinkwrap.json is usually a byte-identical COPY of
+// package-lock.json, so in the common case the two share one git blob
+// SHA and one blobAnalysis. Reading authority out of that shared entry
+// made the ignored file look measured: its surface was recorded a second
+// time under its own path, and it got no "npm ignores it" line. A later
+// identical change then produced two findings and twice the score for
+// one underlying event.
+func TestTwoLockfilesWithIdenticalContentDoNotCountTwice(t *testing.T) {
+	const sha = "same"
+	facts := lockfileFacts{Supported: true, Packages: map[string]string{"fsevents@2.3.3": "sha512-a"}}
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 1,
+		Branches: []scanBranch{{Prov: provBranch("main", true), Matches: []ignitionMatch{
+			lockMatch("package-lock.json", sha, 400),
+			lockMatch("npm-shrinkwrap.json", sha, 400),
+		}}},
+		Blobs: map[string]blobAnalysis{sha: {Size: 400, Fetched: true, Lockfile: &facts}},
+		Now:   time.Now(),
+	}
+	s := evaluateScan(in)
+
+	if n := len(s.Fingerprint.Deps); n != 1 {
+		t.Errorf("Deps recorded %d surfaces, want 1 — npm reads one of these files: %v", n, s.Fingerprint.Deps)
+	}
+	if _, ok := s.Fingerprint.Deps[fingerprintKey("main", "npm-shrinkwrap.json")]; !ok {
+		t.Errorf("the recorded surface must be the shrinkwrap's: %v", s.Fingerprint.Deps)
+	}
+
+	var told bool
+	for _, f := range s.Findings {
+		if f.Path == "package-lock.json" && strings.Contains(f.Reason, "higher-precedence") {
+			told = true
+		}
+	}
+	if !told {
+		t.Error("the ignored file must still be disclosed as ignored, even sharing a blob with the one that was read")
+	}
+}

--- a/internal/github/lockfile_disclosure_test.go
+++ b/internal/github/lockfile_disclosure_test.go
@@ -1,0 +1,190 @@
+package github
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func packageJSONMatch() ignitionMatch {
+	return ignitionMatch{Path: "package.json", Size: 900, BlobSHA: "pkg",
+		Rule: ignitionRule{Glob: "package.json", Class: classPackage, Weight: 0}}
+}
+
+// disclosureScan runs one scan of a default branch with the given
+// surface and returns every weight-0 delta reason it produced, joined.
+// No baseline, so the only other line is the "no previous scan" one the
+// engine has always emitted.
+func disclosureScan(matches []ignitionMatch, blobs map[string]blobAnalysis, foreign []string) string {
+	s := evaluateScan(scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 1,
+		Branches: []scanBranch{{
+			Prov: provBranch("main", true), Matches: matches, OtherLockfiles: foreign,
+		}},
+		Blobs: blobs, Now: time.Now(),
+	})
+	var out []string
+	for _, f := range s.Findings {
+		if f.Axis == AxisDelta && f.Weight == 0 {
+			out = append(out, f.Reason)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// Every reason a lockfile can go unread has to reach the reader, because
+// the alternative is silence and silence is indistinguishable from
+// "nothing here runs code at install". Two of these reasons cannot be
+// re-derived at report time, which is why the gather records them.
+func TestEveryUnreadLockfileSaysWhy(t *testing.T) {
+	cases := []struct {
+		name   string
+		unread lockfileUnread
+		want   string
+	}{
+		{"oversized", lockUnreadOversized, "larger than the scan reads"},
+		{"fetch failed", lockUnreadFetchFailed, "content could not be fetched"},
+		{"npm ignores it", lockUnreadNotAuthoritative, "higher-precedence lockfile"},
+		{"reason missing", "", "recorded no reason"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := disclosureScan(
+				[]ignitionMatch{lockMatch("package-lock.json", "l1", 400)},
+				map[string]blobAnalysis{"l1": {Size: 400, LockfileUnread: tc.unread}},
+				nil)
+
+			if !strings.Contains(got, "was not compared") {
+				t.Errorf("an unread lockfile must say the surface was not compared; got:\n%s", got)
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("the disclosure must carry the reason %q; got:\n%s", tc.want, got)
+			}
+		})
+	}
+}
+
+// A lockfile that WAS read but had something to declare — a schema that
+// cannot answer, content that would not decode, an ambiguous duplicate.
+// The sentence is written where the fact was established and passed
+// through, rather than re-derived here where it would drift.
+func TestAReadLockfileWithSomethingToDeclareSaysIt(t *testing.T) {
+	cases := map[string]lockfileFacts{
+		"unsupported schema": {Note: "lockfileVersion 1 ...", Supported: false},
+		"undecodable":        {Note: "could not be decoded as JSON", Unparsed: true},
+		"ambiguous":          {Note: "the same version appears at more than one install location", Supported: true},
+	}
+	for name, lf := range cases {
+		t.Run(name, func(t *testing.T) {
+			facts := lf
+			got := disclosureScan(
+				[]ignitionMatch{lockMatch("package-lock.json", "l1", 400)},
+				map[string]blobAnalysis{"l1": {Size: 400, Fetched: true, Lockfile: &facts}},
+				nil)
+
+			if !strings.Contains(got, facts.Note) {
+				t.Errorf("the parser's own note must reach the reader verbatim; got:\n%s", got)
+			}
+			if !strings.Contains(got, "package-lock.json") {
+				t.Errorf("the disclosure must name the file; got:\n%s", got)
+			}
+		})
+	}
+}
+
+// A lockfile that parsed cleanly and had nothing to declare says
+// nothing. A line on every scan of every healthy repository is how a
+// reader learns to skip an axis.
+func TestACleanlyReadLockfileIsSilent(t *testing.T) {
+	facts := lockfileFacts{Supported: true, Packages: map[string]string{"fsevents@2.3.3": "sha512-a"}}
+	got := disclosureScan(
+		[]ignitionMatch{lockMatch("package-lock.json", "l1", 400)},
+		map[string]blobAnalysis{"l1": {Size: 400, Fetched: true, Lockfile: &facts}},
+		nil)
+
+	if strings.Contains(got, "was not compared") {
+		t.Errorf("a lockfile that was read owes no disclosure; got:\n%s", got)
+	}
+}
+
+// The likeliest place for this axis to look like coverage when it is
+// not: a JavaScript repository whose lockfile belongs to a package
+// manager whose format does not declare install-time execution.
+func TestAForeignLockfileIsNamedRatherThanIgnored(t *testing.T) {
+	got := disclosureScan(
+		[]ignitionMatch{packageJSONMatch()},
+		map[string]blobAnalysis{},
+		[]string{"pnpm-lock.yaml"})
+
+	if !strings.Contains(got, "pnpm-lock.yaml") || !strings.Contains(got, "npm lockfiles only") {
+		t.Errorf("a pnpm lockfile must be named, with what the scan does read; got:\n%s", got)
+	}
+	// And it must not ALSO claim there is no lockfile: that case has
+	// just been stated, more precisely.
+	if strings.Contains(got, "commits no npm lockfile") {
+		t.Errorf("the two lines say the same thing; only the precise one belongs:\n%s", got)
+	}
+}
+
+// eslint/eslint and expressjs/express both commit no lockfile at all
+// (measured 2026-09-08). A common state, not an anomaly — and still one
+// line, because "no findings" and "nothing to look at" differ.
+func TestAnNpmProjectWithNoLockfileSaysSo(t *testing.T) {
+	got := disclosureScan([]ignitionMatch{packageJSONMatch()}, map[string]blobAnalysis{}, nil)
+
+	if !strings.Contains(got, "commits no npm lockfile") {
+		t.Errorf("a package.json with no lockfile owes the reader a line; got:\n%s", got)
+	}
+}
+
+// ...but a repository that is not an npm project at all owes nothing.
+// "No npm lockfile" on a Go or Rust repository is noise, and noise is
+// what this axis spends its whole design avoiding.
+func TestARepositoryThatIsNotAnNpmProjectIsNotToldAboutNpm(t *testing.T) {
+	got := disclosureScan([]ignitionMatch{
+		{Path: ".github/workflows/ci.yml", Size: 900, BlobSHA: "w",
+			Rule: ignitionRule{Glob: ".github/workflows/*.yml", Class: classCI, Weight: 0}},
+	}, map[string]blobAnalysis{}, nil)
+
+	if strings.Contains(got, "npm lockfile") {
+		t.Errorf("a non-npm repository must not be told about npm lockfiles; got:\n%s", got)
+	}
+}
+
+// A side branch's lockfile is out of scope by design, and saying so once
+// per branch would drown the axis on a fork-heavy repository.
+func TestASideBranchLockfileOwesNoDisclosure(t *testing.T) {
+	s := evaluateScan(scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 2,
+		Branches: []scanBranch{
+			{Prov: provBranch("main", true)},
+			{Prov: provBranch("next", false), Matches: []ignitionMatch{
+				lockMatch("package-lock.json", "l1", 400)}},
+		},
+		Blobs: map[string]blobAnalysis{"l1": {Size: 400, LockfileUnread: lockUnreadSideBranch}},
+		Now:   time.Now(),
+	})
+	for _, f := range s.Findings {
+		if f.Axis == AxisDelta && strings.Contains(f.Reason, "not compared") {
+			t.Errorf("a side-branch lockfile must not produce a disclosure: %q", f.Reason)
+		}
+	}
+}
+
+func TestIsForeignLockfile(t *testing.T) {
+	yes := []string{"pnpm-lock.yaml", "yarn.lock", "bun.lockb", "bun.lock"}
+	for _, p := range yes {
+		if !isForeignLockfile(p) {
+			t.Errorf("%q is a lockfile this scan does not read and must be observed", p)
+		}
+	}
+	// The ones we DO read must never arrive here — they are ignition
+	// matches, and counting them twice would disclose that the file we
+	// just compared was not compared.
+	no := []string{"package-lock.json", "npm-shrinkwrap.json", "go.sum", "Cargo.lock", "src/yarn.lock"}
+	for _, p := range no {
+		if isForeignLockfile(p) {
+			t.Errorf("%q must not be observed as a foreign lockfile", p)
+		}
+	}
+}

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -183,6 +183,9 @@ func TestALockfileOnASideBranchIsNotRead(t *testing.T) {
 	if ba.Size != len(lockfileV3) {
 		t.Errorf("Size = %d, want %d — the file is still inventory", ba.Size, len(lockfileV3))
 	}
+	if ba.LockfileUnread != lockUnreadSideBranch {
+		t.Errorf("unread reason = %q, want %q", ba.LockfileUnread, lockUnreadSideBranch)
+	}
 }
 
 // A monorepo lockfile past maxBlobScanBytes is *declared unread*, not
@@ -208,6 +211,9 @@ func TestAnOversizedLockfileIsDeclaredUnreadRatherThanSkipped(t *testing.T) {
 	}
 	if ba.Size != huge {
 		t.Errorf("Size = %d, want %d — the disclosure needs the number", ba.Size, huge)
+	}
+	if ba.LockfileUnread != lockUnreadOversized {
+		t.Errorf("unread reason = %q, want %q", ba.LockfileUnread, lockUnreadOversized)
 	}
 }
 
@@ -243,8 +249,102 @@ func TestWithBothLockfilesTheOneNpmUsesIsReadFirst(t *testing.T) {
 	}
 	if ba := blobs["plock"]; ba.Lockfile != nil {
 		t.Error("the ignored lockfile must not be read")
+	} else if ba.LockfileUnread != lockUnreadNotAuthoritative {
+		t.Errorf("unread reason = %q, want %q", ba.LockfileUnread, lockUnreadNotAuthoritative)
 	} else if ba.Size != len(lockfileV3) {
 		t.Errorf("Size = %d, want %d — it is still inventory", ba.Size, len(lockfileV3))
+	}
+}
+
+// The precedence claim has to hold when the authoritative file is
+// UNREADABLE, which is where the first version of this broke: the budget
+// counted successful reads, so an oversized or unfetchable
+// npm-shrinkwrap.json left it unspent and the loop fell through to the
+// package-lock.json npm ignores — then reported a delta about the wrong
+// file, under a comment still claiming precedence. Falling back answers
+// the question about a file npm never installs from; not answering it is
+// the honest outcome.
+func TestAnUnreadableShrinkwrapDoesNotFallBackToTheFileNpmIgnores(t *testing.T) {
+	cases := []struct {
+		name       string
+		shrinkSize int
+		serve      map[string]string // what the blob server knows
+		wantReason lockfileUnread
+		wantCalls  int
+	}{
+		{
+			name:       "oversized",
+			shrinkSize: maxBlobScanBytes + 1,
+			serve:      map[string]string{"plock": lockfileV3, "shrink": lockfileV3},
+			wantReason: lockUnreadOversized,
+			wantCalls:  0, // the cap is checked before the request
+		},
+		{
+			name:       "fetch fails",
+			shrinkSize: len(lockfileV3),
+			serve:      map[string]string{"plock": lockfileV3}, // "shrink" 404s
+			wantReason: lockUnreadFetchFailed,
+			wantCalls:  1, // tried once, and not retried against the other file
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, srv := newBlobClient(t, tc.serve)
+			blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
+				{Prov: provBranch("main", true), Matches: []ignitionMatch{
+					lockMatch("package-lock.json", "plock", len(lockfileV3)),
+					lockMatch("npm-shrinkwrap.json", "shrink", tc.shrinkSize),
+				}},
+			})
+
+			if got := srv.seen(); len(got) != tc.wantCalls {
+				t.Errorf("requested %v, want %d call(s)", got, tc.wantCalls)
+			}
+			if ba := blobs["plock"]; ba.Lockfile != nil {
+				t.Errorf("the ignored lockfile was read anyway: %v", ba.Lockfile.Packages)
+			} else if ba.LockfileUnread != lockUnreadNotAuthoritative {
+				t.Errorf("package-lock reason = %q, want %q", ba.LockfileUnread, lockUnreadNotAuthoritative)
+			}
+			if ba := blobs["shrink"]; ba.LockfileUnread != tc.wantReason {
+				t.Errorf("shrinkwrap reason = %q, want %q", ba.LockfileUnread, tc.wantReason)
+			}
+		})
+	}
+}
+
+// Two paths with identical content share one git blob SHA. The lockfile
+// pass used to mark that SHA in the dedupe map Axis 2 reads, so any
+// other ignition file with the same content was skipped — and since the
+// lockfile pass deliberately fills none of the Axis-2 fields, the skip
+// left nothing behind to notice. Contrived content, but the blob SHA is
+// the scan's identity for a file and a hole in it is not contrived.
+func TestALockfileNeverSuppressesAxis2AnalysisOfTheSameContent(t *testing.T) {
+	const sha = "shared"
+	c, srv := newBlobClient(t, map[string]string{sha: lockfileV3})
+
+	blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
+		{Prov: provBranch("main", true), Matches: []ignitionMatch{
+			lockMatch("package-lock.json", sha, len(lockfileV3)),
+			{Path: ".claude/settings.json", Size: len(lockfileV3), BlobSHA: sha,
+				Rule: ignitionRule{Glob: ".claude/settings.json", Class: classAgentHook, Weight: wIgnitionAgentHook}},
+		}},
+	})
+
+	ba := blobs[sha]
+	if ba.Lockfile == nil {
+		t.Error("the lockfile facts must survive the Axis-2 analysis of the same blob")
+	}
+	// Entropy is filled only by the Axis-2 pass, so a non-zero value is
+	// proof that pass ran rather than an inference from Fetched, which
+	// both passes set.
+	if ba.Entropy == 0 || !ba.IsText {
+		t.Errorf("Axis 2 never analysed the shared blob: entropy=%v isText=%v", ba.Entropy, ba.IsText)
+	}
+	// One read per analysis. Caching the content across the two passes
+	// would save this, and is not worth the coupling for a case this
+	// rare — but it should not silently become three.
+	if got := srv.seen(); len(got) != 2 {
+		t.Errorf("requested %v, want one read per pass", got)
 	}
 }
 

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -1,0 +1,277 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// blobServer answers get-a-blob from a fixed SHA -> content map and
+// records every SHA it was asked for.
+//
+// The recording is the point. What gatherBlobs returns says which files
+// it understood; only the request log says which ones it *spent a call
+// on*, and a budget is an argument about calls. A leak that stays
+// inside the returned map would be invisible.
+type blobServer struct {
+	mu        sync.Mutex
+	requested []string
+}
+
+func (b *blobServer) seen() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.requested...)
+}
+
+func newBlobClient(t *testing.T, content map[string]string) (*Client, *blobServer) {
+	t.Helper()
+	bs := &blobServer{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "/repos/o/r/git/blobs/"
+		if !strings.HasPrefix(r.URL.Path, prefix) {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		sha := strings.TrimPrefix(r.URL.Path, prefix)
+		bs.mu.Lock()
+		bs.requested = append(bs.requested, sha)
+		bs.mu.Unlock()
+
+		body, ok := content[sha]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(restBlob{
+			Content:  base64.StdEncoding.EncodeToString([]byte(body)),
+			Encoding: "base64",
+			Size:     len(body),
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return &Client{rest: &http.Client{Transport: &rewriteHost{host: srv.URL}}, authenticated: true}, bs
+}
+
+// hookMatch is an ordinary Axis-2 candidate: a committed git hook, one
+// per SHA, small enough to be read.
+func hookMatch(n int) ignitionMatch {
+	return ignitionMatch{
+		Path:    fmt.Sprintf(".husky/h%02d", n),
+		Size:    200,
+		BlobSHA: fmt.Sprintf("hook%02d", n),
+		Rule:    ignitionRule{Glob: ".husky/*", Class: classVCSHook, Weight: 0},
+	}
+}
+
+func lockMatch(path, sha string, size int) ignitionMatch {
+	return ignitionMatch{
+		Path: path, Size: size, BlobSHA: sha,
+		Rule: ignitionRule{Glob: path, Class: classLockfile, Weight: 0},
+	}
+}
+
+// The lockfile read must be arithmetically invisible to Axis 2. That is
+// the whole justification for maxLockfileFetches existing beside
+// maxBlobFetches rather than inside it, so it is asserted as a
+// measurement — the same tree scanned with and without a lockfile, and
+// the set of Axis-2 blobs actually pulled compared — rather than
+// asserted as a comment.
+func TestTheLockfileReadNeverSpendsTheAxis2Budget(t *testing.T) {
+	// More hooks than the budget, so the cap really binds: if the
+	// lockfile ever took a read from this pool, one hook would silently
+	// stop being fetched and the two sets would differ.
+	const hooks = maxBlobFetches + 2
+
+	content := map[string]string{"lock": lockfileV3}
+	var withLock, without []ignitionMatch
+	for i := 0; i < hooks; i++ {
+		m := hookMatch(i)
+		content[m.BlobSHA] = "#!/bin/sh\nnpm test\n"
+		// The lockfile sits in the middle of the tree rather than at the
+		// end: a leak at the end would only drop the last hook, which a
+		// sloppy assertion could miss.
+		if i == 3 {
+			withLock = append(withLock, lockMatch("package-lock.json", "lock", len(lockfileV3)))
+		}
+		withLock = append(withLock, m)
+		without = append(without, m)
+	}
+
+	run := func(matches []ignitionMatch) (map[string]blobAnalysis, []string) {
+		c, srv := newBlobClient(t, content)
+		blobs := c.gatherBlobs(context.Background(), "o", "r",
+			[]scanBranch{{Prov: provBranch("main", true), Matches: matches}})
+		var axis2 []string
+		for _, sha := range srv.seen() {
+			if sha != "lock" {
+				axis2 = append(axis2, sha)
+			}
+		}
+		sort.Strings(axis2)
+		return blobs, axis2
+	}
+
+	blobs, readWith := run(withLock)
+	_, readWithout := run(without)
+
+	if len(readWithout) != maxBlobFetches {
+		t.Fatalf("without a lockfile, Axis 2 read %d blobs, want maxBlobFetches = %d "+
+			"(the fixture must saturate the budget or this test measures nothing)",
+			len(readWithout), maxBlobFetches)
+	}
+	if !reflect.DeepEqual(readWith, readWithout) {
+		t.Errorf("Axis 2 read %v with a lockfile in the tree and %v without it; "+
+			"the lockfile must not change which blobs the payload axis gets", readWith, readWithout)
+	}
+
+	// The other half: the lockfile was read, and its facts arrived.
+	// Half a budget test — "Axis 2 is unaffected" — is also satisfied by
+	// a lockfile read that silently does nothing.
+	ba := blobs["lock"]
+	if !ba.Fetched || ba.Lockfile == nil {
+		t.Fatalf("the default branch's lockfile must be read: fetched=%v lockfile=%v", ba.Fetched, ba.Lockfile)
+	}
+	if !ba.Lockfile.Supported {
+		t.Errorf("a v3 lockfile must come back Supported, note %q", ba.Lockfile.Note)
+	}
+	if _, ok := ba.Lockfile.Packages["fsevents@2.3.3"]; !ok {
+		t.Errorf("install surface = %v, want the fixture's install-script packages", ba.Lockfile.Packages)
+	}
+
+	// Axis 2 must not have looked at it. A lockfile is hundreds of
+	// kilobytes of base64 integrity hashes, which is exactly what
+	// looksObfuscated hunts for, so these three zero values are the
+	// exemption expressed in the data rather than trusted to the scorer.
+	if ba.IsText || ba.Entropy != 0 || ba.Markers != nil {
+		t.Errorf("Axis-2 analysis ran on a lockfile: isText=%v entropy=%v markers=%v",
+			ba.IsText, ba.Entropy, ba.Markers)
+	}
+}
+
+// A lockfile on a side branch is deliberately not read: on a repo with
+// twenty branches it would re-report the open pull requests, once per
+// branch, against a baseline recorded from the default branch. It is
+// still inventoried, with its size, so the report can name it.
+func TestALockfileOnASideBranchIsNotRead(t *testing.T) {
+	c, srv := newBlobClient(t, map[string]string{"lock": lockfileV3})
+
+	blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
+		{Prov: provBranch("main", true)},
+		{Prov: provBranch("next", false), Matches: []ignitionMatch{
+			lockMatch("package-lock.json", "lock", len(lockfileV3)),
+		}},
+	})
+
+	if got := srv.seen(); len(got) != 0 {
+		t.Errorf("requested %v, want no blob call at all for a side-branch lockfile", got)
+	}
+	ba := blobs["lock"]
+	if ba.Fetched || ba.Lockfile != nil {
+		t.Errorf("a side-branch lockfile must stay unread: fetched=%v lockfile=%v", ba.Fetched, ba.Lockfile)
+	}
+	if ba.Size != len(lockfileV3) {
+		t.Errorf("Size = %d, want %d — the file is still inventory", ba.Size, len(lockfileV3))
+	}
+}
+
+// A monorepo lockfile past maxBlobScanBytes is *declared unread*, not
+// silently skipped. Size survives so the report can say why, and
+// Lockfile stays nil so nothing downstream can read the absence as "no
+// dependency runs code at install".
+func TestAnOversizedLockfileIsDeclaredUnreadRatherThanSkipped(t *testing.T) {
+	const huge = maxBlobScanBytes + 1
+	c, srv := newBlobClient(t, map[string]string{"lock": lockfileV3})
+
+	blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
+		{Prov: provBranch("main", true), Matches: []ignitionMatch{
+			lockMatch("package-lock.json", "lock", huge),
+		}},
+	})
+
+	if got := srv.seen(); len(got) != 0 {
+		t.Errorf("requested %v, want no call: the size cap is checked before the fetch", got)
+	}
+	ba := blobs["lock"]
+	if ba.Fetched || ba.Lockfile != nil {
+		t.Errorf("an oversized lockfile must stay unread: fetched=%v lockfile=%v", ba.Fetched, ba.Lockfile)
+	}
+	if ba.Size != huge {
+		t.Errorf("Size = %d, want %d — the disclosure needs the number", ba.Size, huge)
+	}
+}
+
+// npm ignores package-lock.json when npm-shrinkwrap.json is present, so
+// reading the wrong one would describe an install surface npm never
+// uses. The budget forces the choice; this pins which way it goes, and
+// that the budget is the bound.
+func TestWithBothLockfilesTheOneNpmUsesIsReadFirst(t *testing.T) {
+	c, srv := newBlobClient(t, map[string]string{
+		"plock":  lockfileV3,
+		"shrink": lockfileV3,
+	})
+
+	blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
+		{Prov: provBranch("main", true), Matches: []ignitionMatch{
+			// Tree order puts the ignored file first, so a pass that
+			// simply took what it found would take the wrong one.
+			lockMatch("package-lock.json", "plock", len(lockfileV3)),
+			lockMatch("npm-shrinkwrap.json", "shrink", len(lockfileV3)),
+		}},
+	})
+
+	got := srv.seen()
+	if len(got) != maxLockfileFetches {
+		t.Fatalf("requested %v, want exactly maxLockfileFetches = %d calls", got, maxLockfileFetches)
+	}
+	if got[0] != "shrink" {
+		t.Errorf("first lockfile read = %q, want the npm-shrinkwrap.json blob: "+
+			"npm ignores package-lock.json when both are present", got[0])
+	}
+	if blobs["shrink"].Lockfile == nil {
+		t.Error("the shrinkwrap's facts must be recorded")
+	}
+	if ba := blobs["plock"]; ba.Lockfile != nil {
+		t.Error("the ignored lockfile must not be read")
+	} else if ba.Size != len(lockfileV3) {
+		t.Errorf("Size = %d, want %d — it is still inventory", ba.Size, len(lockfileV3))
+	}
+}
+
+func TestLockfileReadOrderKeepsOnlyLockfilesAndIsDeterministic(t *testing.T) {
+	in := []ignitionMatch{
+		hookMatch(1),
+		lockMatch("package-lock.json", "p", 10),
+		{Path: "package.json", Size: 10, BlobSHA: "pkg",
+			Rule: ignitionRule{Glob: "package.json", Class: classPackage}},
+		lockMatch("npm-shrinkwrap.json", "s", 10),
+		{Path: ".github/workflows/ci.yml", Size: 10, BlobSHA: "ci",
+			Rule: ignitionRule{Glob: ".github/workflows/*.yml", Class: classCI}},
+	}
+
+	var got []string
+	for _, m := range lockfileReadOrder(in) {
+		got = append(got, m.Path)
+	}
+	want := []string{"npm-shrinkwrap.json", "package-lock.json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("read order = %v, want %v", got, want)
+	}
+
+	// package.json is the neighbouring class this must never swallow:
+	// it is Axis 2's to read, and taking it here would cost that axis a
+	// blob without anyone noticing.
+	if len(lockfileReadOrder([]ignitionMatch{hookMatch(1)})) != 0 {
+		t.Error("a branch with no lockfile must yield nothing to read")
+	}
+}

--- a/internal/github/lockfile_test.go
+++ b/internal/github/lockfile_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -198,11 +199,79 @@ func TestAnAmbiguousDuplicateIsDeterministicAndDisclosed(t *testing.T) {
 			t.Fatalf("parse is not deterministic: %v vs %v", first.Packages, got.Packages)
 		}
 	}
-	if got := first.Packages["dup@1.0.0"]; got != "sha512-aaa" {
-		t.Errorf("the lowest integrity must win, got %q", got)
+	if got := first.Packages["dup@1.0.0"]; got != "sha512-aaa"+ambiguousSep+"sha512-bbb" {
+		t.Errorf("an ambiguous key must record every value, sorted, got %q", got)
 	}
 	if first.Note == "" {
 		t.Error("an ambiguous duplicate owes the reader a disclosure")
+	}
+}
+
+// The first version of this kept only the lowest of the conflicting
+// values, which is deterministic and lossy: a change confined to any
+// other location left the recorded value untouched. That silently drops
+// a republish, which is the sharpest thing this axis can report, so it
+// is worth its own test rather than trust in the reduction.
+func TestAChangeAtAnyLocationOfAnAmbiguousKeyIsVisible(t *testing.T) {
+	src := func(second string) []byte {
+		return []byte(`{
+		  "lockfileVersion": 3,
+		  "packages": {
+		    "node_modules/dup": { "version": "1.0.0", "integrity": "sha512-aaa", "hasInstallScript": true },
+		    "node_modules/nested/node_modules/dup": { "version": "1.0.0", "integrity": "` + second + `", "hasInstallScript": true }
+		  }
+		}`)
+	}
+	// "sha512-zzz" sorts ABOVE "sha512-aaa", so a reduction that keeps
+	// the minimum returns the identical value for both of these.
+	before := parseLockfile(src("sha512-bbb")).Packages["dup@1.0.0"]
+	after := parseLockfile(src("sha512-zzz")).Packages["dup@1.0.0"]
+
+	if before == after {
+		t.Errorf("a republish at the non-minimum location is invisible: both parses recorded %q", before)
+	}
+}
+
+// A packages map is necessary but not sufficient. hasInstallScript was
+// measured at lockfileVersion 2 and 3; a schema nobody has looked at
+// must not be answered from a field whose meaning was assumed.
+func TestAnUnmeasuredLockfileVersionIsNotClaimedAsSupported(t *testing.T) {
+	f := parseLockfile([]byte(`{
+	  "lockfileVersion": 4,
+	  "packages": {
+	    "": { "name": "app", "version": "1.0.0" },
+	    "node_modules/fsevents": { "version": "2.3.3", "integrity": "sha512-x", "hasInstallScript": true }
+	  }
+	}`))
+
+	if f.Supported {
+		t.Error("lockfileVersion 4 has not been measured and must not be reported as supported")
+	}
+	if f.Unparsed {
+		t.Error("the file decoded fine; it is unmeasured, not unreadable")
+	}
+	if len(f.Packages) != 0 {
+		t.Errorf("nothing may be claimed from a schema we do not vouch for, got %v", f.Packages)
+	}
+	if !strings.Contains(f.Note, "4") {
+		t.Errorf("the disclosure must name the version it declined, got %q", f.Note)
+	}
+}
+
+// v2 is the other end of the measured range, and it is a real npm 7
+// lockfile shape.
+func TestLockfileVersion2IsSupported(t *testing.T) {
+	f := parseLockfile([]byte(`{
+	  "lockfileVersion": 2,
+	  "packages": {
+	    "node_modules/esbuild": { "version": "0.28.1", "integrity": "sha512-e", "hasInstallScript": true }
+	  }
+	}`))
+	if !f.Supported {
+		t.Errorf("lockfileVersion 2 must be supported, note %q", f.Note)
+	}
+	if got := f.Packages["esbuild@0.28.1"]; got != "sha512-e" {
+		t.Errorf("surface = %v, want esbuild@0.28.1", f.Packages)
 	}
 }
 

--- a/internal/github/lockfile_test.go
+++ b/internal/github/lockfile_test.go
@@ -1,0 +1,228 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A real v3 shape, trimmed. axios/axios carries exactly this pattern
+// (measured 2026-09-08): 684 packages, two of them flagged, one of the
+// two a nested duplicate of the other.
+const lockfileV3 = `{
+  "name": "app",
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "name": "app", "version": "1.0.0" },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-plain"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-fsevents",
+      "hasInstallScript": true
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-fsevents",
+      "hasInstallScript": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-esbuild",
+      "hasInstallScript": true
+    }
+  }
+}`
+
+func TestParseLockfileExtractsOnlyTheInstallScriptSubset(t *testing.T) {
+	f := parseLockfile([]byte(lockfileV3))
+
+	if !f.Supported || f.Unparsed {
+		t.Fatalf("a v3 lockfile must parse and be supported, got supported=%v unparsed=%v", f.Supported, f.Unparsed)
+	}
+	want := map[string]string{
+		"fsevents@2.3.3": "sha512-fsevents",
+		"esbuild@0.28.1": "sha512-esbuild",
+	}
+	if !reflect.DeepEqual(f.Packages, want) {
+		t.Errorf("install-script surface = %v, want %v", f.Packages, want)
+	}
+	// The subset is the whole point: a package without the flag is an
+	// ordinary dependency, and including it would put the entire
+	// lockfile back into the delta — the noise this axis exists to
+	// avoid.
+	if _, ok := f.Packages["axios@1.7.2"]; ok {
+		t.Error("a package with no install script must not appear in the surface")
+	}
+	if f.Note != "" {
+		t.Errorf("an unambiguous lockfile owes no disclosure, got %q", f.Note)
+	}
+}
+
+func TestANestedDuplicateIsTheSamePackage(t *testing.T) {
+	f := parseLockfile([]byte(lockfileV3))
+
+	// fsevents appears twice — once at the top level and once under
+	// playwright — at the same version and integrity. It is one
+	// dependency installed twice, not two, and counting it twice would
+	// make a hoisting change read as a new install script.
+	if len(f.Packages) != 2 {
+		t.Fatalf("surface = %v, want 2 distinct packages", f.Packages)
+	}
+}
+
+func TestTheRootProjectIsNotADependency(t *testing.T) {
+	f := parseLockfile([]byte(`{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "app", "version": "1.0.0", "hasInstallScript": true }
+	  }
+	}`))
+
+	// The root entry is the scanned repository's own package.json. Its
+	// lifecycle scripts are already Axis 1's business; reporting them
+	// here would double-count the maintainer's own repo as a dependency
+	// finding.
+	if len(f.Packages) != 0 {
+		t.Errorf("the root project must not appear as a dependency, got %v", f.Packages)
+	}
+	if !f.Supported {
+		t.Error("a v3 lockfile with no flagged dependency is still supported")
+	}
+}
+
+func TestAWorkspacePackageIsKept(t *testing.T) {
+	f := parseLockfile([]byte(`{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "monorepo", "version": "1.0.0" },
+	    "packages/cli": { "version": "0.4.0", "hasInstallScript": true }
+	  }
+	}`))
+
+	// Local source rather than a fetched tarball, so it has no
+	// integrity — but a workspace package that starts running code at
+	// install is exactly as interesting as a fetched one.
+	if got, ok := f.Packages["packages/cli@0.4.0"]; !ok || got != noIntegrity {
+		t.Errorf("workspace surface = %v, want packages/cli@0.4.0 recorded as %q", f.Packages, noIntegrity)
+	}
+}
+
+func TestLockfileVersion1IsUnsupportedNotEmpty(t *testing.T) {
+	f := parseLockfile([]byte(`{"lockfileVersion": 1, "dependencies": {"fsevents": {"version": "2.3.3"}}}`))
+
+	// The file read fine; its schema cannot answer the question. An
+	// empty result with no disclosure would read as "no dependency runs
+	// code at install", which is a claim this file cannot make.
+	if f.Supported {
+		t.Error("lockfileVersion 1 declares no install scripts and must not be reported as supported")
+	}
+	if f.Unparsed {
+		t.Error("a v1 lockfile parsed correctly; it is unsupported, not unreadable")
+	}
+	if f.Note == "" {
+		t.Error("an unsupported schema owes the reader a disclosure")
+	}
+}
+
+func TestMalformedContentIsDeclaredNotClean(t *testing.T) {
+	f := parseLockfile([]byte("\x00not json at all{{"))
+
+	if !f.Unparsed || f.Supported {
+		t.Fatalf("undecodable content must be declared unparsed, got supported=%v unparsed=%v", f.Supported, f.Unparsed)
+	}
+	if len(f.Packages) != 0 {
+		t.Errorf("nothing may be claimed from content we could not read, got %v", f.Packages)
+	}
+	if f.Note == "" {
+		t.Error("an unreadable lockfile owes the reader a disclosure")
+	}
+}
+
+func TestAMissingIntegrityFallsBackAndNeverReadsAsAChange(t *testing.T) {
+	// A git dependency carries no integrity hash. `resolved` still pins
+	// content there — it holds the commit SHA — so it is the fallback,
+	// and the sentinel is last.
+	git := `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "node_modules/tool": {
+	      "version": "1.0.0",
+	      "resolved": "git+ssh://git@github.com/o/r.git#abc123",
+	      "hasInstallScript": true
+	    },
+	    "node_modules/linked": { "version": "0.0.0", "hasInstallScript": true }
+	  }
+	}`
+	f := parseLockfile([]byte(git))
+
+	if got := f.Packages["tool@1.0.0"]; got != "git+ssh://git@github.com/o/r.git#abc123" {
+		t.Errorf("a git dependency must fall back to resolved, got %q", got)
+	}
+	if got := f.Packages["linked@0.0.0"]; got != noIntegrity {
+		t.Errorf("an entry with neither integrity nor resolved must record %q, got %q", noIntegrity, got)
+	}
+
+	// The delta compares these values for equality across scans. A
+	// missing value must compare equal to itself, or an unchanged
+	// dependency would be reported as republished — the one false
+	// positive that would discredit the sharpest case this axis has.
+	again := parseLockfile([]byte(git))
+	if !reflect.DeepEqual(f.Packages, again.Packages) {
+		t.Errorf("two parses of the same lockfile disagree: %v vs %v", f.Packages, again.Packages)
+	}
+}
+
+func TestAnAmbiguousDuplicateIsDeterministicAndDisclosed(t *testing.T) {
+	// The same version at two install locations with *different*
+	// integrity. Go randomises map iteration, so "last write wins" would
+	// make consecutive scans of an unchanged lockfile disagree — and a
+	// disagreement here is a republish finding, the most alarming thing
+	// this axis can say. It must be stable.
+	src := `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "node_modules/dup": { "version": "1.0.0", "integrity": "sha512-bbb", "hasInstallScript": true },
+	    "node_modules/nested/node_modules/dup": { "version": "1.0.0", "integrity": "sha512-aaa", "hasInstallScript": true }
+	  }
+	}`
+	first := parseLockfile([]byte(src))
+	for i := 0; i < 50; i++ {
+		got := parseLockfile([]byte(src))
+		if !reflect.DeepEqual(first.Packages, got.Packages) {
+			t.Fatalf("parse is not deterministic: %v vs %v", first.Packages, got.Packages)
+		}
+	}
+	if got := first.Packages["dup@1.0.0"]; got != "sha512-aaa" {
+		t.Errorf("the lowest integrity must win, got %q", got)
+	}
+	if first.Note == "" {
+		t.Error("an ambiguous duplicate owes the reader a disclosure")
+	}
+}
+
+func TestEmptyContentIsUnparsed(t *testing.T) {
+	f := parseLockfile(nil)
+	if !f.Unparsed {
+		t.Error("empty content is not a lockfile with no install scripts; it is unreadable")
+	}
+}
+
+func TestPackageNameFromPath(t *testing.T) {
+	tests := map[string]string{
+		"node_modules/fsevents":                        "fsevents",
+		"node_modules/@scope/pkg":                      "@scope/pkg",
+		"node_modules/playwright/node_modules/esbuild": "esbuild",
+		"packages/cli":                                 "packages/cli",
+	}
+	for path, want := range tests {
+		if got := packageNameFromPath(path); got != want {
+			t.Errorf("packageNameFromPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/internal/github/lockfile_test.go
+++ b/internal/github/lockfile_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -293,5 +294,100 @@ func TestPackageNameFromPath(t *testing.T) {
 		if got := packageNameFromPath(path); got != want {
 			t.Errorf("packageNameFromPath(%q) = %q, want %q", path, got, want)
 		}
+	}
+}
+
+// --- the second review round --------------------------------------------
+
+// Sanitize strips terminal-control escapes and deliberately keeps
+// newlines, which is right for a commit message and wrong for a package
+// name interpolated into a line-oriented report: a name carrying "\n"
+// forges an extra visual finding in a security report. Flattened at the
+// parse boundary, so nothing downstream has to remember.
+func TestALockfileCannotSmuggleANewlineIntoTheReport(t *testing.T) {
+	f := parseLockfile([]byte("{\n  \"lockfileVersion\": 3,\n  \"packages\": {\n" +
+		"    \"node_modules/evil\\nCRITICAL: everything is fine\": " +
+		"{\"version\": \"1.0\\n0.0\", \"integrity\": \"sha512-a\\nb\", \"hasInstallScript\": true}\n  }\n}"))
+
+	for k, v := range f.Packages {
+		if strings.ContainsAny(k, "\n\r\t") {
+			t.Errorf("the recorded key still spans lines: %q", k)
+		}
+		if strings.ContainsAny(v, "\n\r\t") {
+			t.Errorf("the recorded value still spans lines: %q", v)
+		}
+	}
+	if len(f.Packages) != 1 {
+		t.Fatalf("surface = %v, want the one entry", f.Packages)
+	}
+}
+
+// A republish finding is a claim about bytes, and only a hash supports
+// it. A `resolved` URL says where a dependency came FROM.
+func TestIsIntegrity(t *testing.T) {
+	yes := []string{"sha512-abc", "sha256-abc", "sha1-abc", "sha384-abc",
+		"sha512-a" + ambiguousSep + "sha512-b"}
+	for _, v := range yes {
+		if !isIntegrity(v) {
+			t.Errorf("%q is a content hash", v)
+		}
+	}
+	no := []string{"", noIntegrity, "https://registry.npmjs.org/x/-/x-1.0.0.tgz",
+		"git+ssh://git@github.com/o/r.git#abc123",
+		// one hash and one URL is not a hash: the composite is only as
+		// strong as its weakest part.
+		"sha512-a" + ambiguousSep + "https://example.com/x.tgz"}
+	for _, v := range no {
+		if isIntegrity(v) {
+			t.Errorf("%q is not a content hash", v)
+		}
+	}
+}
+
+// The ambiguity note becomes one finding's text, and the per-path
+// finding cap does not reach inside a single Reason — so this list is
+// the one place a crafted lockfile could still write an unbounded line
+// into the report.
+func TestTheAmbiguityDisclosureIsBounded(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"lockfileVersion": 3, "packages": {`)
+	for i := 0; i < maxAmbiguousListed*5; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `"node_modules/p%03d": {"version":"1.0.0","integrity":"sha512-a","hasInstallScript":true},`, i)
+		fmt.Fprintf(&b, `"node_modules/nested/node_modules/p%03d": {"version":"1.0.0","integrity":"sha512-b","hasInstallScript":true}`, i)
+	}
+	b.WriteString("}}")
+
+	f := parseLockfile([]byte(b.String()))
+	if n := strings.Count(f.Note, "p0"); n > maxAmbiguousListed {
+		t.Errorf("the note names %d keys, over the %d cap", n, maxAmbiguousListed)
+	}
+	if !strings.Contains(f.Note, "more") {
+		t.Errorf("a truncated list must say how many were left out: %q", f.Note)
+	}
+}
+
+// The set reduction is NOT lossless, and this pins the miss rather than
+// letting a future reader discover it. Two locations swapping their
+// contents reduce to the same composite. Recording the location instead
+// would key on the install path, which hoisting rearranges constantly —
+// trading a rare miss for routine noise is the trade this axis refuses.
+// Documented in docs/design/supply-chain-scan.md, Honest gaps.
+func TestASwapBetweenTwoInstallLocationsIsInvisible(t *testing.T) {
+	src := func(a, b string) []byte {
+		return []byte(`{"lockfileVersion": 3, "packages": {
+		  "node_modules/dup": {"version":"1.0.0","integrity":"` + a + `","hasInstallScript":true},
+		  "node_modules/nested/node_modules/dup": {"version":"1.0.0","integrity":"` + b + `","hasInstallScript":true}
+		}}`)
+	}
+	before := parseLockfile(src("sha512-aaa", "sha512-bbb")).Packages["dup@1.0.0"]
+	after := parseLockfile(src("sha512-bbb", "sha512-aaa")).Packages["dup@1.0.0"]
+
+	if before != after {
+		t.Fatalf("the reduction has become location-sensitive (%q vs %q) — that is a "+
+			"behaviour change worth a decision, not a silent one: hoisting will now "+
+			"produce findings", before, after)
 	}
 }

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -475,6 +475,33 @@ const (
 	wDeltaChangedIgnition = 2 // a known one whose content changed
 	wDeltaSignedRegressed = 3 // a branch that used to carry a genuine signature no longer does
 
+	// Axis 1b — the dependency install surface. These diff the SUBSET of
+	// dependencies that run code at install rather than the lockfile,
+	// for exactly the reason the note above gives about weight-0 paths:
+	// the file churns constantly and the subset does not. Measured
+	// 2026-09-08 over the last 20 lockfile revisions of axios/axios,
+	// npm/cli and nodejs/undici — the subset moved in 2 of 57, and the
+	// republish case happened zero times. A base rate of zero is what
+	// lets the sharp case carry real weight instead of teaching the
+	// reader to skip the axis.
+	//
+	// wDeltaRepublishedDep at 4 lands on watch alone and reaches
+	// suspicious only with corroboration — the same posture as
+	// wDeltaNewIgnition, and deliberate: octoscope never looks at the
+	// registry, so the claim is "this version's content changed", not
+	// "this dependency is malicious".
+	wDeltaNewInstallScript = 2 // a dependency that did not run code at install now does
+	wDeltaRepublishedDep   = 4 // the same name@version, shipping different content
+
+	// maxDepFindingsPerPath bounds what one lockfile can put in a
+	// report. The file is attacker-controlled and bounded only by
+	// maxBlobScanBytes, which at a minimal entry apiece is tens of
+	// thousands of packages — enough to bury every other axis under its
+	// own output. Past the cap the count is stated and the rest are not
+	// listed; the verdict is unaffected, since tCompromised is reached
+	// several times over long before it.
+	maxDepFindingsPerPath = 25
+
 	// wPushBurstCorroboration is the account-wide timing signal's
 	// contribution, and it is applied **only to a repo that already
 	// scored on Axis 1-3 or on the baseline delta** — never to one whose
@@ -1781,6 +1808,169 @@ func evaluateScan(in scanInput) *RepoScan {
 			}
 		}
 
+		// Axis 1b — the dependency install surface (#108).
+		//
+		// Three cases, and keying by name@version rather than by name is
+		// what separates them. A name that carried no install script and
+		// now does is a dependency that started executing code at
+		// install. The same name@version with different content is that
+		// version republished, which no upgrade explains and which is
+		// the sharpest thing this axis can say. A known install-script
+		// package at a new version is an ordinary bump: inventory, and
+		// nothing more.
+		depKeys := make([]string, 0, len(s.Fingerprint.Deps))
+		for k := range s.Fingerprint.Deps {
+			depKeys = append(depKeys, k)
+		}
+		sort.Strings(depKeys)
+
+		if in.Baseline.Deps == nil {
+			// The baseline predates this axis. The repository has a scan
+			// history and this axis does not, and silence would read as
+			// "your dependency surface did not change" — the one reading
+			// the delta must never support.
+			//
+			// Said only when this scan measured something to have
+			// compared. Otherwise the sentence has no job: the report's
+			// own disclosures already say why nothing was read, and a
+			// line that fires on every scan of every repository without a
+			// lockfile is how a reader learns to skip an axis.
+			if len(depKeys) > 0 {
+				add(Finding{
+					Axis:   AxisDelta,
+					Weight: 0,
+					Reason: "first comparison of the dependency install surface — there is nothing recorded to diff against",
+				})
+			}
+		} else {
+			for _, key := range depKeys {
+				branch, path := splitFingerprintKey(key)
+				if _, known := in.Baseline.Signed[branch]; !known {
+					continue
+				}
+				now := s.Fingerprint.Deps[key]
+				prev, had := in.Baseline.Deps[key]
+				if !had {
+					// A lockfile this scan read and the last one did not.
+					// Diffing it against nothing would report every
+					// install-script dependency in it as newly arrived.
+					add(Finding{
+						Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
+						Reason: fmt.Sprintf("%s was not compared at the last scan, so this is the first comparison of its dependency install surface", path),
+					})
+					continue
+				}
+
+				// Name-level indexes on both sides, so a version bump can
+				// be told from an arrival and from a departure. Without
+				// them every upgrade of an install-script package would
+				// read as one dependency appearing and another leaving.
+				prevNames := map[string]bool{}
+				for dep := range prev {
+					name, _ := splitDepKey(dep)
+					prevNames[name] = true
+				}
+				nowNames := map[string]bool{}
+				for dep := range now {
+					name, _ := splitDepKey(dep)
+					nowNames[name] = true
+				}
+
+				emitted := 0
+				capped := 0
+				depAdd := func(f Finding) {
+					if emitted >= maxDepFindingsPerPath {
+						capped++
+						return
+					}
+					emitted++
+					add(f)
+				}
+
+				nowKeys := make([]string, 0, len(now))
+				for dep := range now {
+					nowKeys = append(nowKeys, dep)
+				}
+				sort.Strings(nowKeys)
+				for _, dep := range nowKeys {
+					name, version := splitDepKey(dep)
+					was, existed := prev[dep]
+					switch {
+					case existed && was != now[dep]:
+						depAdd(Finding{
+							Axis: AxisDelta, Branch: branch, Path: path,
+							Weight: weigh(wDeltaRepublishedDep),
+							Reason: fmt.Sprintf("%s is still pinned at %s in %s, but its recorded content changed since the last scan (%s → %s) — the same version shipping different bytes is not an upgrade%s",
+								name, version, path, shortIntegrity(was), shortIntegrity(now[dep]), stale),
+						})
+					case !existed && !prevNames[name]:
+						depAdd(Finding{
+							Axis: AxisDelta, Branch: branch, Path: path,
+							Weight: weigh(wDeltaNewInstallScript),
+							Reason: fmt.Sprintf("%s runs code at install and did not at the last scan, now at %s per %s%s",
+								name, version, path, stale),
+						})
+					case !existed:
+						depAdd(Finding{
+							Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
+							Reason: fmt.Sprintf("%s already ran code at install and is now at %s, per %s", name, version, path),
+						})
+					}
+				}
+
+				// A departure is an improvement and says nothing on its
+				// own, but it is still inventory: the reader asked what
+				// moved. Skipped where the name survives at another
+				// version, which the bump above has already reported.
+				prevKeys := make([]string, 0, len(prev))
+				for dep := range prev {
+					prevKeys = append(prevKeys, dep)
+				}
+				sort.Strings(prevKeys)
+				for _, dep := range prevKeys {
+					if _, still := now[dep]; still {
+						continue
+					}
+					name, version := splitDepKey(dep)
+					if nowNames[name] {
+						continue
+					}
+					depAdd(Finding{
+						Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
+						Reason: fmt.Sprintf("%s no longer runs code at install; it was at %s, per %s", name, version, path),
+					})
+				}
+
+				if capped > 0 {
+					add(Finding{
+						Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
+						Reason: fmt.Sprintf("%d further change(s) to the dependency install surface of %s are not listed — the report shows the first %d",
+							capped, path, maxDepFindingsPerPath),
+					})
+				}
+			}
+
+			// A surface that was recorded before and was not measured
+			// this time. Nothing else notices: a lockfile is weight 0, so
+			// its path is not in Ignition and its disappearance leaves no
+			// trace there. Silence would let "not compared" read as
+			// "nothing changed", one scan after the comparison worked.
+			goneKeys := make([]string, 0, len(in.Baseline.Deps))
+			for k := range in.Baseline.Deps {
+				if _, still := s.Fingerprint.Deps[k]; !still {
+					goneKeys = append(goneKeys, k)
+				}
+			}
+			sort.Strings(goneKeys)
+			for _, key := range goneKeys {
+				branch, path := splitFingerprintKey(key)
+				add(Finding{
+					Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
+					Reason: fmt.Sprintf("%s carried a dependency install surface at the last scan and was not compared this time — that is not evidence it did not change", path),
+				})
+			}
+		}
+
 		// A branch that used to carry a genuine author signature and no
 		// longer does. The reverse — unsigned becoming signed — is an
 		// improvement and says nothing.
@@ -1944,6 +2134,30 @@ func shortOID(oid string) string {
 		return oid[:7]
 	}
 	return oid
+}
+
+// splitDepKey is the inverse of the "name@version" key parseLockfile
+// builds. The split is on the LAST "@" because a package name may carry
+// one of its own: "@scope/pkg@1.0.0" is scope "@scope/pkg" at 1.0.0, and
+// splitting on the first would name the package "".
+func splitDepKey(k string) (name, version string) {
+	if i := strings.LastIndex(k, "@"); i > 0 {
+		return k[:i], k[i+1:]
+	}
+	return k, ""
+}
+
+// shortIntegrity abbreviates one recorded dependency value for a report
+// line. The value is an SRI hash, a resolved URL, the no-integrity
+// sentinel, or the joined composite of an ambiguous key — so it is
+// truncated rather than parsed, which keeps the leading characters that
+// carry the algorithm or the scheme and never lies about the rest.
+func shortIntegrity(v string) string {
+	const keep = 24
+	if len(v) <= keep {
+		return v
+	}
+	return v[:keep] + "..."
 }
 
 // humanBytes renders a byte count compactly (KiB / MiB) for findings.

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -985,6 +985,14 @@ type ignitionMatch struct {
 type scanBranch struct {
 	Prov    BranchProvenance
 	Matches []ignitionMatch
+
+	// OtherLockfiles are the paths of lockfiles belonging to package
+	// managers this scan does not read (see foreignLockfiles). Not
+	// ignition matches — they make no auto-execution claim and never
+	// reach the inventory — but their presence is what turns "the
+	// dependency install surface was not compared" from silence into a
+	// sentence.
+	OtherLockfiles []string
 }
 
 // scanInput is the gathered, network-sourced intermediate that
@@ -1181,6 +1189,86 @@ func evaluateScan(in scanInput) *RepoScan {
 					branchHasBlobAnomaly[br] = true
 				}
 			}
+		}
+	}
+
+	// --- Axis 1b — what was compared, and what was not ------------------
+	//
+	// Every line here carries weight 0 and every line says the same kind
+	// of thing: this part of the dependency install surface was NOT
+	// compared. They exist because the alternative is silence, and
+	// silence is indistinguishable from "nothing here runs code at
+	// install" — the reading this axis exists to prevent. A reader told
+	// nothing assumes coverage.
+	//
+	// Default branch only, matching where the read happens.
+	for _, b := range in.Branches {
+		if !b.Prov.IsDefault {
+			continue
+		}
+		lockMatches := lockfileReadOrder(b.Matches)
+		hasManifest := false
+		for _, m := range b.Matches {
+			if m.Rule.Class == classPackage {
+				hasManifest = true
+				break
+			}
+		}
+
+		for _, m := range lockMatches {
+			ba := in.Blobs[m.BlobSHA]
+			switch {
+			case ba.Lockfile == nil:
+				// The reason was recorded at the moment it was known,
+				// which is the whole reason LockfileUnread exists: two
+				// of the four states cannot be re-derived here.
+				why := string(ba.LockfileUnread)
+				if why == "" {
+					// Unreachable from the gather path, which names a
+					// reason for every default-branch lockfile. Kept
+					// because "no reason recorded" is still information,
+					// and inventing one would not be.
+					why = "the scan recorded no reason"
+				}
+				add(Finding{
+					Axis: AxisDelta, Branch: b.Prov.Name, Path: m.Path, Weight: 0,
+					Reason: fmt.Sprintf("%s was not read — %s — so the dependency install surface it declares was not compared", m.Path, why),
+				})
+			case ba.Lockfile.Note != "":
+				// The schema that cannot answer, the content that would
+				// not decode, and the ambiguous duplicate. Each already
+				// carries a sentence written where the fact was
+				// established; passing it through rather than
+				// re-deriving it is what stops the two from drifting.
+				add(Finding{
+					Axis: AxisDelta, Branch: b.Prov.Name, Path: m.Path, Weight: 0,
+					Reason: fmt.Sprintf("%s: %s", m.Path, ba.Lockfile.Note),
+				})
+			}
+		}
+
+		// A lockfile belonging to a package manager this scan does not
+		// read. Named rather than skipped: a pnpm or Yarn repository is
+		// the likeliest place for this axis to look like coverage when
+		// it is not.
+		for _, path := range b.OtherLockfiles {
+			add(Finding{
+				Axis: AxisDelta, Branch: b.Prov.Name, Path: path, Weight: 0,
+				Reason: fmt.Sprintf("%s is present, and this scan compares npm lockfiles only (package-lock.json, npm-shrinkwrap.json) — the dependency install surface was not compared", path),
+			})
+		}
+
+		// An npm project committing no lockfile at all. A common state,
+		// not an anomaly — eslint/eslint and expressjs/express are both
+		// in it (measured 2026-09-08) — and still worth a line, because
+		// "no findings" and "nothing to look at" are different answers.
+		// Silent when another ecosystem's lockfile is present: that case
+		// has just said the same thing more precisely.
+		if len(lockMatches) == 0 && len(b.OtherLockfiles) == 0 && hasManifest {
+			add(Finding{
+				Axis: AxisDelta, Branch: b.Prov.Name, Weight: 0,
+				Reason: "this repository has a package.json but commits no npm lockfile, so there is no dependency install surface to compare",
+			})
 		}
 	}
 
@@ -2406,6 +2494,7 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 	for i, p := range plans {
 		tr := treeCache[p.treeOID]
 		var matches []ignitionMatch
+		var foreign []string
 		for _, e := range tr.entries {
 			if e.typ != "blob" {
 				continue
@@ -2417,9 +2506,14 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 					BlobSHA: e.sha,
 					Rule:    rule,
 				})
+				continue
+			}
+			if isForeignLockfile(e.path) {
+				foreign = append(foreign, Sanitize(e.path))
 			}
 		}
-		branches[i] = scanBranch{Prov: p.prov, Matches: matches}
+		sort.Strings(foreign)
+		branches[i] = scanBranch{Prov: p.prov, Matches: matches, OtherLockfiles: foreign}
 	}
 
 	// A truncated tree means we may have missed a deeply-nested

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -285,6 +285,7 @@ const (
 	classPackage    ignitionClass = "package lifecycle script"
 	classVCSHook    ignitionClass = "committed VCS hook"
 	classCI         ignitionClass = "CI workflow"
+	classLockfile   ignitionClass = "dependency lockfile"
 	classDropper    ignitionClass = "known dropper filename"
 )
 
@@ -312,9 +313,9 @@ type ignitionRule struct {
 //     a command or process (Claude/Gemini session hooks, MCP, Aider,
 //     Continue): rarer than package manifests, and the code-execution
 //     vector in the reference incident.
-//   - 0 for ubiquitous or prompt-only surfaces (package.json, .vscode,
-//     workflows, husky, AND instruction/rules files like
-//     copilot-instructions.md / .cursor/rules / .windsurfrules /
+//   - 0 for ubiquitous or prompt-only surfaces (package.json,
+//     lockfiles, .vscode, workflows, husky, AND instruction/rules files
+//     like copilot-instructions.md / .cursor/rules / .windsurfrules /
 //     AGENTS.md): listed in the inventory so the user sees their
 //     attack surface, but they don't inflate the score on their own —
 //     otherwise every modern repo would cry "watch". They escalate
@@ -357,6 +358,15 @@ var ignitionCatalog = []ignitionRule{
 
 	// Package lifecycle scripts (preinstall / postinstall / prepare).
 	{Glob: "package.json", Class: classPackage, Weight: 0, Note: "inspect lifecycle scripts (pre/post-install, prepare)"},
+
+	// Dependency lockfiles. Weight 0 and read for one thing only: the
+	// delta on the subset of dependencies that run code at install
+	// (#108). npm alone declares that subset — see lockfile.go for the
+	// per-format measurement — so these two rows are the whole list, and
+	// the report says npm rather than implying ecosystem-agnostic
+	// coverage.
+	{Glob: "package-lock.json", Class: classLockfile, Weight: 0, Note: "declares which dependencies run code at install (npm lockfileVersion 2/3)"},
+	{Glob: "npm-shrinkwrap.json", Class: classLockfile, Weight: 0, Note: "declares which dependencies run code at install (npm lockfileVersion 2/3)"},
 
 	// Committed VCS hooks.
 	{Glob: ".husky/*", Class: classVCSHook, Weight: 0, Note: "git hook runs on commit / install"},
@@ -1037,6 +1047,25 @@ func evaluateScan(in scanInput) *RepoScan {
 		}
 
 		// Axis 2 — blob anomaly, once per distinct content.
+		//
+		// A lockfile is exempt, and both halves of the axis are why.
+		// Real lockfiles run to hundreds of kilobytes (343 KB in
+		// axios/axios, 437 KB in npm/cli — measured 2026-09-08), far
+		// past oversizeThreshold; and every entry carries a base64
+		// integrity hash, which is exactly the long-base64-run shape
+		// looksObfuscated hunts for. Scoring either would flag every
+		// JavaScript repository on earth for being ordinary, which is
+		// the failure this engine's weights exist to avoid. A lockfile
+		// is read for its install-script delta and for nothing else.
+		//
+		// Axis 2 is the last block in this per-path loop, which is what
+		// makes a bare continue correct. Anything added below it must
+		// decide for itself whether a lockfile is in scope rather than
+		// inherit this exemption by accident.
+		if a.rule.Class == classLockfile {
+			continue
+		}
+
 		for sha, carriers := range a.bySHA {
 			ba := in.Blobs[sha]
 			anomalous := false
@@ -2089,6 +2118,15 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 			}
 			seen[m.BlobSHA] = true
 			ba := blobAnalysis{Size: m.Size}
+			if m.Rule.Class == classLockfile {
+				// Read on its own budget, not out of this one:
+				// maxBlobFetches belongs to Axis 2, which is the axis
+				// that catches the payload, and a lockfile is large
+				// enough to crowd it out. The size is still recorded so
+				// the inventory can report the file.
+				blobs[m.BlobSHA] = ba
+				continue
+			}
 			if m.Size <= maxBlobScanBytes && fetched < maxBlobFetches {
 				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
 				if err == nil {

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -761,12 +761,45 @@ type blobAnalysis struct {
 	// Lockfile holds the Axis-1b install-script facts, set only for a
 	// dependency lockfile and only when its content was actually
 	// pulled. Nil everywhere else, and that nil is load-bearing: it is
-	// how the report tells a lockfile it never read (side branch, over
-	// the size cap, a failed fetch) from one it read and found nothing
-	// in. The two must never render alike — "no dependency runs code at
-	// install" is a claim an unread file cannot support.
+	// how the report tells a lockfile it never read from one it read
+	// and found nothing in. The two must never render alike — "no
+	// dependency runs code at install" is a claim an unread file cannot
+	// support.
 	Lockfile *lockfileFacts
+
+	// LockfileUnread says WHY Lockfile is nil, wherever that is a fact
+	// about this scan rather than about the blob's class.
+	//
+	// The four reasons were first left to be re-derived downstream from
+	// Size and the branch a match came from, and two of them — the
+	// budget and a failed fetch — are not separable that way without
+	// inspecting every other blob in the scan. A disclosure that has to
+	// reconstruct its own reason is one that will eventually
+	// reconstruct it wrongly, and this axis's whole contract is that
+	// "not compared" never renders as "nothing found".
+	LockfileUnread lockfileUnread
 }
+
+// lockfileUnread names why a lockfile's install-script facts are
+// absent. Empty means the question does not arise: the blob is not a
+// lockfile, or it was read.
+type lockfileUnread string
+
+const (
+	// lockUnreadSideBranch — it exists only outside the default branch,
+	// which this axis does not read by design.
+	lockUnreadSideBranch lockfileUnread = "it is not on the default branch"
+	// lockUnreadOversized — past maxBlobScanBytes.
+	lockUnreadOversized lockfileUnread = "it is larger than the scan reads"
+	// lockUnreadFetchFailed — the blob request did not come back.
+	lockUnreadFetchFailed lockfileUnread = "its content could not be fetched"
+	// lockUnreadNotAuthoritative — npm itself ignores this file while a
+	// higher-precedence lockfile sits beside it, so reading it would
+	// describe an install surface npm never uses. It stays unread even
+	// when the authoritative file turned out to be unreadable: falling
+	// back would answer the question about the wrong file.
+	lockUnreadNotAuthoritative lockfileUnread = "npm ignores it while a higher-precedence lockfile is present"
+)
 
 // maxBlobScanBytes caps how large a matched ignition blob we'll pull
 // for content analysis. Above it we still flag "oversized" (a strong
@@ -1904,6 +1937,9 @@ const maxBlobFetches = 12
 // have swallowed all twelve reads and starved the axis that matters.
 // One is enough because the read is default-branch-only: see
 // gatherBlobs for why that is the right scope rather than a shortcut.
+//
+// It counts CANDIDATES, not successful reads. That is what makes it a
+// choice of file rather than a preference: see gatherBlobs.
 const maxLockfileFetches = 1
 
 // scanRefsQuery enumerates a repository's branches with each tip's
@@ -2169,7 +2205,6 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 // through a whole scan.
 func (c *Client) gatherBlobs(ctx context.Context, owner, name string, branches []scanBranch) map[string]blobAnalysis {
 	blobs := map[string]blobAnalysis{}
-	seen := map[string]bool{}
 
 	// Axis 1b — the dependency install surface (#108). First, and on a
 	// budget of its own, for the reason maxLockfileFetches states.
@@ -2187,28 +2222,42 @@ func (c *Client) gatherBlobs(ctx context.Context, owner, name string, branches [
 	// precisely the shape that axis scores), and leaving those fields
 	// zero keeps the exemption a property of the data rather than a
 	// rule every future reader of the struct has to remember.
-	lockFetched := 0
+	// The budget counts CANDIDATES, not successful reads, and that is
+	// the difference between choosing a file and settling for one.
+	// lockfileReadOrder ranks the candidates by npm's own precedence, so
+	// spending the budget on the first one IS the choice. Counting
+	// successes instead — which is what the Axis-2 loop below does,
+	// because its blobs are peers and these are not — falls through to a
+	// package-lock.json npm ignores whenever the shrinkwrap beside it is
+	// oversized or its fetch fails, and then reports a delta about the
+	// wrong file while the code comment still claims precedence.
+	//
+	// Every candidate not read says why, because "not compared" must
+	// never reach the reader looking like "nothing found".
+	lockSeen := map[string]bool{}
+	lockCandidates := 0
 	for _, b := range branches {
 		if !b.Prov.IsDefault {
 			continue
 		}
 		for _, m := range lockfileReadOrder(b.Matches) {
-			if seen[m.BlobSHA] {
+			if lockSeen[m.BlobSHA] {
 				continue
 			}
-			seen[m.BlobSHA] = true
+			lockSeen[m.BlobSHA] = true
 			ba := blobAnalysis{Size: m.Size}
-			// Over the size cap the file is declared unread rather than
-			// silently skipped: Size survives, Lockfile stays nil, and
-			// the report owes the reader that difference.
-			if m.Size <= maxBlobScanBytes && lockFetched < maxLockfileFetches {
+			switch {
+			case lockCandidates >= maxLockfileFetches:
+				ba.LockfileUnread = lockUnreadNotAuthoritative
+			case m.Size > maxBlobScanBytes:
+				lockCandidates++
+				ba.LockfileUnread = lockUnreadOversized
+			default:
+				lockCandidates++
 				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
-				if err == nil {
-					// Counted on success, as the Axis-2 loop counts its
-					// own: a read that failed has told us nothing, so it
-					// must not spend the budget belonging to the file
-					// that could have.
-					lockFetched++
+				if err != nil {
+					ba.LockfileUnread = lockUnreadFetchFailed
+				} else {
 					ba.Fetched = true
 					// Content is bounded by maxBlobScanBytes above,
 					// which is what makes handing it to a JSON decoder
@@ -2223,23 +2272,40 @@ func (c *Client) gatherBlobs(ctx context.Context, owner, name string, branches [
 
 	// Axis 2 — every other matched ignition blob, on the budget that
 	// this feature must leave arithmetically untouched.
+	//
+	// Its dedupe map is its own. Sharing one with the pass above let a
+	// lockfile claim a blob SHA on Axis 2's behalf, so any *other*
+	// ignition file with byte-identical content was skipped and never
+	// analysed — and because the lockfile pass deliberately fills none
+	// of the Axis-2 fields, the skip left nothing behind to notice.
+	// Starting from whatever is already recorded for the SHA is what
+	// then keeps the two analyses of one blob from overwriting each
+	// other.
+	seen := map[string]bool{}
 	fetched := 0
 	for _, b := range branches {
 		for _, m := range b.Matches {
+			// A lockfile is never an Axis-2 read, and it is taken out of
+			// the running BEFORE the dedupe rather than after: marking
+			// the SHA on the way past is what let it suppress the other
+			// file. If the pass above never considered this one at all,
+			// it is not on the default branch — say so, rather than
+			// leaving a nil for the report to explain to itself.
+			if m.Rule.Class == classLockfile {
+				ba := blobs[m.BlobSHA]
+				ba.Size = m.Size
+				if ba.Lockfile == nil && ba.LockfileUnread == "" {
+					ba.LockfileUnread = lockUnreadSideBranch
+				}
+				blobs[m.BlobSHA] = ba
+				continue
+			}
 			if seen[m.BlobSHA] {
 				continue
 			}
 			seen[m.BlobSHA] = true
-			ba := blobAnalysis{Size: m.Size}
-			if m.Rule.Class == classLockfile {
-				// Reached only by a lockfile the pass above declined to
-				// read — a side-branch one, or a second lockfile past
-				// maxLockfileFetches. It must not spend an Axis-2 read
-				// here either; the size is still recorded so the
-				// inventory can report the file.
-				blobs[m.BlobSHA] = ba
-				continue
-			}
+			ba := blobs[m.BlobSHA]
+			ba.Size = m.Size
 			if m.Size <= maxBlobScanBytes && fetched < maxBlobFetches {
 				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
 				if err == nil {

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -223,6 +223,25 @@ type ScanFingerprint struct {
 	// the baseline and extended by this scan: key → OID → first observed.
 	// See config.BaselineFingerprint.Seen for why it is not bounded.
 	Seen map[string]map[string]time.Time
+
+	// Deps is the Axis-1b dependency install surface: for each lockfile
+	// path this scan actually read, "name@version" → integrity for the
+	// subset of dependencies that run code at install.
+	//
+	// Fingerprinting the lockfile's own OID would fire on every bump,
+	// which is the noise this axis exists to avoid; the subset is
+	// roughly thirty times quieter than the file (2 changes in 57
+	// lockfile revisions across three repositories, measured
+	// 2026-09-08), which is what makes a finding here worth reading.
+	//
+	// A present-but-empty inner map and an absent key are DIFFERENT
+	// answers and must stay that way. Empty means the file was read and
+	// nothing in it runs code at install; absent means the comparison
+	// did not happen — a side branch, an unread file, a schema we do not
+	// vouch for. Collapsing the two would make the next scan report
+	// every install-script package as newly appeared, the first time the
+	// file became readable.
+	Deps map[string]map[string]string
 }
 
 // fingerprintKey joins a branch and path into a single map key. NUL
@@ -1566,6 +1585,7 @@ func evaluateScan(in scanInput) *RepoScan {
 		CapturedAt: in.Now,
 		Ignition:   map[string]string{},
 		Signed:     map[string]bool{},
+		Deps:       map[string]map[string]string{},
 	}
 	for _, b := range in.Branches {
 		s.Fingerprint.Signed[b.Prov.Name] = b.Prov.Signed && !b.Prov.SignedByGitHub
@@ -1574,6 +1594,38 @@ func evaluateScan(in scanInput) *RepoScan {
 				continue // ubiquitous surface; see the delta weights
 			}
 			s.Fingerprint.Ignition[fingerprintKey(b.Prov.Name, m.Path)] = m.BlobSHA
+		}
+	}
+
+	// Axis 1b — the dependency install surface, recorded only where it
+	// was actually measured: the default branch, and only from a
+	// lockfile whose schema can answer the question.
+	//
+	// Weight is deliberately not consulted, so this cannot ride the loop
+	// above. That loop skips weight-0 matches because a ubiquitous
+	// path's OID churns for reasons nobody wants scored — and a lockfile
+	// is weight 0 for exactly that reason, so that the *file* never
+	// scores while the subset recorded here is the thing that does.
+	//
+	// The map is copied rather than aliased: lf.Packages belongs to this
+	// scan's input, and the fingerprint outlives it on disk.
+	for _, b := range in.Branches {
+		if !b.Prov.IsDefault {
+			continue
+		}
+		for _, m := range b.Matches {
+			if m.Rule.Class != classLockfile {
+				continue
+			}
+			lf := in.Blobs[m.BlobSHA].Lockfile
+			if lf == nil || !lf.Supported {
+				continue
+			}
+			deps := make(map[string]string, len(lf.Packages))
+			for k, v := range lf.Packages {
+				deps[k] = v
+			}
+			s.Fingerprint.Deps[fingerprintKey(b.Prov.Name, m.Path)] = deps
 		}
 	}
 

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -757,6 +757,15 @@ type blobAnalysis struct {
 	// Nil everywhere else, so the engine can tell "not a workflow" from
 	// "a workflow we could not read".
 	Workflow *workflowFacts
+
+	// Lockfile holds the Axis-1b install-script facts, set only for a
+	// dependency lockfile and only when its content was actually
+	// pulled. Nil everywhere else, and that nil is load-bearing: it is
+	// how the report tells a lockfile it never read (side branch, over
+	// the size cap, a failed fetch) from one it read and found nothing
+	// in. The two must never render alike — "no dependency runs code at
+	// install" is a claim an unread file cannot support.
+	Lockfile *lockfileFacts
 }
 
 // maxBlobScanBytes caps how large a matched ignition blob we'll pull
@@ -1885,6 +1894,18 @@ const maxScanBranches = 20
 // for content analysis in a single scan.
 const maxBlobFetches = 12
 
+// maxLockfileFetches caps the dependency-lockfile reads (Axis 1b) and
+// is counted separately from maxBlobFetches on purpose.
+//
+// Sharing the budget was the obvious implementation and the wrong one.
+// maxBlobFetches belongs to Axis 2 — the axis that actually catches a
+// payload — and a lockfile is one file per branch on any JavaScript
+// repository, so with maxScanBranches at 20 the lockfiles alone would
+// have swallowed all twelve reads and starved the axis that matters.
+// One is enough because the read is default-branch-only: see
+// gatherBlobs for why that is the right scope rather than a shortcut.
+const maxLockfileFetches = 1
+
 // scanRefsQuery enumerates a repository's branches with each tip's
 // provenance (Axis 3) plus the tip's tree OID, which feeds the REST
 // get-a-tree call (a real tree SHA, avoiding any ref-resolution
@@ -1949,7 +1970,8 @@ type scanRefsQuery struct {
 //     yields blob sizes for free (Axis 2 size).
 //  3. REST get-a-blob for each distinct matched ignition file, bounded
 //     by maxBlobFetches — entropy / obfuscation markers (Axis 2
-//     content).
+//     content) — preceded by the default branch's dependency lockfile
+//     on its own maxLockfileFetches budget (Axis 1b).
 //
 // Then the pure evaluateScan reduces the gathered facts to findings +
 // verdict.
@@ -2107,48 +2129,7 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 		}
 	}
 
-	// REST get-a-blob for each distinct matched ignition file, bounded.
-	blobs := map[string]blobAnalysis{}
-	seen := map[string]bool{}
-	fetched := 0
-	for _, b := range branches {
-		for _, m := range b.Matches {
-			if seen[m.BlobSHA] {
-				continue
-			}
-			seen[m.BlobSHA] = true
-			ba := blobAnalysis{Size: m.Size}
-			if m.Rule.Class == classLockfile {
-				// Read on its own budget, not out of this one:
-				// maxBlobFetches belongs to Axis 2, which is the axis
-				// that catches the payload, and a lockfile is large
-				// enough to crowd it out. The size is still recorded so
-				// the inventory can report the file.
-				blobs[m.BlobSHA] = ba
-				continue
-			}
-			if m.Size <= maxBlobScanBytes && fetched < maxBlobFetches {
-				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
-				if err == nil {
-					fetched++
-					ba.Fetched = true
-					ba.IsText = isTextContent(content)
-					ba.Entropy = shannonEntropy(content)
-					ba.Markers = looksObfuscated(content)
-					if m.Rule.Class == classCI {
-						// Content is already bounded by maxBlobScanBytes
-						// above, which is what makes handing it to a
-						// YAML parser acceptable.
-						wf := parseWorkflow(content)
-						ba.Workflow = &wf
-					}
-				}
-				// A blob fetch failure is non-fatal: we still have the
-				// size signal from the tree entry.
-			}
-			blobs[m.BlobSHA] = ba
-		}
-	}
+	blobs := c.gatherBlobs(ctx, owner, name, branches)
 
 	in := scanInput{
 		Owner:         Sanitize(owner),
@@ -2175,6 +2156,113 @@ func (c *Client) FetchRepoScan(ctx context.Context, owner, name string, opts Sca
 		in.BurstHit = true
 	}
 	return evaluateScan(in), nil
+}
+
+// gatherBlobs runs the bounded REST get-a-blob fan-out over the matched
+// ignition files of every scanned branch and returns the per-blob
+// analysis, keyed by blob SHA so identical content shared across
+// branches is fetched and analysed exactly once.
+//
+// It is a method rather than an inline loop because it owns two
+// budgets that must not leak into each other, and a budget is the kind
+// of arithmetic that has to be assertable on its own rather than
+// through a whole scan.
+func (c *Client) gatherBlobs(ctx context.Context, owner, name string, branches []scanBranch) map[string]blobAnalysis {
+	blobs := map[string]blobAnalysis{}
+	seen := map[string]bool{}
+
+	// Axis 1b — the dependency install surface (#108). First, and on a
+	// budget of its own, for the reason maxLockfileFetches states.
+	//
+	// Default branch only. A dependency change that matters lands
+	// there; on side branches this would mostly re-report the open pull
+	// requests, once per branch, against a baseline recorded from the
+	// default branch — noise the delta axis exists to avoid. A lockfile
+	// that exists only on a side branch still reaches the loop below,
+	// which records its size and reads nothing.
+	//
+	// Nothing here fills IsText / Entropy / Markers. A lockfile is
+	// exempt from Axis 2 by construction (evaluateScan says why: it is
+	// hundreds of kilobytes of base64 integrity hashes, which is
+	// precisely the shape that axis scores), and leaving those fields
+	// zero keeps the exemption a property of the data rather than a
+	// rule every future reader of the struct has to remember.
+	lockFetched := 0
+	for _, b := range branches {
+		if !b.Prov.IsDefault {
+			continue
+		}
+		for _, m := range lockfileReadOrder(b.Matches) {
+			if seen[m.BlobSHA] {
+				continue
+			}
+			seen[m.BlobSHA] = true
+			ba := blobAnalysis{Size: m.Size}
+			// Over the size cap the file is declared unread rather than
+			// silently skipped: Size survives, Lockfile stays nil, and
+			// the report owes the reader that difference.
+			if m.Size <= maxBlobScanBytes && lockFetched < maxLockfileFetches {
+				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
+				if err == nil {
+					// Counted on success, as the Axis-2 loop counts its
+					// own: a read that failed has told us nothing, so it
+					// must not spend the budget belonging to the file
+					// that could have.
+					lockFetched++
+					ba.Fetched = true
+					// Content is bounded by maxBlobScanBytes above,
+					// which is what makes handing it to a JSON decoder
+					// acceptable.
+					lf := parseLockfile(content)
+					ba.Lockfile = &lf
+				}
+			}
+			blobs[m.BlobSHA] = ba
+		}
+	}
+
+	// Axis 2 — every other matched ignition blob, on the budget that
+	// this feature must leave arithmetically untouched.
+	fetched := 0
+	for _, b := range branches {
+		for _, m := range b.Matches {
+			if seen[m.BlobSHA] {
+				continue
+			}
+			seen[m.BlobSHA] = true
+			ba := blobAnalysis{Size: m.Size}
+			if m.Rule.Class == classLockfile {
+				// Reached only by a lockfile the pass above declined to
+				// read — a side-branch one, or a second lockfile past
+				// maxLockfileFetches. It must not spend an Axis-2 read
+				// here either; the size is still recorded so the
+				// inventory can report the file.
+				blobs[m.BlobSHA] = ba
+				continue
+			}
+			if m.Size <= maxBlobScanBytes && fetched < maxBlobFetches {
+				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
+				if err == nil {
+					fetched++
+					ba.Fetched = true
+					ba.IsText = isTextContent(content)
+					ba.Entropy = shannonEntropy(content)
+					ba.Markers = looksObfuscated(content)
+					if m.Rule.Class == classCI {
+						// Content is already bounded by maxBlobScanBytes
+						// above, which is what makes handing it to a
+						// YAML parser acceptable.
+						wf := parseWorkflow(content)
+						ba.Workflow = &wf
+					}
+				}
+				// A blob fetch failure is non-fatal: we still have the
+				// size signal from the tree entry.
+			}
+			blobs[m.BlobSHA] = ba
+		}
+	}
+	return blobs
 }
 
 // treeEntry is one node from GitHub's get-a-tree response, reshaped.

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -501,6 +501,19 @@ const (
 	// listed; the verdict is unaffected, since tCompromised is reached
 	// several times over long before it.
 	maxDepFindingsPerPath = 25
+)
+
+// Severity order for the dependency-delta findings of one lockfile.
+// maxDepFindingsPerPath cuts the list at the bottom, so this decides what
+// survives — and it has to be a property of the CASE rather than of the
+// weight, because a stale baseline weighs every case 0 and the sharpest
+// line is still the one to show first.
+const (
+	rankRepublished = iota
+	rankNewInstallScript
+	rankSourceMoved
+	rankBumped
+	rankDeparted
 
 	// wPushBurstCorroboration is the account-wide timing signal's
 	// contribution, and it is applied **only to a repo that already
@@ -1215,8 +1228,19 @@ func evaluateScan(in scanInput) *RepoScan {
 			}
 		}
 
-		for _, m := range lockMatches {
+		for i, m := range lockMatches {
 			ba := in.Blobs[m.BlobSHA]
+			if i >= maxLockfileFetches {
+				// npm ignores this one, and saying so cannot be left to
+				// the blob: a byte-identical shrinkwrap shares its
+				// analysis, so the shared entry claims it was read.
+				add(Finding{
+					Axis: AxisDelta, Branch: b.Prov.Name, Path: m.Path, Weight: 0,
+					Reason: fmt.Sprintf("%s was not read — %s — so the dependency install surface it declares was not compared",
+						m.Path, lockUnreadNotAuthoritative),
+				})
+				continue
+			}
 			switch {
 			case ba.Lockfile == nil:
 				// The reason was recorded at the moment it was known,
@@ -1728,9 +1752,19 @@ func evaluateScan(in scanInput) *RepoScan {
 		if !b.Prov.IsDefault {
 			continue
 		}
-		for _, m := range b.Matches {
-			if m.Rule.Class != classLockfile {
-				continue
+		// Authority comes from the ranking, not from the blob.
+		//
+		// npm-shrinkwrap.json is usually a byte-identical COPY of
+		// package-lock.json, so the two share one git blob SHA and one
+		// blobAnalysis — and reading facts out of that shared entry
+		// recorded the same surface twice, once under each path, for a
+		// file npm ignores. A later identical change then produced two
+		// findings and twice the score for one underlying event.
+		// lockfileReadOrder is what decided which file to read; it is
+		// what decides which file counts.
+		for i, m := range lockfileReadOrder(b.Matches) {
+			if i >= maxLockfileFetches {
+				break
 			}
 			lf := in.Blobs[m.BlobSHA].Lockfile
 			if lf == nil || !lf.Supported {
@@ -1964,15 +1998,29 @@ func evaluateScan(in scanInput) *RepoScan {
 					nowNames[name] = true
 				}
 
-				emitted := 0
-				capped := 0
-				depAdd := func(f Finding) {
-					if emitted >= maxDepFindingsPerPath {
-						capped++
-						return
-					}
-					emitted++
-					add(f)
+				// Candidates are collected, ranked by severity, and only
+				// then capped.
+				//
+				// Emitting in key order and cutting at the cap let the
+				// lockfile decide WHICH findings survive: twenty-five
+				// weight-0 bumps named early in the alphabet pushed a
+				// republish named late out of the report — and out of the
+				// score, since a finding dropped before add() never
+				// contributes its weight. That is an attacker-orderable
+				// suppression of the verdict, which is a worse failure
+				// than the flood the cap exists to stop.
+				//
+				// Ranked by severity rather than by weight, because a
+				// stale baseline zeroes every weight and the reader still
+				// wants the sharpest line first.
+				type depCandidate struct {
+					rank int
+					key  string
+					f    Finding
+				}
+				var cand []depCandidate
+				depAdd := func(rank int, key string, f Finding) {
+					cand = append(cand, depCandidate{rank: rank, key: key, f: f})
 				}
 
 				nowKeys := make([]string, 0, len(now))
@@ -1984,22 +2032,36 @@ func evaluateScan(in scanInput) *RepoScan {
 					name, version := splitDepKey(dep)
 					was, existed := prev[dep]
 					switch {
-					case existed && was != now[dep]:
-						depAdd(Finding{
+					case existed && was != now[dep] && isIntegrity(was) && isIntegrity(now[dep]):
+						depAdd(rankRepublished, dep, Finding{
 							Axis: AxisDelta, Branch: branch, Path: path,
 							Weight: weigh(wDeltaRepublishedDep),
-							Reason: fmt.Sprintf("%s is still pinned at %s in %s, but its recorded content changed since the last scan (%s → %s) — the same version shipping different bytes is not an upgrade%s",
+							Reason: fmt.Sprintf("%s is still pinned at %s in %s, but its integrity hash changed since the last scan (%s → %s) — the same version shipping different bytes is not an upgrade%s",
 								name, version, path, shortIntegrity(was), shortIntegrity(now[dep]), stale),
 						})
+					case existed && was != now[dep]:
+						// The value moved, but at least one side is a
+						// `resolved` URL or the no-integrity sentinel
+						// rather than a hash. Those say where a
+						// dependency came FROM, not what it contains, so
+						// a registry or mirror change would otherwise
+						// have scored 4 as a republish — the heaviest
+						// thing this axis says, on evidence that cannot
+						// support it.
+						depAdd(rankSourceMoved, dep, Finding{
+							Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
+							Reason: fmt.Sprintf("%s is still pinned at %s in %s and its recorded source changed (%s → %s); neither side is an integrity hash, so this says the dependency moved, not that its content did",
+								name, version, path, shortIntegrity(was), shortIntegrity(now[dep])),
+						})
 					case !existed && !prevNames[name]:
-						depAdd(Finding{
+						depAdd(rankNewInstallScript, dep, Finding{
 							Axis: AxisDelta, Branch: branch, Path: path,
 							Weight: weigh(wDeltaNewInstallScript),
 							Reason: fmt.Sprintf("%s runs code at install and did not at the last scan, now at %s per %s%s",
 								name, version, path, stale),
 						})
 					case !existed:
-						depAdd(Finding{
+						depAdd(rankBumped, dep, Finding{
 							Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
 							Reason: fmt.Sprintf("%s already ran code at install and is now at %s, per %s", name, version, path),
 						})
@@ -2023,17 +2085,29 @@ func evaluateScan(in scanInput) *RepoScan {
 					if nowNames[name] {
 						continue
 					}
-					depAdd(Finding{
+					depAdd(rankDeparted, dep, Finding{
 						Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
 						Reason: fmt.Sprintf("%s no longer runs code at install; it was at %s, per %s", name, version, path),
 					})
 				}
 
-				if capped > 0 {
+				sort.SliceStable(cand, func(i, j int) bool {
+					if cand[i].rank != cand[j].rank {
+						return cand[i].rank < cand[j].rank
+					}
+					return cand[i].key < cand[j].key
+				})
+				for i, c := range cand {
+					if i >= maxDepFindingsPerPath {
+						break
+					}
+					add(c.f)
+				}
+				if over := len(cand) - maxDepFindingsPerPath; over > 0 {
 					add(Finding{
 						Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
-						Reason: fmt.Sprintf("%d further change(s) to the dependency install surface of %s are not listed — the report shows the first %d",
-							capped, path, maxDepFindingsPerPath),
+						Reason: fmt.Sprintf("%d further change(s) to the dependency install surface of %s are not listed — the report shows the %d most serious",
+							over, path, maxDepFindingsPerPath),
 					})
 				}
 			}

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -2320,15 +2320,20 @@ func TestTheHistoryAdoptsAPreExistingBaseline(t *testing.T) {
 // lockBranch builds a branch carrying one lockfile whose facts are
 // whatever the caller wants recorded for it.
 func lockBranch(name string, isDefault bool, sha string, lf *lockfileFacts) (scanBranch, map[string]blobAnalysis) {
-	return scanBranch{
+	// Built into variables rather than returned as two composite
+	// literals in one return statement: gofmt 1.25 and 1.27 indent that
+	// construct differently, and CI runs the version in go.mod.
+	br := scanBranch{
 		Prov: provBranch(name, isDefault),
 		Matches: []ignitionMatch{
 			{Path: "package-lock.json", Size: 400, BlobSHA: sha,
 				Rule: ignitionRule{Glob: "package-lock.json", Class: classLockfile, Weight: 0}},
 		},
-	}, map[string]blobAnalysis{
+	}
+	blobs := map[string]blobAnalysis{
 		sha: {Size: 400, Fetched: lf != nil, Lockfile: lf},
 	}
+	return br, blobs
 }
 
 // A side branch's lockfile mostly re-reports the open pull requests, so

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -2314,3 +2314,111 @@ func TestTheHistoryAdoptsAPreExistingBaseline(t *testing.T) {
 		t.Errorf("a return to the adopted content was not noticed: %v", deltaFindings(back))
 	}
 }
+
+// --- Axis 1b: what the fingerprint records ------------------------------
+
+// lockBranch builds a branch carrying one lockfile whose facts are
+// whatever the caller wants recorded for it.
+func lockBranch(name string, isDefault bool, sha string, lf *lockfileFacts) (scanBranch, map[string]blobAnalysis) {
+	return scanBranch{
+		Prov: provBranch(name, isDefault),
+		Matches: []ignitionMatch{
+			{Path: "package-lock.json", Size: 400, BlobSHA: sha,
+				Rule: ignitionRule{Glob: "package-lock.json", Class: classLockfile, Weight: 0}},
+		},
+	}, map[string]blobAnalysis{
+		sha: {Size: 400, Fetched: lf != nil, Lockfile: lf},
+	}
+}
+
+// A side branch's lockfile mostly re-reports the open pull requests, so
+// the scan does not read one — but the fingerprint must refuse it on its
+// own terms too. Recording a side branch here would diff the default
+// branch's surface against a feature branch's on the next scan, which
+// invents a change out of an ordinary merge.
+func TestDepsAreRecordedOnlyForTheDefaultBranch(t *testing.T) {
+	main, blobs := lockBranch("main", true, "l1",
+		&lockfileFacts{Supported: true, Packages: map[string]string{"fsevents@2.3.3": "sha512-a"}})
+	next, sideBlobs := lockBranch("next", false, "l2",
+		&lockfileFacts{Supported: true, Packages: map[string]string{"esbuild@0.28.1": "sha512-b"}})
+	for k, v := range sideBlobs {
+		blobs[k] = v
+	}
+
+	got := evaluateScan(scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 2,
+		Branches: []scanBranch{main, next}, Blobs: blobs, Now: time.Now(),
+	})
+
+	deps := got.Fingerprint.Deps
+	if len(deps) != 1 {
+		t.Fatalf("Deps = %v, want exactly the default branch's entry", deps)
+	}
+	want := fingerprintKey("main", "package-lock.json")
+	if _, ok := deps[want]; !ok {
+		t.Errorf("Deps keys = %v, want %q", deps, want)
+	}
+}
+
+// "Read it, and nothing in this repository runs code at install" is a
+// measurement. "We never compared" is not. They must not render alike,
+// so the empty set is recorded as present-and-empty — otherwise the
+// first scan that manages to read the file reports every install-script
+// package as newly appeared.
+func TestAReadLockfileWithNothingFlaggedRecordsAnEmptySetNotNothing(t *testing.T) {
+	main, blobs := lockBranch("main", true, "l1",
+		&lockfileFacts{Supported: true, Packages: map[string]string{}})
+
+	got := evaluateScan(scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 1,
+		Branches: []scanBranch{main}, Blobs: blobs, Now: time.Now(),
+	})
+
+	set, ok := got.Fingerprint.Deps[fingerprintKey("main", "package-lock.json")]
+	if !ok {
+		t.Fatalf("a lockfile that was read must be recorded, got %v", got.Fingerprint.Deps)
+	}
+	if set == nil || len(set) != 0 {
+		t.Errorf("recorded surface = %v, want a present but empty set", set)
+	}
+}
+
+// The mirror image: a lockfile whose facts we do not have must leave no
+// entry at all, so the next scan says "first comparison" rather than
+// diffing against an emptiness it never measured.
+func TestALockfileWithoutUsableFactsRecordsNoDeps(t *testing.T) {
+	cases := map[string]*lockfileFacts{
+		"never read":           nil,
+		"schema cannot answer": {Supported: false, Note: "lockfileVersion 1"},
+		"content was not JSON": {Unparsed: true, Note: "undecodable"},
+	}
+	for name, lf := range cases {
+		t.Run(name, func(t *testing.T) {
+			main, blobs := lockBranch("main", true, "l1", lf)
+			got := evaluateScan(scanInput{
+				Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 1,
+				Branches: []scanBranch{main}, Blobs: blobs, Now: time.Now(),
+			})
+			if len(got.Fingerprint.Deps) != 0 {
+				t.Errorf("Deps = %v, want nothing recorded", got.Fingerprint.Deps)
+			}
+		})
+	}
+}
+
+// The recorded set must not alias the scan's own parse: the fingerprint
+// is persisted and outlives the scanInput it came from.
+func TestTheRecordedSurfaceIsACopy(t *testing.T) {
+	facts := &lockfileFacts{Supported: true, Packages: map[string]string{"fsevents@2.3.3": "sha512-a"}}
+	main, blobs := lockBranch("main", true, "l1", facts)
+
+	got := evaluateScan(scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main", BranchesTotal: 1,
+		Branches: []scanBranch{main}, Blobs: blobs, Now: time.Now(),
+	})
+	facts.Packages["fsevents@2.3.3"] = "sha512-TAMPERED"
+
+	if got := got.Fingerprint.Deps[fingerprintKey("main", "package-lock.json")]["fsevents@2.3.3"]; got != "sha512-a" {
+		t.Errorf("the fingerprint aliased the parse: %q", got)
+	}
+}

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -99,6 +99,14 @@ func TestMatchIgnition(t *testing.T) {
 		{".github/workflows/ci.yml", true, classCI},
 		{".vscode/tasks.json", true, classEditorTask},
 		{"package.json", true, classPackage},
+		{"package-lock.json", true, classLockfile},
+		{"npm-shrinkwrap.json", true, classLockfile},
+		// npm-only is a measured decision, not an omission: pnpm dropped
+		// requiresBuild at lockfileVersion 9 and yarn never declared an
+		// equivalent, so matching these would promise a comparison the
+		// format cannot support. See lockfile.go.
+		{"pnpm-lock.yaml", false, ""},
+		{"yarn.lock", false, ""},
 		{".devcontainer/devcontainer.json", true, classDevcontain},
 		// Nested path must NOT match a single-segment glob.
 		{".github/workflows/nested/ci.yml", false, ""},
@@ -115,6 +123,54 @@ func TestMatchIgnition(t *testing.T) {
 				t.Errorf("class = %q, want %q", rule.Class, tt.wantClass)
 			}
 		})
+	}
+}
+
+// A lockfile is large and full of base64 by construction, and neither
+// fact says anything. Axis 2 scores exactly those two shapes, so without
+// an exemption adding lockfiles to the catalog would have flagged every
+// ordinary JavaScript repository — 343 KB in axios/axios and 437 KB in
+// npm/cli, both well past oversizeThreshold (measured 2026-09-08).
+func TestALockfileIsNeverScoredForItsSizeOrItsHashes(t *testing.T) {
+	const lockSize = 437 * 1024
+	in := scanInput{
+		Owner: "o", Name: "r", DefaultBranch: "main",
+		BranchesTotal: 1,
+		Branches: []scanBranch{
+			{
+				Prov: provBranch("main", true),
+				Matches: []ignitionMatch{
+					{Path: "package-lock.json", Size: lockSize, BlobSHA: "l", Rule: ignitionRule{Glob: "package-lock.json", Class: classLockfile, Weight: 0}},
+				},
+			},
+		},
+		Blobs: map[string]blobAnalysis{
+			// Markers are set deliberately, even though production never
+			// fetches a lockfile's content: the exemption belongs to the
+			// scoring engine, so it must hold whatever the analysis says.
+			"l": {Size: lockSize, Fetched: true, IsText: true, Markers: []string{"long base64 run"}},
+		},
+	}
+	got := evaluateScan(in)
+
+	for _, f := range got.Findings {
+		if f.Axis == AxisBlob {
+			t.Errorf("a lockfile must not produce a blob-anomaly finding, got %q", f.Reason)
+		}
+	}
+	if got.Score != 0 || got.Verdict != VerdictClean {
+		t.Fatalf("verdict = %v score = %d, want clean/0 (findings %+v)", got.Verdict, got.Score, got.Findings)
+	}
+	// It is still inventory: the user sees the surface, it just does not
+	// move the verdict on its own.
+	var listed bool
+	for _, f := range got.IgnitionInventory() {
+		if f.Path == "package-lock.json" {
+			listed = true
+		}
+	}
+	if !listed {
+		t.Error("the lockfile must still appear in the ignition inventory")
 	}
 }
 

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -594,6 +594,40 @@ func viewRepoScanCmd(r github.Repo) tea.Cmd {
 	}
 }
 
+// baselineToFingerprint and fingerprintToBaseline convert between the
+// on-disk baseline shape (internal/config) and the domain shape
+// (internal/github). This layer owns them because it is the only one
+// that imports both packages.
+//
+// They are named functions rather than two struct literals inside
+// fetchRepoScanCmd for one reason: they are two field lists that must
+// stay in step, sitting either side of a network call, and a field added
+// to one of them is a scan that silently forgets something. Extracted,
+// the round trip is assertable without a network — and a test does
+// assert it field by field, plus that neither struct has grown a field
+// the other lacks.
+func baselineToFingerprint(fp config.BaselineFingerprint) github.ScanFingerprint {
+	return github.ScanFingerprint{
+		CapturedAt: fp.CapturedAt,
+		Verdict:    fp.Verdict,
+		Ignition:   fp.Ignition,
+		Signed:     fp.Signed,
+		Seen:       fp.Seen,
+		Deps:       fp.Deps,
+	}
+}
+
+func fingerprintToBaseline(fp github.ScanFingerprint) config.BaselineFingerprint {
+	return config.BaselineFingerprint{
+		CapturedAt: fp.CapturedAt,
+		Verdict:    fp.Verdict,
+		Ignition:   fp.Ignition,
+		Signed:     fp.Signed,
+		Seen:       fp.Seen,
+		Deps:       fp.Deps,
+	}
+}
+
 // scanFetchTimeout is generous: a scan is a bounded REST fan-out (one
 // tree per branch + a few blobs) on top of one GraphQL round-trip, so
 // it can run longer than a single detail query on a many-branched
@@ -613,13 +647,8 @@ func fetchRepoScanCmd(client *github.Client, owner, name, url string, accountRep
 		store := config.LoadBaselines(baselinePath)
 		var prev *github.ScanFingerprint
 		if fp, ok := store.Repos[key]; ok {
-			prev = &github.ScanFingerprint{
-				CapturedAt: fp.CapturedAt,
-				Verdict:    fp.Verdict,
-				Ignition:   fp.Ignition,
-				Signed:     fp.Signed,
-				Seen:       fp.Seen,
-			}
+			read := baselineToFingerprint(fp)
+			prev = &read
 		}
 
 		scan, err := client.FetchRepoScan(ctx, owner, name, github.ScanOptions{
@@ -636,13 +665,7 @@ func fetchRepoScanCmd(client *github.Client, owner, name, url string, accountRep
 			if store.Repos == nil {
 				store.Repos = map[string]config.BaselineFingerprint{}
 			}
-			store.Repos[key] = config.BaselineFingerprint{
-				CapturedAt: scan.Fingerprint.CapturedAt,
-				Verdict:    scan.Fingerprint.Verdict,
-				Ignition:   scan.Fingerprint.Ignition,
-				Signed:     scan.Fingerprint.Signed,
-				Seen:       scan.Fingerprint.Seen,
-			}
+			store.Repos[key] = fingerprintToBaseline(scan.Fingerprint)
 			_ = config.SaveBaselines(baselinePath, store)
 		}
 

--- a/internal/ui/scan_fingerprint_test.go
+++ b/internal/ui/scan_fingerprint_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gfazioli/octoscope/internal/config"
+	"github.com/gfazioli/octoscope/internal/github"
+)
+
+// The domain shape and the on-disk shape are two field lists that have
+// to stay in step, and they live in two packages neither of which can
+// see the other. A field added to one and forgotten in the other is a
+// scan that silently stops recording something — it compiles, it passes
+// every other test, and the loss only shows up as a delta that never
+// fires. So the parity is asserted by name rather than trusted.
+func TestTheTwoFingerprintShapesStayInStep(t *testing.T) {
+	names := func(v any) map[string]bool {
+		typ := reflect.TypeOf(v)
+		out := map[string]bool{}
+		for i := 0; i < typ.NumField(); i++ {
+			out[typ.Field(i).Name] = true
+		}
+		return out
+	}
+	domain := names(github.ScanFingerprint{})
+	disk := names(config.BaselineFingerprint{})
+
+	for f := range domain {
+		if !disk[f] {
+			t.Errorf("github.ScanFingerprint.%s has no counterpart in config.BaselineFingerprint — it will never be persisted", f)
+		}
+	}
+	for f := range disk {
+		if !domain[f] {
+			t.Errorf("config.BaselineFingerprint.%s has no counterpart in github.ScanFingerprint — it will never be read back", f)
+		}
+	}
+}
+
+// And parity of names is not parity of wiring: both conversions have to
+// actually carry every field. The fixture is checked for having no zero
+// field first, because a round trip of an empty struct is byte-perfect
+// and proves nothing at all.
+func TestFingerprintConversionCarriesEveryField(t *testing.T) {
+	when := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	in := github.ScanFingerprint{
+		CapturedAt: when,
+		Verdict:    "watch",
+		Ignition:   map[string]string{"main\x00.claude/settings.json": "abc123"},
+		Signed:     map[string]bool{"main": true},
+		Seen:       map[string]map[string]time.Time{"main\x00.claude/settings.json": {"abc123": when}},
+		Deps:       map[string]map[string]string{"main\x00package-lock.json": {"fsevents@2.3.3": "sha512-a"}},
+	}
+
+	v := reflect.ValueOf(in)
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).IsZero() {
+			t.Fatalf("fixture leaves %s zero; a round trip that carries nothing would still pass",
+				v.Type().Field(i).Name)
+		}
+	}
+
+	if got := baselineToFingerprint(fingerprintToBaseline(in)); !reflect.DeepEqual(got, in) {
+		t.Errorf("a field was dropped in the round trip:\n got %+v\nwant %+v", got, in)
+	}
+}

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -84,7 +84,26 @@ var whatsNew032 = whatsNewEntry{
 	},
 }
 
+var whatsNew033 = whatsNewEntry{
+	headline: "The part of a pull request nobody reads line by line.",
+	items: []whatsNewItem{
+		{
+			title: "A dependency that starts running code at install",
+			desc:  "The scan now reads your npm lockfile and compares the subset of dependencies that execute code at install time. One that did not and now does is a finding. The same version shipping different content is a stronger one — no upgrade explains it. An ordinary bump scores nothing.",
+		},
+		{
+			title: "Why the subset, and not the lockfile",
+			desc:  "Over the last 20 lockfile revisions of axios, npm/cli and undici — 57 in all — the file churned constantly and the install-script subset moved twice. The same version was never republished once. That measured base rate is what lets the sharp case carry weight instead of teaching you to skip it.",
+		},
+		{
+			title: "It says what it could not compare",
+			desc:  "npm only, and the report tells you so. A pnpm or Yarn lockfile, no lockfile at all, one too large to read, a schema nobody has measured — each gets its own line saying your dependency surface was not compared. Silence would look exactly like nothing running code at install.",
+		},
+	},
+}
+
 var whatsNew = map[string]whatsNewEntry{
+	"0.33.0": whatsNew033,
 	"0.32.0": whatsNew032,
 	// 0.31.1 shows 0.31.0's highlights, on the 0.30.1 precedent below.
 	// The tab renders only the running version, and this patch is a


### PR DESCRIPTION
## What & why

The whole of #108 — the parser, the catalog rows, the read, the fingerprint
that records it, the delta that compares it, the disclosures that say what it
could not cover, and the docs. All seven steps of the plan.

The delta axis (#68) notices when something that auto-executes *in the
repository's own source* changes. It cannot see a dependency that starts
executing on install: that is a lockfile diff, and a lockfile diff is the one
part of a pull request nobody reads line by line. It needs no scope the scan
does not already have, because the lockfile is a blob in the repository's own
tree.

**The axis fires from this PR on.** Three cases, keyed by `name@version`
because that is what separates them:

| Case | Meaning | Weight |
|---|---|---|
| a name that carried no install script now does | a dependency began executing code at install | 2 |
| same `name@version`, different recorded content | that version was republished | 4 |
| a known install-script package at a new version | an ordinary bump | 0 — inventory |
| an install-script package disappeared | an improvement | 0 |

4 lands on `watch` alone and reaches `suspicious` only with corroboration — the
same posture as `wDeltaNewIgnition`, and it can carry that weight because the
base rate below was measured rather than guessed. octoscope never looks at the
registry, so the claim stays *this version's content changed*, never *this
dependency is malicious*.

### Everything it could not compare says so

Every weight-0 line here says the same kind of thing, because the alternative
is silence and silence is indistinguishable from *nothing here runs code at
install*. A reader told nothing assumes coverage.

From the delta: a baseline recorded before this axis existed; a lockfile read
now and not last time; a surface recorded before and not measured now (nothing
else notices — a lockfile is weight 0, so its path never enters `Ignition`);
and more changes than the report will list, with the number stated.

From the scan itself: a lockfile seen and not read, carrying the reason
recorded at the moment it was known (oversized, unfetchable, or the file npm
ignores while a shrinkwrap sits beside it); a lockfile read with something to
declare (a schema that cannot answer, content that would not decode, an
ambiguous duplicate) passed through verbatim from where the fact was
established; a lockfile from a package manager this scan does not read; and an
npm project committing no lockfile at all.

That third one needed data the scan was not keeping. pnpm, Yarn and Bun
lockfiles are deliberately **not** in `ignitionCatalog` — a catalog row is a
claim that a path auto-executes, and they make no such claim, which
`TestMatchIgnition` pins. The tree walk observes them separately, on
`scanBranch.OtherLockfiles`, making no ignition claim and never reaching the
inventory. A pnpm repository is the likeliest place for this axis to look like
coverage when it is not, and it was silent there.

Two conditions keep the last line from becoming noise: it needs a
`package.json` (*no npm lockfile* on a Go repository is not a disclosure), and
it stays quiet when a foreign lockfile is present, because that case has just
said the same thing more precisely.

### Docs

`docs/design/supply-chain-scan.md` gains `## Axis 1b — dependency install
surface` between Axis 1 and Axis 2, carrying the measurements above rather than
the conclusions drawn from them. *Baseline / delta* gains the second record the
fingerprint now holds; *Honest gaps* gains three (npm-only, `--ignore-scripts`
undetected, a lockfile past the blob cap reading as *not compared*). The
README, the guide page and the landing page each say it at their own altitude,
and all three say what was **not** compared — describing this feature only by
what it catches would misrepresent it. The what's-new entry is filed under
0.33.0, the next minor; if the release lands on another number it is a
rename.

### npm only, and it is a measurement rather than a starting point

Per format, measured 2026-09-08:

| Format | Declares install-time execution? | Evidence |
|---|---|---|
| `package-lock.json` v2/v3 | **yes** — `"hasInstallScript": true` per entry | `axios/axios`: 684 packages, 2 flagged |
| `package-lock.json` v1 | no — no `packages` map | format |
| `npm-shrinkwrap.json` | yes — same schema | format |
| `pnpm-lock.yaml` v6 | yes — `requiresBuild: true` | `vitejs/vite` @ `v4.5.0`: 95 occurrences |
| `pnpm-lock.yaml` v9 | **no** — `requiresBuild` is gone | `vitejs/vite` @ `main`: 0 occurrences |
| `yarn.lock` (v1 and berry) | no per-entry flag | `facebook/react`, `babel/babel` |
| `go.sum` | n/a — the Go toolchain runs no install scripts | — |

So pnpm and yarn are deliberately absent: building on `requiresBuild` would
ship a rule that decays, and `hasBin` is not a substitute — a bin entry runs
when the developer chooses to run it, which is not this threat. A repo whose
only lockfile is one of those will get an explicit weight-0 line saying its
dependency surface was *not* compared (step 6), never silence.

### The noise bet, also measured

Keeping only the install-script subset rather than the file: over the last 20
lockfile revisions of `axios/axios`, `npm/cli` and `nodejs/undici`, the subset
changed in **2 of 57** revisions, and the sharp case — same `name@version`,
different `integrity` — happened **zero** times. That base rate is what makes
it safe to weight a republish meaningfully later, rather than training the
reader to ignore the axis.

### Two decisions the plan did not have

**The Axis-2 exemption** (step 2). A real lockfile runs 343 KB (`axios/axios`)
to 437 KB (`npm/cli`) and every entry carries a base64 integrity hash, so
`wBlobOversized` and `wBlobObfuscated` would both have fired on every ordinary
JavaScript repository — and `oversizeThreshold` is checked against the tree
entry's size, so it would have scored with no blob fetched at all.

**`lockfileReadOrder`** (step 3). A budget of one forces a choice when a repo
carries both files, and npm decides it: "If both `package-lock.json` and
`npm-shrinkwrap.json` are present in the root of a project,
`npm-shrinkwrap.json` will take precedence and `package-lock.json` will be
ignored" ([npm docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json)).
Reading the ignored file would describe an install surface npm never uses. The
tie-break on path is the determinism guard: tree order is GitHub's to choose,
and a pick that flipped between two scans would replace the recorded dependency
set wholesale and manufacture a republish finding for every entry in it.

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `refactor` / `perf` — no behaviour change
- [ ] `docs` / `chore` / `test`

## Checklist

- [x] `gofmt -w .` clean and `go vet ./...` passes
- [x] `go test ./...` passes (168 in `internal/github`, green everywhere;
      also `go test -race ./...`)
- [x] Commit messages follow Conventional Commits
- [x] Keeps octoscope **read-only** — one extra `GET /git/blobs/:sha` per scan
      at most, on the default branch only
- [x] Built locally (`make build`) — but **not** exercised in the running app,
      deliberately: this PR changes nothing a user can see, so there is nothing
      to look at until the delta lands in step 5

## Notes for reviewers

The three things most worth a second pair of eyes:

1. **`maxLockfileFetches = 1` is counted separately from `maxBlobFetches`, and
   that separation is the load-bearing claim.** `maxBlobFetches` belongs to
   Axis 2 — the axis that actually catches a payload — and a lockfile is one
   file per branch on any JavaScript repo, so with `maxScanBranches` at 20 the
   lockfiles alone would have swallowed all twelve reads. `TestTheLockfileRead
   NeverSpendsTheAxis2Budget` scans the same tree with and without a lockfile
   and compares the SHAs Axis 2 actually pulled; the fixture saturates the cap
   so it really binds, and the lockfile sits mid-tree so a leak cannot hide at
   the end.
2. **`Lockfile == nil` covers four distinct states** — side branch, over
   `maxBlobScanBytes`, not the authoritative file, failed fetch — and step 6
   has to disclose them apart. Each one now says which it is, in
   `blobAnalysis.LockfileUnread`; the first version of this PR left them to be
   re-derived downstream from `Size` and the branch, and two of the four are
   not separable that way.
3. **The cap on findings per lockfile path.** `maxDepFindingsPerPath` is not
   tidiness: the lockfile is attacker-controlled and bounded only by
   `maxBlobScanBytes`, which at a minimal entry apiece is tens of thousands of
   packages. Past the cap the count is stated and the rest are not listed.
4. **`gatherBlobs` is extracted from `FetchRepoScan`** rather than left inline.
   A budget is arithmetic about API calls, and counting calls through a whole
   scan is not something a test can reasonably do. The Axis-2 half is moved
   verbatim.

Known gaps, deliberate and documented in the code: a lockfile over
`maxBlobScanBytes` is *declared unread* rather than silently skipped (a
follow-up issue, not a cap raise here); a user who installs with
`--ignore-scripts` is not exposed the way this axis assumes; and octoscope
never looks at the registry, so the claim is only ever *your dependencies'
auto-execute surface changed*, never that a dependency is malicious.

## Review round

An adversarial pass by Codex found four things, all fixed in
`74f5a13` + `1ad031d`, each with its own test and each mutation-checked:

- **Precedence was a preference.** The budget counted *successful* reads, so an
  oversized or unfetchable `npm-shrinkwrap.json` fell through to the
  `package-lock.json` npm ignores — reporting a delta about the wrong file,
  under a comment asserting precedence. It counts candidates now.
- **A lockfile could suppress Axis-2 analysis of another file with the same
  content**, via a blob SHA marked in a shared dedupe map.
- **`lockfileVersion` was decoded and never read**, so any future schema with a
  `packages` map would have been answered from an unverified field.
- **The ambiguous-duplicate reduction was lossy**: keeping the lowest of the
  conflicting integrities hid every change confined to the others — dropping a
  republish, which is the sharpest case this axis has.

Two of its findings were not defects and are left alone: the delta is
unimplemented *because it was steps 4-7* — steps 4 and 5 are in this PR now, and the `bySHA` iteration order it
flagged is a real but pre-existing nondeterminism that predates this branch —
worth its own issue, not this PR. One is a documented trade-off: a workspace
entry is keyed by its install path, so moving a workspace reads as a new
package.

Refs #108
