### PR TITLE
chore(release): the formula becomes a cask, and the test it carried

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,22 +302,24 @@ jobs:
   # Measured here rather than assumed, by reintroducing the collision on
   # purpose: goreleaser does NOT refuse during defaulting. It sets
   # defaults, builds all five targets, archives them, checksums them, and
-  # only then refuses while *rendering* the formula — a minute in. The
+  # only then refuses while *rendering* the tap artifact — a minute in. The
   # conclusion still holds, because publishing comes after that, but a
   # regression of this class costs the full build before it says so.
   #
   # So this job runs the real thing with NOTHING skipped. In snapshot
-  # mode goreleaser builds every artifact, renders the formula and builds
+  # mode goreleaser builds every artifact, renders the cask and builds
   # the images without publishing anything, which is precisely the
   # coverage that was missing.
   #
   # Two limits, both measured on the first run rather than assumed, so
   # nobody reads more coverage into this job than it has:
   #
-  #   - it needs NO secrets. `brews` carries a .Env.HOMEBREW_TAP_TOKEN
-  #     template and goreleaser does not evaluate it while not
-  #     publishing — it lands in the formula's config verbatim. That is
-  #     what lets this job run on a fork's pull request.
+  #   - it needs NO secrets. `homebrew_casks` carries a
+  #     .Env.HOMEBREW_TAP_TOKEN template and goreleaser does not evaluate
+  #     it while not publishing — it lands in the cask's config verbatim.
+  #     That is what lets this job run on a fork's pull request, and it
+  #     still held after the migration: this job's first run on #166
+  #     failed on the artifact type, not on a missing secret.
   #   - it does NOT exercise the multi-platform manifest. A snapshot
   #     builds one image per platform (`:...-amd64`, `:...-arm64`) and
   #     assembles nothing, so the containerd-versus-overlay2 export
@@ -360,11 +362,15 @@ jobs:
 
           count() { jq "[.[] | select($1)] | length" dist/artifacts.json; }
 
-          # The formula is the artifact whose absence cost v0.31.0: two
+          # The tap artifact is the one whose absence cost v0.31.0: two
           # artifacts per os/arch and the tap generator refuses to guess.
-          n=$(count '.type == "Homebrew Formula"')
-          [ "$n" -eq 1 ] || { echo "want 1 rendered formula, got $n — the brews pipe did not run"; exit 1; }
-          echo "--- dist/homebrew/Formula/octoscope.rb ---"; cat dist/homebrew/Formula/octoscope.rb
+          # It is a Cask since #142 — and this assertion is why that
+          # migration could not be a one-line config change: it failed
+          # here first, reporting "got 0", which is exactly the job this
+          # step was added to do.
+          n=$(count '.type == "Homebrew Cask"')
+          [ "$n" -eq 1 ] || { echo "want 1 rendered cask, got $n — the homebrew_casks pipe did not run"; exit 1; }
+          echo "--- dist/homebrew/Casks/octoscope.rb ---"; cat dist/homebrew/Casks/octoscope.rb
 
           # Five archives (four tarballs plus the Windows zip) and five
           # bare binaries, which are Binary artifacts carrying the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,16 +98,22 @@ jobs:
 
       # A GHCR package does NOT inherit its repository's visibility —
       # The Homebrew formula carried `test: system "#{bin}/octoscope
-      # --version"`, and Homebrew ran it on every install — the only
-      # automated check that the PUBLISHED artifact starts rather than
-      # merely builds. A cask has no `test` stanza (goreleaser's own cask
-      # has none either), so migrating to `homebrew_casks` in #142 would
-      # have dropped that check silently, which is the exact shape of a
-      # gate that stops running and looks like a gate that found nothing.
+      # --version"`, and a cask has no `test` stanza (goreleaser's own
+      # cask has none either), so #142 would have dropped it silently.
       #
-      # This is its replacement, and it is strictly better placed: it
-      # exercises the tarball a user downloads, from the release that was
-      # just published, rather than a copy Homebrew unpacked locally.
+      # How much was actually lost is smaller than it looks, and worth
+      # stating rather than dramatising: a formula's test runs on `brew
+      # test`, and on Homebrew's CI for core formulae — NOT on install.
+      # In a third-party tap nothing ran it automatically, so the stanza
+      # was a check nobody was executing.
+      #
+      # This step is therefore a net gain rather than a like-for-like
+      # replacement, and its coverage is narrow on purpose: it downloads
+      # the LINUX x86_64 tarball from the release just published and runs
+      # it. It does not exercise either macOS artifact, and it does not
+      # exercise a Homebrew install at all — that is #165's job, by hand,
+      # once. What it does cover is the one thing no other check did: the
+      # bytes a user downloads actually start.
       #
       # A hard failure, unlike the ghcr check below. That one warns
       # because a private package is a settings problem with the artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,45 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       # A GHCR package does NOT inherit its repository's visibility —
