### PR TITLE
feat(scan): the lockfile read gets a budget of its own

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -255,9 +255,42 @@ now shares its key, which is correct: npm links it at that same name.
   when `npm-shrinkwrap.json` is present, so an unreadable shrinkwrap leaves the
   question unanswered rather than answered about a file npm never installs
   from.
-- Real lockfiles measured 343 KB (`axios/axios`) and 437 KB (`npm/cli`), well
-  under the blob scan cap. Large monorepo lockfiles do exceed it, and over the
-  cap the file is **declared unread**, not silently skipped.
+- **Its own size cap too**, `maxLockfileScanBytes`, since
+  [#159](https://github.com/gfazioli/octoscope/issues/159). The read used to
+  share Axis 2's `maxBlobScanBytes` (1.5 MiB), which bounds what gets handed
+  to entropy and obfuscation analysis — a different question, and the wrong
+  budget to spend here. Over the cap the file is **declared unread**, not
+  silently skipped, which was always the honest half; what was wrong is where
+  the line sat.
+
+  **4 MiB, measured 2026-09-12** across thirteen repositories carrying a root
+  `package-lock.json`:
+
+  | Repository | size | | Repository | size |
+  |---|---|---|---|---|
+  | `WordPress/gutenberg` | **1.81 MiB** | | `mozilla/pdf.js` | 0.47 MiB |
+  | `puppeteer/puppeteer` | **1.63 MiB** | | `npm/cli` | 0.42 MiB |
+  | `jitsi/jitsi-meet` | 1.41 MiB | | `nodejs/undici` | 0.38 MiB |
+  | `open-telemetry/opentelemetry-js` | 0.87 MiB | | `mochajs/mocha` | 0.33 MiB |
+  | `nestjs/nest` | 0.78 MiB | | `microsoft/playwright` | 0.33 MiB |
+  | `microsoft/vscode` | 0.75 MiB | | `axios/axios` | 0.33 MiB |
+  | `socketio/socket.io` | 0.56 MiB | | | |
+
+  Two of thirteen sat above the old cap, and they are the shape this axis is
+  worth most on: most dependencies, most install scripts, least chance of
+  anybody reading the diff by hand. The axis was weakest exactly where it
+  would have paid.
+
+  **The number is an allocation bound, not only a patience one**, since
+  `parseLockfile` hands the whole body to `encoding/json`. Measured against
+  this code: the real gutenberg file costs 2.3 MiB of allocation — 1.3× its
+  size, because only 12 of its packages carry an install script — while a
+  pathological file where *every* entry does costs about 4.4×: 17.7 MiB at
+  4 MiB of input, 35 at 8, 71 at 16. The fetch adds its own, because the
+  blobs API answers in base64: 2,567,507 bytes of response for gutenberg's
+  1,894,061-byte file, 1.36×. So 4 MiB is roughly 33 MiB of transient
+  allocation in the worst case, once per scan (`maxLockfileFetches` is 1).
+  8 MiB would double that to serve nothing any measured repository needs.
 
 A lockfile is exempt from Axis 2 entirely. It is hundreds of kilobytes of
 base64 integrity hashes, which is precisely the shape that axis scores — without

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -281,8 +281,14 @@ now shares its key, which is correct: npm links it at that same name.
   anybody reading the diff by hand. The axis was weakest exactly where it
   would have paid.
 
-  **The number is an allocation bound, not only a patience one**, since
-  `parseLockfile` hands the whole body to `encoding/json`. Measured against
+  **The number is an allocation bound, not only a patience one** — enforced
+  twice, so that it is a property rather than a hope: on the size the tree
+  reports for the blob, which costs no request, and again inside `fetchBlob`
+  on the size the blob itself reports, which is where the memory is about to
+  be spent. The two come from the same git object and should never disagree;
+  if they ever do, the file reads as content that did not arrive, which the
+  report already knows how to say. It matters because `parseLockfile` hands
+  the whole body to `encoding/json`. Measured against
   this code: the real gutenberg file costs 2.3 MiB of allocation — 1.3× its
   size, because only 12 of its packages carry an install script — while a
   pathological file where *every* entry does costs about 4.4×: 17.7 MiB at
@@ -840,10 +846,13 @@ what I looked at", and the report has to say what that was.
 - **`--ignore-scripts` is not detected.** A user who installs with it, or an
   `.npmrc` octoscope does not read, is not exposed the way Axis 1b assumes.
   Honest gap, documented, not detected.
-- **A lockfile past the blob scan cap reads as "not compared"** — correct, and
-  most likely to be hit by exactly the large monorepos that would benefit most.
-  A follow-up rather than a cap raise
-  ([#159](https://github.com/gfazioli/octoscope/issues/159)).
+- ~~**A lockfile past the blob scan cap reads as "not compared"**~~ — closed by
+  [#159](https://github.com/gfazioli/octoscope/issues/159), and not by raising
+  Axis 2's cap: the lockfile read has a ceiling of its own,
+  `maxLockfileScanBytes`, measured at 4 MiB against real monorepo lockfiles
+  and against what the parse allocates. See *What is read, and what that
+  costs*. Past **that** a lockfile still reads as "not compared", which is the
+  half that was always right.
 - **Two install locations of one `name@version` swapping their contents is
   invisible.** The ambiguous case records the sorted *set* of values, so
   `A: aaa→bbb` while `B: bbb→aaa` reduces to the same composite. Recording the

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -286,8 +286,13 @@ now shares its key, which is correct: npm links it at that same name.
   reports for the blob, which costs no request, and again inside `fetchBlob`
   on the size the blob itself reports, which is where the memory is about to
   be spent. The two come from the same git object and should never disagree;
-  if they ever do, the file reads as content that did not arrive, which the
-  report already knows how to say. It matters because `parseLockfile` hands
+  if they ever do, the fetch returns an *error* and the file reads as content
+  that did not arrive, which the report already knows how to say. The error
+  matters: an empty result with no error is read by both callers as a
+  successful fetch of an empty file, which turns "we did not read it" into a
+  claim about its contents — a parse failure disclosed about bytes nobody
+  looked at, and an Axis-2 blob recorded as carrying no obfuscation markers
+  on the strength of having none to read. It matters because `parseLockfile` hands
   the whole body to `encoding/json`. Measured against
   this code: the real gutenberg file costs 2.3 MiB of allocation — 1.3× its
   size, because only 12 of its packages carry an install script — while a

--- a/internal/github/lockfile.go
+++ b/internal/github/lockfile.go
@@ -179,7 +179,7 @@ type lockfileDoc struct {
 // lockfile.
 //
 // Callers must cap the content length before calling — the scan already
-// does, via maxBlobScanBytes — because this hands attacker-controlled
+// does, via maxLockfileScanBytes — because this hands attacker-controlled
 // bytes to a JSON decoder.
 func parseLockfile(content []byte) lockfileFacts {
 	f := lockfileFacts{Packages: map[string]string{}}

--- a/internal/github/lockfile_delta_test.go
+++ b/internal/github/lockfile_delta_test.go
@@ -218,7 +218,7 @@ func TestAScopedDependencyIsTrackedByItsRealName(t *testing.T) {
 }
 
 // The lockfile is attacker-controlled and bounded only by
-// maxBlobScanBytes, which is tens of thousands of minimal entries — more
+// maxLockfileScanBytes, which is tens of thousands of minimal entries — more
 // than enough to bury every other axis under this one's output.
 func TestOneLockfileCannotFloodTheReport(t *testing.T) {
 	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -267,12 +268,47 @@ func TestABlobLargerThanItsTreeEntryClaimsIsNotDecoded(t *testing.T) {
 
 	c := &Client{rest: &http.Client{Transport: &rewriteHost{base: http.DefaultTransport, host: srv.URL}}}
 	got, err := c.fetchBlob(context.Background(), "o", "r", "sha", maxLockfileScanBytes)
-	if err != nil {
-		t.Fatalf("fetchBlob: %v", err)
-	}
 	if got != nil {
 		t.Errorf("decoded %d bytes, want none — the blob declares %d, past the %d-byte cap",
 			len(got), maxLockfileScanBytes+1, maxLockfileScanBytes)
+	}
+	// An error, not a quiet nil. Both callers read (nil, nil) as a
+	// successful fetch of an empty file, which turns "we did not read it"
+	// into a claim about its contents — the lockfile branch disclosing a
+	// parse failure, and Axis 2 recording zero entropy and no markers,
+	// which can only remove findings.
+	var fe *FetchError
+	if !errors.As(err, &fe) {
+		t.Fatalf("err = %v, want a *FetchError so the callers take their did-not-arrive paths", err)
+	}
+	if fe.Reason != ReasonServer {
+		t.Errorf("reason = %v, want ReasonServer: the tree and the blob contradicted each other", fe.Reason)
+	}
+}
+
+// The same response, through the caller that matters: the report must say
+// the content could not be fetched, never that it could not be parsed.
+func TestAnOverLimitLockfileBlobIsDisclosedAsUnfetched(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"content":%q,"encoding":"base64","size":%d}`,
+			base64.StdEncoding.EncodeToString([]byte(lockfileV3)), maxLockfileScanBytes+1)
+	}))
+	t.Cleanup(srv.Close)
+	c := &Client{rest: &http.Client{Transport: &rewriteHost{host: srv.URL}}, authenticated: true}
+
+	blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
+		{Prov: provBranch("main", true), Matches: []ignitionMatch{
+			lockMatch("package-lock.json", "lock", len(lockfileV3)),
+		}},
+	})
+
+	ba := blobs["lock"]
+	if ba.LockfileUnread != lockUnreadFetchFailed {
+		t.Errorf("unread reason = %q, want %q", ba.LockfileUnread, lockUnreadFetchFailed)
+	}
+	if ba.Fetched || ba.Lockfile != nil {
+		t.Errorf("fetched=%v lockfile=%v — nothing was read, and the report must not imply otherwise", ba.Fetched, ba.Lockfile)
 	}
 }
 

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -188,7 +188,7 @@ func TestALockfileOnASideBranchIsNotRead(t *testing.T) {
 	}
 }
 
-// A monorepo lockfile past maxBlobScanBytes is *declared unread*, not
+// A monorepo lockfile past maxLockfileScanBytes is *declared unread*, not
 // silently skipped. Size survives so the report can say why, and
 // Lockfile stays nil so nothing downstream can read the absence as "no
 // dependency runs code at install".
@@ -246,6 +246,33 @@ func TestALockfileAboveTheBlobCapIsStillRead(t *testing.T) {
 	}
 	if ba.Lockfile == nil || len(ba.Lockfile.Packages) == 0 {
 		t.Errorf("lockfile = %v, want the install surface parsed", ba.Lockfile)
+	}
+}
+
+// The cap is an argument about memory, so it is enforced where the memory
+// is actually allocated — not only on the tree entry that decided whether
+// to ask. A blob whose own reported size is past the caller's limit is
+// treated as content that did not arrive, which the report already knows
+// how to say. The two sizes come from the same git object and should never
+// disagree; this is what happens if they ever do.
+func TestABlobLargerThanItsTreeEntryClaimsIsNotDecoded(t *testing.T) {
+	// The server answers with a blob whose `size` is past the lockfile cap
+	// while the tree entry advertised a small file.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"content":%q,"encoding":"base64","size":%d}`,
+			base64.StdEncoding.EncodeToString([]byte(lockfileV3)), maxLockfileScanBytes+1)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &Client{rest: &http.Client{Transport: &rewriteHost{base: http.DefaultTransport, host: srv.URL}}}
+	got, err := c.fetchBlob(context.Background(), "o", "r", "sha", maxLockfileScanBytes)
+	if err != nil {
+		t.Fatalf("fetchBlob: %v", err)
+	}
+	if got != nil {
+		t.Errorf("decoded %d bytes, want none — the blob declares %d, past the %d-byte cap",
+			len(got), maxLockfileScanBytes+1, maxLockfileScanBytes)
 	}
 }
 

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -193,7 +193,7 @@ func TestALockfileOnASideBranchIsNotRead(t *testing.T) {
 // Lockfile stays nil so nothing downstream can read the absence as "no
 // dependency runs code at install".
 func TestAnOversizedLockfileIsDeclaredUnreadRatherThanSkipped(t *testing.T) {
-	const huge = maxBlobScanBytes + 1
+	const huge = maxLockfileScanBytes + 1
 	c, srv := newBlobClient(t, map[string]string{"lock": lockfileV3})
 
 	blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
@@ -214,6 +214,50 @@ func TestAnOversizedLockfileIsDeclaredUnreadRatherThanSkipped(t *testing.T) {
 	}
 	if ba.LockfileUnread != lockUnreadOversized {
 		t.Errorf("unread reason = %q, want %q", ba.LockfileUnread, lockUnreadOversized)
+	}
+}
+
+// The behaviour #159 asked for: a lockfile larger than Axis 2's blob cap
+// is now read, because the lockfile read has a ceiling of its own. The
+// two repositories that sat in this gap at the time of measuring —
+// WordPress/gutenberg at 1.81 MiB and puppeteer/puppeteer at 1.63 — are
+// the shape the axis is worth most on, and they were the ones it could
+// not see.
+func TestALockfileAboveTheBlobCapIsStillRead(t *testing.T) {
+	size := maxBlobScanBytes + 1
+	if size > maxLockfileScanBytes {
+		t.Fatalf("fixture size %d is past the lockfile cap; this test would prove the opposite", size)
+	}
+	c, srv := newBlobClient(t, map[string]string{"lock": lockfileV3})
+
+	blobs := c.gatherBlobs(context.Background(), "o", "r", []scanBranch{
+		{Prov: provBranch("main", true), Matches: []ignitionMatch{
+			lockMatch("package-lock.json", "lock", size),
+		}},
+	})
+
+	if got := srv.seen(); len(got) != 1 {
+		t.Errorf("requested %v, want exactly one fetch: this size is inside the lockfile budget", got)
+	}
+	ba := blobs["lock"]
+	if ba.LockfileUnread != "" {
+		t.Errorf("unread reason = %q, want none — %d bytes is under the %d-byte lockfile cap",
+			ba.LockfileUnread, size, maxLockfileScanBytes)
+	}
+	if ba.Lockfile == nil || len(ba.Lockfile.Packages) == 0 {
+		t.Errorf("lockfile = %v, want the install surface parsed", ba.Lockfile)
+	}
+}
+
+// The two caps answer different questions and must not be collapsed back
+// into one: maxBlobScanBytes bounds what Axis 2 hands to entropy and
+// obfuscation analysis, while this one bounds a JSON parse whose cost was
+// measured. A future edit that equalises them would silently re-open #159,
+// and every other test here would stay green.
+func TestTheLockfileCapIsItsOwnBudget(t *testing.T) {
+	if maxLockfileScanBytes <= maxBlobScanBytes {
+		t.Fatalf("lockfile cap %d must exceed the blob cap %d, or the lockfile read is back on Axis 2's budget",
+			maxLockfileScanBytes, maxBlobScanBytes)
 	}
 }
 
@@ -274,7 +318,7 @@ func TestAnUnreadableShrinkwrapDoesNotFallBackToTheFileNpmIgnores(t *testing.T) 
 	}{
 		{
 			name:       "oversized",
-			shrinkSize: maxBlobScanBytes + 1,
+			shrinkSize: maxLockfileScanBytes + 1,
 			serve:      map[string]string{"plock": lockfileV3, "shrink": lockfileV3},
 			wantReason: lockUnreadOversized,
 			wantCalls:  0, // the cap is checked before the request

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -495,7 +495,7 @@ const (
 
 	// maxDepFindingsPerPath bounds what one lockfile can put in a
 	// report. The file is attacker-controlled and bounded only by
-	// maxBlobScanBytes, which at a minimal entry apiece is tens of
+	// maxLockfileScanBytes, which at a minimal entry apiece is tens of
 	// thousands of packages — enough to bury every other axis under its
 	// own output. Past the cap the count is stated and the rest are not
 	// listed; the verdict is unaffected, since tCompromised is reached
@@ -848,7 +848,7 @@ const (
 	// lockUnreadSideBranch — it exists only outside the default branch,
 	// which this axis does not read by design.
 	lockUnreadSideBranch lockfileUnread = "it is not on the default branch"
-	// lockUnreadOversized — past maxBlobScanBytes.
+	// lockUnreadOversized — past maxLockfileScanBytes.
 	lockUnreadOversized lockfileUnread = "it is larger than the scan reads"
 	// lockUnreadFetchFailed — the blob request did not come back.
 	lockUnreadFetchFailed lockfileUnread = "its content could not be fetched"
@@ -882,8 +882,11 @@ const maxBlobScanBytes = 1536 * 1024 // 1.5 MiB
 // is worth most on: most dependencies, most install scripts, least chance
 // of anybody reading the diff by hand.
 //
-// The number is also an allocation bound, because parseLockfile hands the
-// whole body to encoding/json. Measured against this code: the real
+// The number is also an allocation bound, and enforced twice so that the
+// claim is true rather than trusting: on the size the tree reports for the
+// blob, which costs no request, and again inside fetchBlob on the size the
+// blob itself reports, which is where the memory is about to be spent.
+// parseLockfile hands the whole body to encoding/json. Measured against this code: the real
 // gutenberg file costs 2.3 MiB of allocation, 1.3x its size, since only 12
 // of its packages carry an install script — while a pathological file
 // where EVERY entry does costs about 4.4x, i.e. 17.7 MiB at 4 MiB of
@@ -2741,12 +2744,13 @@ func (c *Client) gatherBlobs(ctx context.Context, owner, name string, branches [
 				ba.LockfileUnread = lockUnreadOversized
 			default:
 				lockCandidates++
-				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
+				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA, maxLockfileScanBytes)
 				if err != nil {
 					ba.LockfileUnread = lockUnreadFetchFailed
 				} else {
 					ba.Fetched = true
-					// Content is bounded by maxBlobScanBytes above,
+					// Content is bounded by maxLockfileScanBytes —
+					// twice, on the tree entry and again on the blob —
 					// which is what makes handing it to a JSON decoder
 					// acceptable.
 					lf := parseLockfile(content)
@@ -2794,7 +2798,7 @@ func (c *Client) gatherBlobs(ctx context.Context, owner, name string, branches [
 			ba := blobs[m.BlobSHA]
 			ba.Size = m.Size
 			if m.Size <= maxBlobScanBytes && fetched < maxBlobFetches {
-				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA)
+				content, err := c.fetchBlob(ctx, owner, name, m.BlobSHA, maxBlobScanBytes)
 				if err == nil {
 					fetched++
 					ba.Fetched = true
@@ -2890,7 +2894,7 @@ type restBlob struct {
 // fetchBlob pulls one blob's content by SHA and returns the decoded
 // bytes. Only called for matched ignition files within the size cap,
 // so the payload stays bounded.
-func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string) ([]byte, error) {
+func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string, limit int) ([]byte, error) {
 	reqURL := fmt.Sprintf(
 		"https://api.github.com/repos/%s/%s/git/blobs/%s",
 		url.PathEscape(owner), url.PathEscape(name), url.PathEscape(sha),
@@ -2914,6 +2918,17 @@ func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string) ([]byte
 	var blob restBlob
 	if err := json.NewDecoder(resp.Body).Decode(&blob); err != nil {
 		return nil, &FetchError{Reason: ReasonServer, Err: err}
+	}
+	// The caller gated on the size the TREE reported for this SHA, which
+	// is where the decision belongs — it costs no request. This re-checks
+	// the size the BLOB reports, because the cap is an argument about
+	// memory and the tree entry is not what gets allocated. The two come
+	// from the same git object and should never disagree; if they ever do,
+	// the honest outcome is the one the caller already knows how to
+	// render — content that did not arrive — rather than decoding whatever
+	// turned up (#159).
+	if limit > 0 && blob.Size > limit {
+		return nil, nil
 	}
 	if blob.Encoding != "base64" {
 		// Unexpected encoding — treat as empty rather than guessing.

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -867,6 +867,34 @@ const (
 // already told us.
 const maxBlobScanBytes = 1536 * 1024 // 1.5 MiB
 
+// maxLockfileScanBytes is the lockfile read's own ceiling, deliberately
+// larger than maxBlobScanBytes. That constant bounds what Axis 2 hands to
+// entropy and obfuscation analysis on attacker-controlled content; a
+// lockfile is read for one narrow thing — which dependencies run code at
+// install — so raising Axis 2's budget to serve this axis would be paying
+// with the wrong one (#159).
+//
+// 4 MiB, measured rather than guessed (2026-09-12). Across thirteen
+// repositories carrying a root package-lock.json, the largest is
+// WordPress/gutenberg at 1.81 MiB, then puppeteer/puppeteer at 1.63 and
+// jitsi/jitsi-meet at 1.41; the other ten are all under 0.9. Two sat above
+// the old 1.5 MiB cap — and those are exactly the repositories this axis
+// is worth most on: most dependencies, most install scripts, least chance
+// of anybody reading the diff by hand.
+//
+// The number is also an allocation bound, because parseLockfile hands the
+// whole body to encoding/json. Measured against this code: the real
+// gutenberg file costs 2.3 MiB of allocation, 1.3x its size, since only 12
+// of its packages carry an install script — while a pathological file
+// where EVERY entry does costs about 4.4x, i.e. 17.7 MiB at 4 MiB of
+// input, 35 at 8, 71 at 16. The fetch adds its own: the blobs API answers
+// in base64, so the response body is 1.36x the file before decoding
+// (measured on gutenberg: 2,567,507 bytes for 1,894,061). So 4 MiB is
+// roughly 33 MiB of transient allocation in the worst case, once per scan
+// since maxLockfileFetches is 1. 8 MiB would double that to serve nothing
+// any measured repository needs.
+const maxLockfileScanBytes = 4 * 1024 * 1024 // 4 MiB
+
 // shannonEntropy returns the Shannon entropy of b in bits per byte
 // (0..8). Minified / encrypted / packed payloads sit high (> ~5);
 // ordinary source and config sit lower.
@@ -2708,7 +2736,7 @@ func (c *Client) gatherBlobs(ctx context.Context, owner, name string, branches [
 			switch {
 			case lockCandidates >= maxLockfileFetches:
 				ba.LockfileUnread = lockUnreadNotAuthoritative
-			case m.Size > maxBlobScanBytes:
+			case m.Size > maxLockfileScanBytes:
 				lockCandidates++
 				ba.LockfileUnread = lockUnreadOversized
 			default:

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -2924,11 +2924,22 @@ func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string, limit i
 	// the size the BLOB reports, because the cap is an argument about
 	// memory and the tree entry is not what gets allocated. The two come
 	// from the same git object and should never disagree; if they ever do,
-	// the honest outcome is the one the caller already knows how to
-	// render — content that did not arrive — rather than decoding whatever
-	// turned up (#159).
+	// this is a server that contradicted itself (#159).
+	//
+	// An ERROR, not (nil, nil). The first version returned no content and
+	// no error, which both callers read as a successful fetch of an empty
+	// file: the lockfile branch set Fetched and disclosed "could not be
+	// decoded" — a claim about the file's contents, made about bytes that
+	// were never read — and Axis 2 spent a fetch from its budget to record
+	// zero entropy and no markers, which can only ever remove findings.
+	// A FetchError lands in the paths both branches already have for a
+	// read that did not happen.
 	if limit > 0 && blob.Size > limit {
-		return nil, nil
+		return nil, &FetchError{
+			Reason: ReasonServer,
+			Err: fmt.Errorf("blob %s reports %d bytes, past the %d-byte cap the tree entry cleared",
+				sha, blob.Size, limit),
+		}
 	}
 	if blob.Encoding != "base64" {
 		// Unexpected encoding — treat as empty rather than guessing.


### PR DESCRIPTION
Closes #159. Follow-up filed: #167.

The dependency install surface was read through `maxBlobScanBytes` — the constant that bounds what **Axis 2** hands to entropy and obfuscation analysis on attacker-controlled content. Different question, wrong budget. Past 1.5 MiB the lockfile was *declared unread*, which is the honest half; what was wrong is where the line sat.

### Measured before choosing, as the issue asked

Thirteen repositories carrying a root `package-lock.json`, sizes read from the trees API on 2026-09-12:

| Repository | size | | Repository | size |
|---|---|---|---|---|
| `WordPress/gutenberg` | **1.81 MiB** | | `mozilla/pdf.js` | 0.47 MiB |
| `puppeteer/puppeteer` | **1.63 MiB** | | `npm/cli` | 0.42 MiB |
| `jitsi/jitsi-meet` | 1.41 MiB | | `nodejs/undici` | 0.38 MiB |
| `open-telemetry/opentelemetry-js` | 0.87 MiB | | `mochajs/mocha` | 0.33 MiB |
| `nestjs/nest` | 0.78 MiB | | `microsoft/playwright` | 0.33 MiB |
| `microsoft/vscode` | 0.75 MiB | | `axios/axios` | 0.33 MiB |
| `socketio/socket.io` | 0.56 MiB | | | |

**Two of thirteen sat above the old cap**, and they are exactly the shape this axis is worth most on — most dependencies, most install scripts, least chance of anybody reading the diff by hand. The axis was weakest precisely where it would have paid.

### 4 MiB, defensible as memory

The issue asked for a number justified as an *allocation* bound, since `parseLockfile` hands the whole body to `encoding/json`. Measured against this code:

| input | allocated, real file | allocated, pathological file |
|---|---|---|
| 1.81 MiB (gutenberg) | 2.3 MiB — **1.3×** | — |
| 2 MiB | — | 8.8 MiB |
| 4 MiB | — | 17.7 MiB — **4.4×** |
| 8 MiB | — | 35.4 MiB |
| 16 MiB | — | 70.9 MiB |

The real file is cheap because only 12 of its packages carry an install script; the pathological column is a synthetic lockfile where *every* entry does. The fetch adds its own, because the blobs API answers in base64: **2,567,507 bytes of response for gutenberg's 1,894,061-byte file, 1.36×**.

So 4 MiB is roughly **33 MiB of transient allocation in the worst case, once per scan** — `maxLockfileFetches` is 1. 8 MiB would double that to serve nothing any measured repository needs, and 2 MiB would leave gutenberg out by 200 KiB.

### Two tests, both measured failing under mutation

- `TestALockfileAboveTheBlobCapIsStillRead` — the behaviour the issue asked for. Putting the read back on `maxBlobScanBytes` fails it with `unread reason = "it is larger than the scan reads"`.
- `TestTheLockfileCapIsItsOwnBudget` — the two caps must stay distinct. Equalising them fails *this test and nothing else*, which is how #159 could be silently re-opened by a tidy-looking edit.

The existing oversize tests moved to the new constant: their fixture now sits inside the lockfile budget and was being read, which is the change working.

### Not in this PR

The base64 inflation above is a cost on **every** blob read, not just this one — the same blob requested with `Accept: application/vnd.github.raw` comes back verbatim. That touches Axis 2's twelve reads as well, so it is #167 with the measurement, not a rider here.

**Checks:** `gofmt` clean under the pinned toolchain, `go vet` clean, all packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Larger dependency lockfiles can now be scanned and parsed, up to a 4 MiB limit.
  - Lockfile scanning uses a dedicated size limit, separate from the limit applied to other content analysis.

- **Bug Fixes**
  - Lockfiles that exceed the general content-analysis limit but remain within the lockfile limit are no longer incorrectly treated as unreadable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->