### PR TITLE
chore(release): 0.33.0 — the part of a PR nobody reads line by line

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ Each release also carries the bare executables next to the archives, named
 `octoscope_<version>_<os>-<arch>`, for when unpacking is the awkward part:
 
 ```bash
-VERSION=0.32.0   # or whatever the latest release says
+VERSION=0.33.0   # or whatever the latest release says
 curl -fsSL -o octoscope \
   "https://github.com/gfazioli/octoscope/releases/download/v${VERSION}/octoscope_${VERSION}_linux-amd64" \
   && chmod +x octoscope

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -46,7 +46,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.32.0</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.33.0</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1298,7 +1298,7 @@
                      keeps #version-pill, which the release-API fetch
                      below writes its text into. -->
                 <a class="version-link" href="guide/releases.html">
-                    <span class="version-tag" id="version-pill">0.32.0</span>
+                    <span class="version-tag" id="version-pill">0.33.0</span>
                     <span class="version-more">what&rsquo;s new &rarr;</span>
                 </a>
             </div>

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 // showing up only in local builds. Measured before the change:
 // `go build -ldflags "-X main.version=9.9.9-fromtag"` still printed
 // 0.31.0.
-var version = "0.32.0"
+var version = "0.33.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
## What & why

Release prep for 0.33.0. #156 shipped the feature and its What's new entry but not the version bump, so this is the dedicated prep PR — the pattern v0.22.0 used (#39 feature, #40 prep).

Four hand-written surfaces, three of which `version_test.go` keeps honest:

| Surface | What a stale value does |
|---|---|
| `main.go` `var version` | the number the binary reports |
| `docs/index.html` hero pill | the landing's inline fallback, rendered **only when the Releases API fetch fails** — i.e. when nobody is watching |
| `docs/guide/docs.js` sidebar brand | same deal, on the guide |
| `README.md` curl snippet | embeds the version in an asset name, so an old value does not 404 — it **installs an old octoscope** |

The bump was not written from a checklist: `main.go` went first and the test named the other three. That is the gate doing its job, which is worth saying because it was added for exactly this (#121).

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `refactor` / `perf` — no behaviour change
- [x] `docs` / `chore` / `test`

## Checklist

- [x] `gofmt -w .` clean and `go vet ./...` passes — run under the toolchain `go.mod` pins (1.25.13), which is what CI runs, not this machine's 1.27.1
- [x] `go test ./...` passes, including `TestVersionSurfacesAgree`
- [x] Commit messages follow Conventional Commits
- [x] Keeps octoscope read-only

## Notes for reviewers

No behaviour change: four string literals. The hero screenshot refresh is step 6 of the release checklist and comes after this merges, so the tag tree includes it.

Refs #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documented version from 0.32.0 to 0.33.0 across download instructions and documentation version displays.

- **Updates**
  - Updated the application’s reported default version to 0.33.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->