### PR TITLE
fix(scan): a path with two contents rendered in map order

### DIFF
--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1175,14 +1175,16 @@ func evaluateScan(in scanInput) *RepoScan {
 			continue
 		}
 
-		// Sorted, not ranged. Go randomises map iteration, and every
-		// finding below carries a weight fixed by its rule — so a path
-		// with two distinct contents emits two findings of EQUAL weight,
-		// which ScoredFindings' stable sort then faithfully leaves in
-		// whatever order the map seed produced. The scan is meant to be
-		// re-run and the two reports compared by eye, and a block that
-		// shuffles is noise exactly where the reader looks for change.
-		// Same reason ignKeys, sigBranches and depKeys are sorted below.
+		// Sorted, not ranged. Go randomises map iteration, and the weight
+		// of each finding below is fixed by the ANOMALY (oversized 4,
+		// obfuscated or binary 5) rather than by the content that tripped
+		// it — so two distinct contents tripping the same anomaly on one
+		// path emit two findings of EQUAL weight, which ScoredFindings'
+		// stable sort then faithfully leaves in whatever order the map
+		// seed produced. The scan is meant to be re-run and the two
+		// reports compared by eye, and a block that shuffles is noise
+		// exactly where the reader looks for change. Same reason ignKeys,
+		// sigBranches and depKeys are sorted below.
 		shas := make([]string, 0, len(a.bySHA))
 		for sha := range a.bySHA {
 			shas = append(shas, sha)

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1184,9 +1184,11 @@ func evaluateScan(in scanInput) *RepoScan {
 		// hits, or one of each, since those are distinct conditions sharing
 		// one constant. An oversized finding never collides with either,
 		// their weights differ. ScoredFindings sorts on weight alone and is
-		// stable, so it preserves whatever order this block emitted — which
-		// is why the order has to be decided here: unsorted, every colliding
-		// pair would reach the report in the order the map seed produced.
+		// stable: it reorders by descending weight, and within one weight it
+		// keeps the order of emission — so for a colliding pair the report
+		// shows exactly the order chosen here, which is why it has to be
+		// chosen here at all. Unsorted, that is the order the map seed
+		// produced.
 		// The scan is meant to be re-run and the two reports compared by
 		// eye, and a block that shuffles is noise exactly where the reader
 		// looks for change. Same reason ignKeys, sigBranches and depKeys

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1178,11 +1178,13 @@ func evaluateScan(in scanInput) *RepoScan {
 		// Sorted, not ranged. Go randomises map iteration, and the weight
 		// of each finding below is fixed by the ANOMALY rather than by the
 		// content that tripped it — oversized 4, obfuscation markers 5,
-		// binary-in-a-text-file 5. So any two findings from this block can
-		// collide at EQUAL weight: two oversized contents at 4, and — note
-		// — a marker hit against a binary hit at 5, which are two distinct
-		// conditions sharing one constant. ScoredFindings' stable sort then
-		// faithfully leaves every such pair in whatever order the map seed
+		// binary-in-a-text-file 5. Two findings collide at EQUAL weight in
+		// exactly two ways: two oversized contents, at 4; and any pair
+		// drawn from {markers, binary}, at 5 — two marker hits, two binary
+		// hits, or one of each, since those are distinct conditions sharing
+		// one constant. An oversized finding never collides with either,
+		// their weights differ. ScoredFindings' stable sort then faithfully
+		// leaves every colliding pair in whatever order the map seed
 		// produced. The scan is meant to be re-run and the two
 		// reports compared by eye, and a block that shuffles is noise
 		// exactly where the reader looks for change. Same reason ignKeys,

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1175,7 +1175,22 @@ func evaluateScan(in scanInput) *RepoScan {
 			continue
 		}
 
-		for sha, carriers := range a.bySHA {
+		// Sorted, not ranged. Go randomises map iteration, and every
+		// finding below carries a weight fixed by its rule — so a path
+		// with two distinct contents emits two findings of EQUAL weight,
+		// which ScoredFindings' stable sort then faithfully leaves in
+		// whatever order the map seed produced. The scan is meant to be
+		// re-run and the two reports compared by eye, and a block that
+		// shuffles is noise exactly where the reader looks for change.
+		// Same reason ignKeys, sigBranches and depKeys are sorted below.
+		shas := make([]string, 0, len(a.bySHA))
+		for sha := range a.bySHA {
+			shas = append(shas, sha)
+		}
+		sort.Strings(shas)
+
+		for _, sha := range shas {
+			carriers := a.bySHA[sha]
 			ba := in.Blobs[sha]
 			anomalous := false
 			if ba.Size > oversizeThreshold || a.size > oversizeThreshold {

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1183,12 +1183,14 @@ func evaluateScan(in scanInput) *RepoScan {
 		// drawn from {markers, binary}, at 5 — two marker hits, two binary
 		// hits, or one of each, since those are distinct conditions sharing
 		// one constant. An oversized finding never collides with either,
-		// their weights differ. ScoredFindings' stable sort then faithfully
-		// leaves every colliding pair in whatever order the map seed
-		// produced. The scan is meant to be re-run and the two
-		// reports compared by eye, and a block that shuffles is noise
-		// exactly where the reader looks for change. Same reason ignKeys,
-		// sigBranches and depKeys are sorted below.
+		// their weights differ. ScoredFindings sorts on weight alone and is
+		// stable, so it preserves whatever order this block emitted — which
+		// is why the order has to be decided here: unsorted, every colliding
+		// pair would reach the report in the order the map seed produced.
+		// The scan is meant to be re-run and the two reports compared by
+		// eye, and a block that shuffles is noise exactly where the reader
+		// looks for change. Same reason ignKeys, sigBranches and depKeys
+		// are sorted below.
 		shas := make([]string, 0, len(a.bySHA))
 		for sha := range a.bySHA {
 			shas = append(shas, sha)

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -1176,12 +1176,14 @@ func evaluateScan(in scanInput) *RepoScan {
 		}
 
 		// Sorted, not ranged. Go randomises map iteration, and the weight
-		// of each finding below is fixed by the ANOMALY (oversized 4,
-		// obfuscated or binary 5) rather than by the content that tripped
-		// it — so two distinct contents tripping the same anomaly on one
-		// path emit two findings of EQUAL weight, which ScoredFindings'
-		// stable sort then faithfully leaves in whatever order the map
-		// seed produced. The scan is meant to be re-run and the two
+		// of each finding below is fixed by the ANOMALY rather than by the
+		// content that tripped it — oversized 4, obfuscation markers 5,
+		// binary-in-a-text-file 5. So any two findings from this block can
+		// collide at EQUAL weight: two oversized contents at 4, and — note
+		// — a marker hit against a binary hit at 5, which are two distinct
+		// conditions sharing one constant. ScoredFindings' stable sort then
+		// faithfully leaves every such pair in whatever order the map seed
+		// produced. The scan is meant to be re-run and the two
 		// reports compared by eye, and a block that shuffles is noise
 		// exactly where the reader looks for change. Same reason ignKeys,
 		// sigBranches and depKeys are sorted below.

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -424,9 +424,21 @@ func TestBlobFindingsDoNotShuffleBetweenRuns(t *testing.T) {
 	if len(first) < 3 {
 		t.Fatalf("fixture produced %d blob findings; it must carry several contents on one path", len(first))
 	}
-	// Fifty runs rather than a handful: with three contents a shuffle has
-	// one chance in six of reproducing the first order by accident, and a
-	// flaky guard against flakiness is worse than none.
+	// The contract, asserted rather than inferred from repetition: sorted
+	// by blob SHA, so sha-0 (512 KiB) comes before sha-1 (768 KiB) before
+	// sha-2 (1.0 MiB). This is the half that cannot pass by luck.
+	for i, want := range []string{"512 KiB", "768 KiB", "1.0 MiB"} {
+		if !strings.Contains(first[i].Reason, want) {
+			t.Errorf("finding %d: want the %s content, got %q", i, want, first[i].Reason)
+		}
+	}
+
+	// The repetition is a tripwire for the other half — that engine order
+	// does not depend on the map seed. It cannot be a proof: Go randomises
+	// map iteration without promising any distribution over the orders, so
+	// an unfixed run can coincide with the sorted one. Fifty runs make that
+	// coincidence a poor bet to rely on; the assertion above is what states
+	// the contract.
 	for i := 0; i < 50; i++ {
 		if got := blobFindings(evaluateScan(in())); !reflect.DeepEqual(got, first) {
 			t.Fatalf("run %d disagrees — the report shuffles between scans of an unchanged repo:\n got %+v\nwant %+v", i, got, first)

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -389,9 +389,15 @@ func TestBlobFindingsDoNotShuffleBetweenRuns(t *testing.T) {
 	in := func() scanInput {
 		var branches []scanBranch
 		blobs := map[string]blobAnalysis{}
+		// The sizes deliberately do NOT ascend with the SHA: sha-0 is the
+		// largest. Ordered by size the block would read 512 KiB, 768 KiB,
+		// 1.0 MiB, so a fixture where the two agree could not tell the
+		// documented contract (sorted by blob SHA) from an accidental
+		// size ordering.
+		sizes := []int{4, 2, 3} // × oversizeThreshold → 1.0 MiB, 512 KiB, 768 KiB
 		for i, name := range []string{"main", "dev", "release"} {
 			sha := fmt.Sprintf("sha-%d", i)
-			size := oversizeThreshold * (i + 2)
+			size := oversizeThreshold * sizes[i]
 			branches = append(branches, scanBranch{
 				Prov: provBranch(name, name == "main"),
 				Matches: []ignitionMatch{{
@@ -425,9 +431,12 @@ func TestBlobFindingsDoNotShuffleBetweenRuns(t *testing.T) {
 		t.Fatalf("fixture produced %d blob findings; it must carry several contents on one path", len(first))
 	}
 	// The contract, asserted rather than inferred from repetition: sorted
-	// by blob SHA, so sha-0 (512 KiB) comes before sha-1 (768 KiB) before
-	// sha-2 (1.0 MiB). This is the half that cannot pass by luck.
-	for i, want := range []string{"512 KiB", "768 KiB", "1.0 MiB"} {
+	// by blob SHA, so sha-0 (1.0 MiB) comes before sha-1 (512 KiB) before
+	// sha-2 (768 KiB) — an order no size comparison would produce. This is
+	// the half that cannot pass by luck. The three sizes are far enough
+	// apart that humanBytes, which rounds, renders them distinctly; two
+	// sizes a byte apart would share a string and identify nothing.
+	for i, want := range []string{"1.0 MiB", "512 KiB", "768 KiB"} {
 		if !strings.Contains(first[i].Reason, want) {
 			t.Errorf("finding %d: want the %s content, got %q", i, want, first[i].Reason)
 		}

--- a/internal/github/scan_test.go
+++ b/internal/github/scan_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -365,6 +366,71 @@ func TestScoredFindingsSortIsStable(t *testing.T) {
 			t.Errorf("weight %d reordered: %q came after %q — the sort is not stable", f.Weight, f.Path, prev)
 		}
 		lastByWeight[f.Weight] = f.Path
+	}
+}
+
+// The stable sort above preserves engine order, which is only a virtue
+// when engine order is itself deterministic. The per-path Axis-2 loop
+// walks `a.bySHA`, a map: a path carrying several distinct contents that
+// each trip the same rule emits findings of EQUAL weight, and the stable
+// sort then faithfully preserves whatever order Go's map seed handed it.
+//
+// It matters for the same reason the delta axis already sorts ignKeys,
+// sigBranches and depKeys: the scan is meant to be re-run and the two
+// reports diffed by eye. A block that shuffles between two scans of an
+// unchanged repository is noise exactly where the reader is looking for
+// a change. Found while reviewing #156, but it predates that branch.
+func TestBlobFindingsDoNotShuffleBetweenRuns(t *testing.T) {
+	now := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+
+	// One path, three branches, three distinct contents, each oversized
+	// by a different amount — three findings with the same path and the
+	// same weight, told apart only by their reason text.
+	in := func() scanInput {
+		var branches []scanBranch
+		blobs := map[string]blobAnalysis{}
+		for i, name := range []string{"main", "dev", "release"} {
+			sha := fmt.Sprintf("sha-%d", i)
+			size := oversizeThreshold * (i + 2)
+			branches = append(branches, scanBranch{
+				Prov: provBranch(name, name == "main"),
+				Matches: []ignitionMatch{{
+					Path: ".claude/hooks/pre-commit", Size: size, BlobSHA: sha,
+					Rule: ignitionRule{Class: classAgentHook, Weight: wIgnitionAgentHook},
+				}},
+			})
+			blobs[sha] = blobAnalysis{Size: size, Fetched: true, IsText: true}
+		}
+		return scanInput{
+			Owner: "o", Name: "r", DefaultBranch: "main",
+			BranchesTotal: len(branches),
+			Branches:      branches,
+			Blobs:         blobs,
+			Now:           now,
+		}
+	}
+
+	blobFindings := func(s *RepoScan) []Finding {
+		var out []Finding
+		for _, f := range s.Findings {
+			if f.Axis == AxisBlob {
+				out = append(out, f)
+			}
+		}
+		return out
+	}
+
+	first := blobFindings(evaluateScan(in()))
+	if len(first) < 3 {
+		t.Fatalf("fixture produced %d blob findings; it must carry several contents on one path", len(first))
+	}
+	// Fifty runs rather than a handful: with three contents a shuffle has
+	// one chance in six of reproducing the first order by accident, and a
+	// flaky guard against flakiness is worse than none.
+	for i := 0; i < 50; i++ {
+		if got := blobFindings(evaluateScan(in())); !reflect.DeepEqual(got, first) {
+			t.Fatalf("run %d disagrees — the report shuffles between scans of an unchanged repo:\n got %+v\nwant %+v", i, got, first)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #157.

`evaluateScan`'s per-path Axis-2 loop walked `a.bySHA`, a map. Every finding in that block carries a weight fixed by its rule, so a path carrying two distinct contents emits two findings of **equal weight** — and `ScoredFindings` sorts with `sort.SliceStable` on `Weight` alone, which faithfully preserves whatever order Go's map seed produced. Two scans of an unchanged repository could render that block differently.

Not cosmetic: the scan is meant to be re-run and the two reports compared by eye. That is the same argument that already made the delta axis sort `ignKeys`, `sigBranches` and `depKeys`, and the argument behind `TestScoredFindingsSortIsStable` — a stable sort only buys determinism when engine order is itself deterministic.

### The fix

Collect the SHAs, `sort.Strings`, iterate. Sorted by SHA rather than by size, mirroring the delta block; ranking by severity *within* one path would change what the report says, which is a separate question.

### The test was measured failing first

A test that passes before the fix proves nothing. Three contents on one path, 50 runs, deep-equal against the first — it reproduced the shuffle on run 2 of the unfixed code:

```
got  [{blob … Weight:4 Reason:oversized for its type: 1.0 MiB} {… 512 KiB} {… 768 KiB}]
want [{blob … Weight:4 Reason:oversized for its type: 512 KiB} {… 768 KiB} {… 1.0 MiB}]
```

The repetition is a tripwire, not a proof: Go randomises map iteration without promising any distribution over the orders, so an unfixed run can coincide with the sorted one and no probability can be quoted. The test therefore also asserts the expected order outright — sha-0 (512 KiB), sha-1 (768 KiB), sha-2 (1.0 MiB) — which is the half that cannot pass by luck. Mutation-tested: removing only `sort.Strings(shas)` fails it on three runs out of three.

### Every other map in the evaluator was checked

Fixing one map and leaving a sibling is a partial fix that looks complete. The sweep:

| Loop | Verdict |
| --- | --- |
| outer per-path loop | `pathOrder`, insertion order — deterministic |
| `ignKeys`, `depKeys`, `goneKeys`, `sigBranches`, `nowKeys`, `prevKeys` | collect-then-`sort.Strings` |
| `prevNames`, `nowNames` | build maps; order-independent |
| `carriers` | sets flags only |
| **`a.bySHA`** | **the only one that reached a `Finding`** — fixed here |

**Checks:** `gofmt` clean under the *pinned* toolchain (`go1.25.13`, what CI runs — the local 1.27.1 is not the gate), `go vet ./...` clean, all eight packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made blob anomaly findings appear in a consistent order across repeated scans, improving report stability and readability.

* **Tests**
  * Added coverage to verify that repeated evaluations produce identical blob findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->