+      # The Homebrew formula carried `test: system "#{bin}/octoscope
+      # --version"`, and Homebrew ran it on every install — the only
+      # automated check that the PUBLISHED artifact starts rather than
+      # merely builds. A cask has no `test` stanza (goreleaser's own cask
+      # has none either), so migrating to `homebrew_casks` in #142 would
+      # have dropped that check silently, which is the exact shape of a
+      # gate that stops running and looks like a gate that found nothing.
+      #
+      # This is its replacement, and it is strictly better placed: it
+      # exercises the tarball a user downloads, from the release that was
+      # just published, rather than a copy Homebrew unpacked locally.
+      #
+      # A hard failure, unlike the ghcr check below. That one warns
+      # because a private package is a settings problem with the artifact
+      # intact; here the artifact itself would be broken, and a red
+      # release is the correct signal for a binary that does not start.
+      # Nothing is un-published either way.
+      - name: Does the published binary start?
+        if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          asset="octoscope_${version}_Linux_x86_64.tar.gz"
+          gh release download "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" --pattern "$asset" --dir /tmp/smoke
+          tar -xzf "/tmp/smoke/$asset" -C /tmp/smoke
+          out="$(/tmp/smoke/octoscope --version)"
+          echo "published binary says: $out"
+          # Asserting the version rather than just a zero exit: a binary
+          # built from the wrong ref would start perfectly well and be the
+          # thing worth catching. This is the same check version_test.go
+          # makes at build time, aimed at the artifact people download.
+          case "$out" in
+            *"$version"*) ;;
+            *) echo "::error title=Published binary reports the wrong version::expected $version in: $out"; exit 1 ;;
+          esac
+
       # GitHub's own docs say permissions are inherited "but not the
       # visibility" — so the package this release creates is private
       # until somebody flips it once, by hand, in the package settings.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -180,7 +180,7 @@ release:
     Via Homebrew (recommended):
 
     ```bash
-    brew install gfazioli/tap/octoscope
+    brew install --cask gfazioli/tap/octoscope
     ```
 
     Or download a platform-specific archive below and drop the binary on your `$PATH`.
@@ -225,7 +225,11 @@ homebrew_casks:
     directory: Casks
     homepage: "https://github.com/gfazioli/octoscope"
     description: "Terminal dashboard for your GitHub account"
-    license: "MIT"
+    # No `license:` here, deliberately. The key is accepted by the config
+    # and the cask template never renders it — measured on the generated
+    # file — so carrying it would claim a stanza the artifact does not
+    # have. It is the one piece of formula metadata this migration loses,
+    # and the repository's LICENSE is where it lives anyway.
     # skip_upload: auto — pre-releases (-dev / -rc) won't bump the
     # stable cask but still upload archives for testing.
     skip_upload: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -194,7 +194,14 @@ release:
       && chmod +x octoscope
     ```
 
-brews:
+# Since 0.34.0 this is a CASK, not a formula: `brews` is deprecated and
+# `goreleaser check` — which this repo wants as a gate — exits non-zero on
+# it. A cask serves Linux Homebrew too, which is what the migration hung
+# on for a week: `Cask::Cask#supports_linux?` is true unless the cask says
+# `depends_on macos` (Homebrew 6.0+), and goreleaser releases ITSELF as a
+# cask carrying on_macos and on_linux for all four os/arch pairs. See
+# issue #142 for the three reads that settled it.
+homebrew_casks:
   - name: octoscope
     # Scoped to the archive, and this is load-bearing since the bare
     # binaries were added: with two artifacts per os/arch goreleaser
@@ -214,22 +221,37 @@ brews:
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
-    commit_msg_template: "chore(formula): bump octoscope to {{ .Tag }}"
-    directory: Formula
+    commit_msg_template: "chore(cask): bump octoscope to {{ .Tag }}"
+    directory: Casks
     homepage: "https://github.com/gfazioli/octoscope"
     description: "Terminal dashboard for your GitHub account"
     license: "MIT"
     # skip_upload: auto — pre-releases (-dev / -rc) won't bump the
-    # stable formula but still upload archives for testing.
+    # stable cask but still upload archives for testing.
     skip_upload: auto
