### PR TITLE
fix(scan): a workspace is named, not located

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -168,6 +168,60 @@ change confined to any other location.
 The composite is a **set**, so it discards which location held which value —
 see Honest gaps.
 
+### What names a workspace, and how that was settled
+
+A fetched dependency's entry path *is* its identity — npm resolves it at that
+location, nesting included — so the segment after the last `node_modules/` is
+the name. A **workspace** entry has no such segment: its path says where the
+package lives in the repository, which is not what it is. Keying on the path
+meant a monorepo reorganisation (`packages/cli` → `apps/cli`) reported one
+dependency that started running code at install and another that stopped, for
+a rename that changed nothing about what executes
+([#158](https://github.com/gfazioli/octoscope/issues/158)) — and it arrived as
+a burst, which is the shape most likely to teach a reader to skip the axis.
+
+The entry's declared `name` now wins, and the fallback is the **last path
+segment** rather than the whole path. That second half is the part measurement
+added, and the issue's own proposal did not have it — 2026-09-12, every
+`package-lock.json` reachable at the default branch of seven npm-workspace
+monorepos:
+
+| Repository | workspace entries | carry `name` | `name` ≠ basename | `name` = basename | with an install script | of those, named |
+|---|---|---|---|---|---|---|
+| `npm/cli` | 16 | 6 | 6 | 0 | 0 | — |
+| `open-telemetry/opentelemetry-js` | 56 | 54 | 54 | 0 | 0 | — |
+| `socketio/socket.io` | 13 | 6 | 6 | 0 | 0 | — |
+| `mochajs/mocha` | 1 | 1 | 1 | 0 | 0 | — |
+| `puppeteer/puppeteer` | 10 | 8 | 8 | 0 | 1 | 0 |
+| `microsoft/playwright` | 16 | 7 | 7 | 0 | 6 | 3 |
+| `nestjs/nest` | 3 | 3 | 3 | 0 | 0 | — |
+| **total** | **115** | **85** | **85** | **0** | **7** | **3** |
+
+Two facts decided the shape:
+
+- **npm writes `name` exactly when the path does not already say it.** All 85
+  declared names differ from their directory's basename; not one entry carried
+  a redundant one. So an absent field means the basename *is* the name — and
+  "read `name`, fall back to the path" would have fixed **3 of the 7** real
+  install-script workspaces in the sample, leaving the other four keyed on a
+  path that a move still breaks.
+- **The link entry is not a duplicate.** A workspace also appears as
+  `node_modules/<name>` with `link: true`; all seven such entries carry no
+  `hasInstallScript`, so the parse loop skips them and keying by name adds no
+  second value for the same key.
+
+An **aliased** install (`npm i foo@npm:bar`) is the mirror image — a
+`node_modules/` entry that declares a different name — and the install
+location is deliberately kept there: 20 aliases among 10,881 fetched entries
+in the same sample, none carrying an install script, so reading the alias
+target would rewrite 0.18% of keys to fix nothing this axis can observe.
+
+What remains: renaming the *directory* of a workspace that has no declared
+name moves the key once, until npm rewrites the lockfile — at which point the
+name differs from the new basename and npm records it, and the key becomes
+stable again. And a workspace that shares a name with a registry dependency
+now shares its key, which is correct: npm links it at that same name.
+
 ### What is read, and what that costs
 
 - **The default branch only.** A dependency change that matters lands there; on
@@ -746,9 +800,11 @@ what I looked at", and the report has to say what that was.
   constantly for entirely ordinary reasons — trading a rare miss for routine
   noise is the trade this axis exists to refuse. Pinned by a test, so it stays
   a decision rather than becoming a discovery.
-- **A workspace entry is keyed by its install path**, so moving a workspace
-  reads as one dependency starting to run code at install and another stopping
-  ([#158](https://github.com/gfazioli/octoscope/issues/158)).
+- ~~**A workspace entry is keyed by its install path**~~ — closed by
+  [#158](https://github.com/gfazioli/octoscope/issues/158): the declared
+  `name` wins and the fallback is the last path segment, so a move no longer
+  moves the key. See *What names a workspace* under Axis 1b for the
+  measurement that decided the fallback.
 - **The Axis-1 catalog is a moving target** by nature. It ships as a
   maintained data table, and the scan leans on Axes 2–4 — which do not depend
   on the catalog being exhaustive — for variants using an ignition point

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -170,9 +170,11 @@ see Honest gaps.
 
 ### What names a workspace, and how that was settled
 
-A fetched dependency's entry path *is* its identity — npm resolves it at that
-location, nesting included — so the segment after the last `node_modules/` is
-the name. A **workspace** entry has no such segment: its path says where the
+A fetched dependency's name is the segment after the **last**
+`node_modules/` in its entry path, so the same package hoisted to two depths
+collapses to one name rather than reading as two — deliberate, and pinned by
+`TestANestedDuplicateIsTheSamePackage`. A **workspace** entry has no such
+segment: its path says where the
 package lives in the repository, which is not what it is. Keying on the path
 meant a monorepo reorganisation (`packages/cli` → `apps/cli`) reported one
 dependency that started running code at install and another that stopped, for
@@ -180,8 +182,10 @@ a rename that changed nothing about what executes
 ([#158](https://github.com/gfazioli/octoscope/issues/158)) — and it arrived as
 a burst, which is the shape most likely to teach a reader to skip the axis.
 
-The entry's declared `name` now wins, and the fallback is the **last path
-segment** rather than the whole path. That second half is the part measurement
+There the entry's declared `name` now wins — only there: a `node_modules/`
+entry keeps its location-derived name even when it declares another, which is
+the aliased-install case below. The fallback is the **last path segment**
+rather than the whole path. That second half is the part measurement
 added, and the issue's own proposal did not have it — 2026-09-12, every
 `package-lock.json` reachable at the default branch of seven npm-workspace
 monorepos:
@@ -199,9 +203,12 @@ monorepos:
 
 Two facts decided the shape:
 
-- **npm writes `name` exactly when the path does not already say it.** All 85
+- **Every `name` npm wrote was one the path did not already say.** All 85
   declared names differ from their directory's basename; not one entry carried
-  a redundant one. So an absent field means the basename *is* the name — and
+  a redundant one. That is a dated observation of npm's output, not a promise
+  it makes — and the fallback is built to hold either way, since a redundant
+  `name` equals the basename anyway. So an absent field means the basename
+  *is* the name — and
   "read `name`, fall back to the path" would have fixed **3 of the 7** real
   install-script workspaces in the sample, leaving the other four keyed on a
   path that a move still breaks.
@@ -209,6 +216,17 @@ Two facts decided the shape:
   `node_modules/<name>` with `link: true`; all seven such entries carry no
   `hasInstallScript`, so the parse loop skips them and keying by name adds no
   second value for the same key.
+
+**A workspace records the sentinel, never a content hash.** Keying by name
+means two nameless workspaces sharing a basename *and* a version land in one
+bucket, and two integrity-shaped values in one bucket are exactly what the
+delta scores as *same version, different bytes* at weight 4 — the heaviest
+claim this axis makes. npm refuses two workspaces with one name, so that
+collision only exists in a lockfile written to produce it; rather than rely on
+that, the parser ignores `integrity` and `resolved` on a workspace entry
+outright. It loses nothing observable: those same 115 entries carried **zero**
+of either field, because a workspace is local source and npm has no hash to
+record for it.
 
 An **aliased** install (`npm i foo@npm:bar`) is the mirror image — a
 `node_modules/` entry that declares a different name — and the install
@@ -800,11 +818,13 @@ what I looked at", and the report has to say what that was.
   constantly for entirely ordinary reasons — trading a rare miss for routine
   noise is the trade this axis exists to refuse. Pinned by a test, so it stays
   a decision rather than becoming a discovery.
-- ~~**A workspace entry is keyed by its install path**~~ — closed by
+- ~~**A workspace entry is keyed by its install path**~~ — narrowed by
   [#158](https://github.com/gfazioli/octoscope/issues/158): the declared
-  `name` wins and the fallback is the last path segment, so a move no longer
-  moves the key. See *What names a workspace* under Axis 1b for the
-  measurement that decided the fallback.
+  `name` wins and the fallback is the last path segment, so **moving** a
+  workspace no longer moves the key. What survives is smaller and stated in
+  *What names a workspace* under Axis 1b: renaming the *directory* of a
+  workspace that declares no name moves the key once, until npm rewrites the
+  lockfile and records the name it can no longer derive.
 - **The Axis-1 catalog is a moving target** by nature. It ships as a
   maintained data table, and the scan leans on Axes 2–4 — which do not depend
   on the catalog being exhaustive — for variants using an ignition point

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -161,10 +161,11 @@ type lockPackage struct {
 	Integrity        string `json:"integrity"`
 	HasInstallScript bool   `json:"hasInstallScript"`
 
-	// Name is what the package calls itself, and npm writes it only when
-	// the entry's path does not already say so — for a workspace whose
-	// directory differs from its package name, and for an aliased install.
-	// See packageNameOf for which of those this axis reads and why.
+	// Name is what the package calls itself. In every lockfile sampled it
+	// appeared only where the path does not already say it — a workspace
+	// whose directory differs from its package name, and an aliased
+	// install — but nothing here depends on npm never writing a redundant
+	// one. See packageNameOf for which of the two this axis reads and why.
 	Name string `json:"name"`
 }
 
@@ -251,6 +252,17 @@ func parseLockfile(content []byte) lockfileFacts {
 		if path == "" {
 			continue
 		}
+		// One normalisation, two decisions. The name and the "is this local
+		// source" test both read the tail of the path, and they disagreed:
+		// the trim lived inside packageNameOf, so "packages/a/node_modules/"
+		// was NAMED as a workspace (basename "node_modules") and VALUED as a
+		// fetched dependency, which handed its supplied integrity straight
+		// back into the bucket the sentinel exists to keep clean. Trailing
+		// slashes are not canonical npm output; a lockfile written to
+		// exploit the disagreement is exactly the input this parser must be
+		// dull about.
+		path = strings.TrimRight(path, "/")
+
 		name := oneLine(packageNameOf(path, p.Name))
 		if name == "" {
 			continue
@@ -270,7 +282,7 @@ func parseLockfile(content []byte) lockfileFacts {
 		// collision only exists in a lockfile written to produce it; the
 		// sentinel makes the heaviest claim on this axis unreachable
 		// that way rather than merely unlikely.
-		if !strings.Contains(path, "node_modules/") {
+		if !strings.Contains(path, "node_modules/") { // normalised above
 			if values[key] == nil {
 				values[key] = map[string]bool{}
 			}
@@ -369,21 +381,28 @@ func parseLockfile(content []byte) lockfileFacts {
 // entries in the sample), so the loop above skips it and keying by name
 // introduces no duplicate.
 //
-// Entries are keyed by install location, so a nested copy reads as
-// "node_modules/playwright/node_modules/fsevents" and the name is what
-// follows the last node_modules segment. A workspace entry
-// ("packages/cli") has no such segment and is its own name — it is local
+// Entries are addressed by install location, so a nested copy reads as
+// "node_modules/playwright/node_modules/fsevents" — but the KEY is the
+// name that follows the last node_modules segment, so the nested copy and
+// the hoisted one are one package rather than two. A workspace entry
+// ("packages/cli") has no such segment and is keyed by the name it
+// declares, or by its directory when it declares none — it is local
 // source rather than a fetched dependency, and it is kept, because a
 // workspace package that gains an install script is exactly as
 // interesting as a fetched one.
 func packageNameOf(path, declared string) string {
-	// A trailing slash is not canonical npm output, but the parser takes
+	// Trailing slashes are not canonical npm output, but the parser takes
 	// attacker-controlled input, and both branches below read the tail:
 	// untrimmed, a workspace path ends in an empty name and the entry is
 	// dropped silently, while a fetched one keys as "pkg/" and compares
 	// equal to nothing. A dependency that runs code at install must never
 	// leave the surface without a word, which is the whole of Axis 1b.
-	path = strings.TrimSuffix(path, "/")
+	//
+	// The caller trims too, so this is idempotent rather than redundant:
+	// the classification there and the name here have to agree on the same
+	// string, and when they did not, a crafted path was named one way and
+	// valued the other.
+	path = strings.TrimRight(path, "/")
 
 	const seg = "node_modules/"
 	if i := strings.LastIndex(path, seg); i >= 0 {

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -152,7 +152,7 @@ type lockfileFacts struct {
 	Note string
 }
 
-// lockPackage is one entry of the v2/v3 `packages` map. Only the four
+// lockPackage is one entry of the v2/v3 `packages` map. Only the five
 // fields this axis reads are declared; everything else in a real entry
 // is ignored by encoding/json.
 type lockPackage struct {
@@ -257,6 +257,27 @@ func parseLockfile(content []byte) lockfileFacts {
 		}
 		key := name + "@" + oneLine(p.Version)
 
+		// A workspace records no content identity, ever. It is local
+		// source: npm writes neither integrity nor resolved for one, and
+		// a sample of 115 workspace entries across seven monorepos
+		// (2026-09-12) had zero of each. Reading them anyway would cost
+		// nothing in an honest file and quite a lot in a crafted one —
+		// since the key is now the package name, two nameless workspaces
+		// sharing a basename and a version land in one bucket, and two
+		// integrity-shaped values in that bucket are exactly what the
+		// delta scores as "same version, different bytes" at weight 4.
+		// npm itself refuses two workspaces with one name, so the
+		// collision only exists in a lockfile written to produce it; the
+		// sentinel makes the heaviest claim on this axis unreachable
+		// that way rather than merely unlikely.
+		if !strings.Contains(path, "node_modules/") {
+			if values[key] == nil {
+				values[key] = map[string]bool{}
+			}
+			values[key][noIntegrity] = true
+			continue
+		}
+
 		value := oneLine(p.Integrity)
 		if value == "" {
 			// A git or link dependency has no integrity hash. `resolved`
@@ -314,24 +335,34 @@ func parseLockfile(content []byte) lockfileFacts {
 
 // packageNameOf turns a lockfile entry into the name this axis keys on.
 //
-// A WORKSPACE entry has no node_modules/ segment: its path is where the
-// package lives in the repository, which is not its identity. Keying on
-// the path made a move — packages/cli -> apps/cli — read as one
+// For a fetched dependency that is the segment after the LAST
+// `node_modules/`, so the same package hoisted to two depths collapses to
+// one name — deliberate, and pinned by TestANestedDuplicateIsTheSamePackage.
+// The entry's own `name`, set there only for an aliased install, is ignored:
+// measured 2026-09-12, 20 aliases among 10,881 fetched entries across the
+// sample below and not one of them carried an install script, so reading the
+// alias target would rewrite 0.18% of keys to fix nothing this axis observes.
+//
+// A WORKSPACE entry has no node_modules/ segment, and there the declared
+// name wins: its path is where the package lives in the repository, which
+// is not its identity. Keying on the path made a move — packages/cli -> apps/cli — read as one
 // dependency that started running code at install (weight 2) and another
 // that stopped, for a rename that changed nothing about what executes.
 // A monorepo reorganisation produced a burst of them at once, which is
 // the shape most likely to teach a reader to skip the axis (#158).
 //
-// So the declared name wins, and the fallback is the LAST SEGMENT rather
-// than the whole path. That second half is what the issue's own proposal
-// was missing, and measurement is why: across 115 workspace entries in
+// The fallback is then the LAST SEGMENT rather than the whole path, and
+// that second half is what the issue's own proposal was missing.
+// Measurement is why: across 115 workspace entries in
 // npm/cli, open-telemetry/opentelemetry-js, socketio/socket.io,
 // mochajs/mocha, puppeteer/puppeteer, microsoft/playwright and
-// nestjs/nest (2026-09-12), npm writes `name` EXACTLY when it differs
-// from the directory's basename — 85 entries carried one, all 85
-// differed, not one was redundant. So an absent field means the basename
-// is the name, and "read the name field, fall back to the path" would
-// have fixed 3 of the 7 real install-script workspaces in that sample.
+// nestjs/nest (2026-09-12), every `name` that was written differed from
+// its directory's basename — 85 of 115 entries carried one, all 85
+// differed, none was redundant. That is a dated observation of what npm
+// emits, not a guarantee it makes; the fallback is built to be right
+// either way, since a redundant `name` equals the basename anyway. On
+// that sample "read the name field, fall back to the path" would have
+// fixed 3 of the 7 real install-script workspaces.
 //
 // The workspace also appears as `node_modules/<name>` with `link: true`,
 // but that entry carries no hasInstallScript (measured on all seven such
@@ -346,16 +377,16 @@ func parseLockfile(content []byte) lockfileFacts {
 // workspace package that gains an install script is exactly as
 // interesting as a fetched one.
 func packageNameOf(path, declared string) string {
+	// A trailing slash is not canonical npm output, but the parser takes
+	// attacker-controlled input, and both branches below read the tail:
+	// untrimmed, a workspace path ends in an empty name and the entry is
+	// dropped silently, while a fetched one keys as "pkg/" and compares
+	// equal to nothing. A dependency that runs code at install must never
+	// leave the surface without a word, which is the whole of Axis 1b.
+	path = strings.TrimSuffix(path, "/")
+
 	const seg = "node_modules/"
 	if i := strings.LastIndex(path, seg); i >= 0 {
-		// A fetched dependency: the install location IS the identity npm
-		// resolves against, nesting included. `declared` is set here only
-		// for an aliased install (`npm i foo@npm:bar`), and the location
-		// is kept on purpose — measured 2026-09-12 across the seven
-		// monorepos below: 20 aliases in 10,881 fetched entries, none of
-		// them carrying an install script, so reading the alias target
-		// would rewrite keys for 0.18% of entries to fix nothing this axis
-		// can see.
 		return path[i+len(seg):]
 	}
 	if declared != "" {

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -160,6 +160,12 @@ type lockPackage struct {
 	Resolved         string `json:"resolved"`
 	Integrity        string `json:"integrity"`
 	HasInstallScript bool   `json:"hasInstallScript"`
+
+	// Name is what the package calls itself, and npm writes it only when
+	// the entry's path does not already say so — for a workspace whose
+	// directory differs from its package name, and for an aliased install.
+	// See packageNameOf for which of those this axis reads and why.
+	Name string `json:"name"`
 }
 
 // lockfileDoc is the subset of the lockfile schema this axis decodes.
@@ -245,7 +251,7 @@ func parseLockfile(content []byte) lockfileFacts {
 		if path == "" {
 			continue
 		}
-		name := oneLine(packageNameFromPath(path))
+		name := oneLine(packageNameOf(path, p.Name))
 		if name == "" {
 			continue
 		}
@@ -306,7 +312,31 @@ func parseLockfile(content []byte) lockfileFacts {
 	return f
 }
 
-// packageNameFromPath turns a lockfile entry path into the package name.
+// packageNameOf turns a lockfile entry into the name this axis keys on.
+//
+// A WORKSPACE entry has no node_modules/ segment: its path is where the
+// package lives in the repository, which is not its identity. Keying on
+// the path made a move — packages/cli -> apps/cli — read as one
+// dependency that started running code at install (weight 2) and another
+// that stopped, for a rename that changed nothing about what executes.
+// A monorepo reorganisation produced a burst of them at once, which is
+// the shape most likely to teach a reader to skip the axis (#158).
+//
+// So the declared name wins, and the fallback is the LAST SEGMENT rather
+// than the whole path. That second half is what the issue's own proposal
+// was missing, and measurement is why: across 115 workspace entries in
+// npm/cli, open-telemetry/opentelemetry-js, socketio/socket.io,
+// mochajs/mocha, puppeteer/puppeteer, microsoft/playwright and
+// nestjs/nest (2026-09-12), npm writes `name` EXACTLY when it differs
+// from the directory's basename — 85 entries carried one, all 85
+// differed, not one was redundant. So an absent field means the basename
+// is the name, and "read the name field, fall back to the path" would
+// have fixed 3 of the 7 real install-script workspaces in that sample.
+//
+// The workspace also appears as `node_modules/<name>` with `link: true`,
+// but that entry carries no hasInstallScript (measured on all seven such
+// entries in the sample), so the loop above skips it and keying by name
+// introduces no duplicate.
 //
 // Entries are keyed by install location, so a nested copy reads as
 // "node_modules/playwright/node_modules/fsevents" and the name is what
@@ -315,10 +345,24 @@ func parseLockfile(content []byte) lockfileFacts {
 // source rather than a fetched dependency, and it is kept, because a
 // workspace package that gains an install script is exactly as
 // interesting as a fetched one.
-func packageNameFromPath(path string) string {
+func packageNameOf(path, declared string) string {
 	const seg = "node_modules/"
 	if i := strings.LastIndex(path, seg); i >= 0 {
+		// A fetched dependency: the install location IS the identity npm
+		// resolves against, nesting included. `declared` is set here only
+		// for an aliased install (`npm i foo@npm:bar`), and the location
+		// is kept on purpose — measured 2026-09-12 across the seven
+		// monorepos below: 20 aliases in 10,881 fetched entries, none of
+		// them carrying an install script, so reading the alias target
+		// would rewrite keys for 0.18% of entries to fix nothing this axis
+		// can see.
 		return path[i+len(seg):]
+	}
+	if declared != "" {
+		return declared
+	}
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
 	}
 	return path
 }

--- a/internal/github/lockfile_test.go
+++ b/internal/github/lockfile_test.go
@@ -110,8 +110,44 @@ func TestAWorkspacePackageIsKept(t *testing.T) {
 	// Local source rather than a fetched tarball, so it has no
 	// integrity — but a workspace package that starts running code at
 	// install is exactly as interesting as a fetched one.
-	if got, ok := f.Packages["packages/cli@0.4.0"]; !ok || got != noIntegrity {
-		t.Errorf("workspace surface = %v, want packages/cli@0.4.0 recorded as %q", f.Packages, noIntegrity)
+	//
+	// Keyed "cli", not "packages/cli": npm omits `name` when it matches
+	// the directory's basename, so the basename is the name (#158).
+	if got, ok := f.Packages["cli@0.4.0"]; !ok || got != noIntegrity {
+		t.Errorf("workspace surface = %v, want cli@0.4.0 recorded as %q", f.Packages, noIntegrity)
+	}
+}
+
+// The defect #158 names, end to end at the parser: the same workspace,
+// the same install script, moved. Before the fix the two lockfiles shared
+// no key at all, and the delta read one dependency that started running
+// code at install and one that stopped.
+func TestMovingAWorkspaceDoesNotChangeItsKey(t *testing.T) {
+	lock := func(path, name string) map[string]string {
+		decl := ""
+		if name != "" {
+			decl = `"name": "` + name + `", `
+		}
+		return parseLockfile([]byte(`{
+		  "lockfileVersion": 3,
+		  "packages": {
+		    "": { "name": "monorepo", "version": "1.0.0" },
+		    "` + path + `": { ` + decl + `"version": "0.4.0", "hasInstallScript": true }
+		  }
+		}`)).Packages
+	}
+
+	// Declared name: carried by npm precisely because it differs from the
+	// directory, which is the case the issue proposed fixing.
+	if before, after := lock("packages/cli", "@scope/cli"), lock("apps/cli", "@scope/cli"); !reflect.DeepEqual(before, after) {
+		t.Errorf("a declared-name workspace moved and its surface changed:\n before %v\n after  %v", before, after)
+	}
+
+	// No declared name, because the package is called after its directory.
+	// This is the half a path fallback would have missed — four of the
+	// seven real install-script workspaces measured.
+	if before, after := lock("packages/cli", ""), lock("apps/cli", ""); !reflect.DeepEqual(before, after) {
+		t.Errorf("a basename-named workspace moved and its surface changed:\n before %v\n after  %v", before, after)
 	}
 }
 
@@ -283,16 +319,31 @@ func TestEmptyContentIsUnparsed(t *testing.T) {
 	}
 }
 
-func TestPackageNameFromPath(t *testing.T) {
-	tests := map[string]string{
-		"node_modules/fsevents":                        "fsevents",
-		"node_modules/@scope/pkg":                      "@scope/pkg",
-		"node_modules/playwright/node_modules/esbuild": "esbuild",
-		"packages/cli":                                 "packages/cli",
+func TestPackageNameOf(t *testing.T) {
+	tests := []struct {
+		path, declared, want string
+	}{
+		// A fetched dependency: the install location is the identity.
+		{"node_modules/fsevents", "", "fsevents"},
+		{"node_modules/@scope/pkg", "", "@scope/pkg"},
+		{"node_modules/playwright/node_modules/esbuild", "", "esbuild"},
+		// An aliased install declares another name; the location still
+		// wins, deliberately — see packageNameOf.
+		{"node_modules/react-is-18", "react-is", "react-is-18"},
+
+		// A workspace: the path is where it lives, not what it is.
+		{"packages/cli", "@scope/cli", "@scope/cli"},
+		{"packages/playwright-chromium", "", "playwright-chromium"},
+		// The same package after a monorepo reorganisation — the key must
+		// not move with it. This is #158.
+		{"apps/cli", "@scope/cli", "@scope/cli"},
+		{"apps/playwright-chromium", "", "playwright-chromium"},
+		// A single-segment workspace path, and the root's own sibling.
+		{"cli", "", "cli"},
 	}
-	for path, want := range tests {
-		if got := packageNameFromPath(path); got != want {
-			t.Errorf("packageNameFromPath(%q) = %q, want %q", path, got, want)
+	for _, tc := range tests {
+		if got := packageNameOf(tc.path, tc.declared); got != tc.want {
+			t.Errorf("packageNameOf(%q, %q) = %q, want %q", tc.path, tc.declared, got, tc.want)
 		}
 	}
 }

--- a/internal/github/lockfile_test.go
+++ b/internal/github/lockfile_test.go
@@ -139,8 +139,17 @@ func TestMovingAWorkspaceDoesNotChangeItsKey(t *testing.T) {
 
 	// Declared name: carried by npm precisely because it differs from the
 	// directory, which is the case the issue proposed fixing.
-	if before, after := lock("packages/cli", "@scope/cli"), lock("apps/cli", "@scope/cli"); !reflect.DeepEqual(before, after) {
+	//
+	// The two directories differ in their LAST segment as well, and the
+	// expected key is asserted outright — with both paths ending in "cli"
+	// this half passed even with the declared-name branch removed, since
+	// the basename fallback answered "cli" on both sides.
+	before, after := lock("tools/cli", "@scope/tools"), lock("apps/renamed", "@scope/tools")
+	if !reflect.DeepEqual(before, after) {
 		t.Errorf("a declared-name workspace moved and its surface changed:\n before %v\n after  %v", before, after)
+	}
+	if got, ok := before["@scope/tools@0.4.0"]; !ok || got != noIntegrity {
+		t.Errorf("surface = %v, want the DECLARED name @scope/tools@0.4.0", before)
 	}
 
 	// No declared name, because the package is called after its directory.
@@ -316,6 +325,53 @@ func TestEmptyContentIsUnparsed(t *testing.T) {
 	f := parseLockfile(nil)
 	if !f.Unparsed {
 		t.Error("empty content is not a lockfile with no install scripts; it is unreadable")
+	}
+}
+
+// A lockfile is attacker-controlled input, so the parser's job is to be
+// dull on shapes npm never writes. A trailing slash used to produce an
+// empty name and drop the entry — a dependency that runs code at install
+// vanishing from the surface without a word, which is the one outcome
+// this axis refuses.
+func TestNonCanonicalPathsStillName(t *testing.T) {
+	tests := []struct{ path, declared, want string }{
+		{"packages/cli/", "", "cli"},
+		{"node_modules/pkg/", "", "pkg"},
+		{"packages//cli", "", "cli"},
+		{"/cli", "", "cli"},
+	}
+	for _, tc := range tests {
+		if got := packageNameOf(tc.path, tc.declared); got != tc.want {
+			t.Errorf("packageNameOf(%q, %q) = %q, want %q", tc.path, tc.declared, got, tc.want)
+		}
+	}
+}
+
+// Keying a workspace by its name means two nameless workspaces sharing a
+// basename and a version land in one bucket. npm refuses two workspaces
+// with one name, so that only happens in a lockfile written to produce
+// it — and the point of this test is that producing it buys nothing: a
+// workspace records the sentinel whatever its entry claims, so the bucket
+// cannot hold two integrity-shaped values and the delta cannot be made to
+// report "same version, different bytes" at weight 4.
+func TestACraftedWorkspaceCollisionCannotForgeARepublish(t *testing.T) {
+	f := parseLockfile([]byte(`{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "monorepo", "version": "1.0.0" },
+	    "packages/cli": { "version": "1.0.0", "hasInstallScript": true,
+	                      "integrity": "sha512-AAAA" },
+	    "apps/cli":     { "version": "1.0.0", "hasInstallScript": true,
+	                      "integrity": "sha512-BBBB" }
+	  }
+	}`))
+
+	got, ok := f.Packages["cli@1.0.0"]
+	if !ok {
+		t.Fatalf("surface = %v, want the colliding workspaces recorded under cli@1.0.0", f.Packages)
+	}
+	if got != noIntegrity {
+		t.Errorf("colliding workspaces recorded %q, want the sentinel %q — two hash-shaped values here are what the delta scores as a republish", got, noIntegrity)
 	}
 }
 

--- a/internal/github/lockfile_test.go
+++ b/internal/github/lockfile_test.go
@@ -111,8 +111,9 @@ func TestAWorkspacePackageIsKept(t *testing.T) {
 	// integrity — but a workspace package that starts running code at
 	// install is exactly as interesting as a fetched one.
 	//
-	// Keyed "cli", not "packages/cli": npm omits `name` when it matches
-	// the directory's basename, so the basename is the name (#158).
+	// Keyed "cli", not "packages/cli": this entry declares no name, and in
+	// every lockfile sampled npm left the field out exactly where the
+	// directory already said it — so the basename is the name (#158).
 	if got, ok := f.Packages["cli@0.4.0"]; !ok || got != noIntegrity {
 		t.Errorf("workspace surface = %v, want cli@0.4.0 recorded as %q", f.Packages, noIntegrity)
 	}
@@ -372,6 +373,29 @@ func TestACraftedWorkspaceCollisionCannotForgeARepublish(t *testing.T) {
 	}
 	if got != noIntegrity {
 		t.Errorf("colliding workspaces recorded %q, want the sentinel %q — two hash-shaped values here are what the delta scores as a republish", got, noIntegrity)
+	}
+}
+
+// The name and the local-source test both read the tail of the path, and
+// a crafted trailing slash once made them disagree: "packages/a/node_modules/"
+// was named as a workspace and valued as a fetched dependency, so its
+// supplied integrity went into the very bucket the sentinel keeps clean.
+func TestNameAndValueAgreeOnACraftedPath(t *testing.T) {
+	f := parseLockfile([]byte(`{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "monorepo", "version": "1.0.0" },
+	    "packages/a/node_modules/": { "version": "1.0.0", "hasInstallScript": true,
+	                                  "integrity": "sha512-AAAA" },
+	    "packages/b/node_modules/": { "version": "1.0.0", "hasInstallScript": true,
+	                                  "integrity": "sha512-BBBB" }
+	  }
+	}`))
+
+	for key, got := range f.Packages {
+		if got != noIntegrity {
+			t.Errorf("%s recorded %q; a path classified as local source must record the sentinel, or two crafted entries forge a republish", key, got)
+		}
 	}
 }
 

--- a/internal/github/lockfile_test.go
+++ b/internal/github/lockfile_test.go
@@ -392,10 +392,18 @@ func TestNameAndValueAgreeOnACraftedPath(t *testing.T) {
 	  }
 	}`))
 
-	for key, got := range f.Packages {
-		if got != noIntegrity {
-			t.Errorf("%s recorded %q; a path classified as local source must record the sentinel, or two crafted entries forge a republish", key, got)
-		}
+	// Asserted by key, not by ranging: a loop over the map says nothing at
+	// all when the map is empty, so a change that dropped both entries
+	// would leave this test green while removing the very thing it guards.
+	if len(f.Packages) != 1 {
+		t.Fatalf("surface = %v, want exactly one bucket for the two crafted entries", f.Packages)
+	}
+	got, ok := f.Packages["node_modules@1.0.0"]
+	if !ok {
+		t.Fatalf("surface = %v, want both crafted entries under node_modules@1.0.0", f.Packages)
+	}
+	if got != noIntegrity {
+		t.Errorf("recorded %q, want the sentinel %q — a path classified as local source must never carry a supplied hash, or two crafted entries forge a republish", got, noIntegrity)
 	}
 }
 


### PR DESCRIPTION
Closes #158.

`parseLockfile` keyed the install-script surface by the entry path. For a fetched dependency that is right — the install location *is* the identity npm resolves against. For a **workspace** it is not: the path says where the package lives in the repository. So `packages/cli` → `apps/cli` reported one dependency that started running code at install (weight 2) and one that stopped, for a rename that changed nothing about what executes — and a monorepo reorganisation produced a burst of them at once, which is the shape most likely to teach a reader to skip the axis.

### The issue asked for measurement first, and measurement changed the answer

Every `package-lock.json` reachable at the default branch of seven npm-workspace monorepos, 2026-09-12:

| Repository | workspace entries | carry `name` | `name` ≠ basename | `name` = basename | with an install script | of those, named |
|---|---|---|---|---|---|---|
| `npm/cli` | 16 | 6 | 6 | 0 | 0 | — |
| `open-telemetry/opentelemetry-js` | 56 | 54 | 54 | 0 | 0 | — |
| `socketio/socket.io` | 13 | 6 | 6 | 0 | 0 | — |
| `mochajs/mocha` | 1 | 1 | 1 | 0 | 0 | — |
| `puppeteer/puppeteer` | 10 | 8 | 8 | 0 | 1 | 0 |
| `microsoft/playwright` | 16 | 7 | 7 | 0 | 6 | 3 |
| `nestjs/nest` | 3 | 3 | 3 | 0 | 0 | — |
| **total** | **115** | **85** | **85** | **0** | **7** | **3** |

- **npm writes `name` exactly when the path does not already say it** — all 85 declared names differ from their basename, not one is redundant. So the issue's own option 1, *read `name`, fall back to the path*, would have fixed **3 of the 7** real install-script workspaces (`@playwright/browser-*`) and left the other four (`packages/puppeteer`, `packages/playwright-chromium|firefox|webkit`) keyed on a path a move still breaks. The fallback has to be the **last path segment**.
- **The link entry is not a duplicate.** A workspace also appears as `node_modules/<name>` with `link: true`; all seven such entries carry no `hasInstallScript`, so the parse loop already skips them — keying by name adds no second value under one key, which would otherwise have risked a spurious *same version, different content* at weight 4.
- **Aliased installs keep the location** (`npm i foo@npm:bar` writes a `node_modules/` entry declaring another name): 20 among 10,881 fetched entries, none with an install script, so reading the alias target would rewrite 0.18% of keys to fix nothing this axis can observe.

### Tests, each measured failing on the old behaviour

- `TestPackageNameOf` — the naming table, fetched / aliased / workspace / moved workspace.
- `TestAWorkspacePackageIsKept` — the surface key is now `cli@0.4.0`, not `packages/cli@0.4.0`.
- `TestMovingAWorkspaceDoesNotChangeItsKey` — the same workspace, the same install script, moved; the parsed surface must be deep-equal. Run twice, once with a declared name and once without, because those are the two halves and only one of them was obvious.

Reverting the fix fails all three, naming both halves of the move test.

### What remains, and it is in the design doc

Renaming the *directory* of a workspace that has no declared name moves the key once, until npm rewrites the lockfile — at which point the name differs from the new basename, npm records it, and the key is stable again. And a workspace sharing a name with a registry dependency now shares its key, which is correct: npm links it at that same name.

The *Honest gaps* entry is struck through rather than deleted — it was a documented decision, and what closed it is worth reading beside it.

**Checks:** `gofmt` clean under the pinned toolchain (`go1.25.13`), `go vet ./...` clean, all packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace dependencies now retain stable identities when moved, reducing false install-surface changes.
  - Dependency names are resolved more consistently across workspace and installed package paths.
  - Local workspace entries now use consistent integrity handling during lockfile processing.
  - Improved handling for unnamed workspaces, scoped packages, aliases, and nonstandard paths.

- **Documentation**
  - Clarified workspace dependency naming behavior and documented the remaining limitation for renaming nameless workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->