-    # terminal-notifier powers the desktop notifications on macOS
-    # (icon + click-through to the relevant page). On Linux it's a
-    # no-op extra; goreleaser only writes one Formula but Homebrew
-    # only installs the dep when the bottle is fetched on macOS.
-    dependencies:
-      - name: terminal-notifier
-        os: mac
-    test: |
-      system "#{bin}/octoscope --version"
-    install: |
-      bin.install "octoscope"
+    # The cask equivalent of the formula's `bin.install "octoscope"`.
+    # Plural since goreleaser 2.12.6; the singular form is deprecated and
+    # `goreleaser check` says so, which is the gate this issue exists for.
+    binaries:
+      - octoscope
+    # terminal-notifier powers the desktop notifications on macOS (icon +
+    # click-through). It CANNOT be expressed through `dependencies:` here:
+    # a cask dependency is {cask, formula} with no os field, and the
+    # formula declares `depends_on :macos`, so an unscoped one would fail
+    # every Linux install for an optional feature. The cask DSL does scope
+    # it — `depends_on` sets `@depends_on_set_in_block` when called inside
+    # an on_system block (Homebrew/brew, Library/Homebrew/cask/dsl.rb:630,
+    # read 2026-09-12) — and custom_block is rendered inside the cask body,
+    # so the scoping survives the port. octoscope degrades without it:
+    # internal/notify falls back to the in-app change pulse.
+    custom_block: |
+      on_macos do
+        depends_on formula: "terminal-notifier"
+      end
+    # NOT declared: `conflicts: [{formula: octoscope}]`. It would have
+    # kept a user from ending up with two octoscope binaries on PATH, and
+    # it does not exist any more — Homebrew removed cask-against-formula
+    # conflicts (Homebrew/brew#20499) where they had been a no-op anyway,
+    # and goreleaser deprecated the field in 2.12. So the formula → cask
+    # transition is a documented manual step rather than something the
+    # config can enforce; the order is in #142.


### PR DESCRIPTION
Closes #142. Follow-up for the release-time steps: #165.

`brews` is deprecated, so `goreleaser check` exits 2 today and cannot be used as a gate. **It now exits 0** — run locally against goreleaser 2.18.1.

The migration hung for a week on one question, and #142 settled it: a binary-artifact cask *does* serve Linux Homebrew. This PR is the port, and every claim in it was rendered or executed rather than read.

### The generated cask, not a description of it

`goreleaser release --snapshot --clean` writes `dist/homebrew/Casks/octoscope.rb`:

```ruby
cask "octoscope" do
  on_macos do
    depends_on formula: "terminal-notifier"
  end

  version "..."

  on_macos do
    on_arm  do sha256 "..." ; url ".../octoscope_#{version}_macOS_arm64.tar.gz" end
    on_intel do ... end
  end
  on_linux do
    on_arm  do ... end
    on_intel do ... end
  end
  ...
  binary "octoscope"
end
```

All four os/arch pairs, a `binary` artifact, **no `depends_on macos`** — so `Cask#supports_linux?` is true and Linux Homebrew is served.

### The three hazards #142 named

| Hazard | What happened |
| --- | --- |
| `test:` has no cask equivalent | **Replaced**, in the release workflow, by a step that downloads the *published* Linux tarball and asserts `--version` reports the tag. Better placed than the original — it exercises the file a user downloads rather than a copy Homebrew unpacked. |
| `terminal-notifier` is mac-scoped | **Preserved** through `custom_block`. A cask dependency is `{cask, formula}` with **no os field**, and the formula declares `depends_on :macos` — so the obvious port would fail every Linux install for an optional feature. |
| the tap ends up with two files | **Cannot be fixed here**: it is a release-time step, tracked in #165 with the order that has to hold. |

**The mac-scoping is measured, not argued.** The cask DSL sets `@depends_on_set_in_block` when `depends_on` is called inside an on_system block (`Library/Homebrew/cask/dsl.rb:630`), and `brew info --cask` on the generated file, loaded from a throwaway local tap, answers:

```
==> Dependencies
Required (1): terminal-notifier
==> Artifacts
octoscope (Binary)
```

**The smoke step is measured too**, against the real v0.33.0 release: the asset name `octoscope_0.33.0_Linux_x86_64.tar.gz` exists, `octoscope` sits at the archive root, and `--version` prints `octoscope 0.33.0` — so the pattern, the extracted path and the assertion are all real rather than guessed. It is a hard failure where the ghcr check beside it warns, and the comment says why: a private package is a settings problem with the artifact intact; a binary that does not start is worth a red release.

### Two of my own choices were deprecated too

Which is the gate doing its job on the first run:

- `binary:` is singular-deprecated since 2.12.6 → `binaries: [octoscope]`;
- `conflicts: [{formula: octoscope}]` was **removed from Homebrew entirely** ([Homebrew/brew#20499](https://github.com/Homebrew/brew/pull/20499)) after being a no-op, so a cask cannot declare a conflict with the formula it replaces. That is why #165 exists.

### Known and accepted

`brew style` reports two `Cask/StanzaOrder` offences, because goreleaser renders `custom_block` before `version`. The cask loads and resolves regardless — `brew info` above — and style is not run on install. Said out loud rather than discovered later.

**Checks:** `goreleaser check` exits 0 · `actionlint` clean on both workflows · the snapshot renders the cask, and CI's goreleaser job runs a full snapshot, so a config regression fails a PR.