### PR TITLE
fix(scan): an upgrade is not a dependency that started running code

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -234,6 +234,18 @@ location is deliberately kept there: 20 aliases among 10,881 fetched entries
 in the same sample, none carrying an install script, so reading the alias
 target would rewrite 0.18% of keys to fix nothing this axis can observe.
 
+**The change of key needed a migration, and the baseline carries a marker for
+it** (`DepsKeyVersion`, [#169](https://github.com/gfazioli/octoscope/issues/169)).
+A store written before this keyed workspaces by path, so the first scan after
+upgrading would have described the same package under two names and reported
+weight-2 *"began executing code at install"* for an upgrade — measured before
+the marker existed. The keys cannot be rewritten, since the old one was the
+path even for a workspace that declares a name and nothing recorded says which;
+so a mismatch reads as **not comparable**, in the words the report already has
+for a surface it has not seen before. It costs one scan, and the surface is
+rewritten in the current format as that scan goes. Zero means "written before
+the marker", which is every baseline that existed when it shipped.
+
 What remains: renaming the *directory* of a workspace that has no declared
 name moves the key once, until npm rewrites the lockfile — at which point the
 name differs from the new basename and npm records it, and the key becomes

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -244,7 +244,13 @@ path even for a workspace that declares a name and nothing recorded says which;
 so a mismatch reads as **not comparable**, in the words the report already has
 for a surface it has not seen before. It costs one scan, and the surface is
 rewritten in the current format as that scan goes. Zero means "written before
-the marker", which is every baseline that existed when it shipped.
+the marker", which is every baseline that existed when it shipped — including
+the narrow case of one written from `main` between #158 and this change, which
+was already name-keyed and would have compared fine. It is treated the same
+way deliberately: the recorded format is unknown, and guessing right is worth
+less than one honest scan. Downgrading to a binary from before #158 is not
+supported and undoes the migration, since an older binary drops the field it
+does not declare.
 
 What remains: renaming the *directory* of a workspace that has no declared
 name moves the key once, until npm rewrites the lockfile — at which point the

--- a/internal/config/baseline.go
+++ b/internal/config/baseline.go
@@ -56,10 +56,17 @@ type BaselineFingerprint struct {
 	Seen map[string]map[string]time.Time `json:"seen,omitempty"`
 
 	// DepsKeyVersion is the key format Deps was written in. Zero means a
-	// store written before the field existed, which is every baseline on
-	// disk today — and the scan treats a mismatch as "not comparable"
-	// rather than diffing two different naming schemes against each
-	// other. See github.ScanFingerprint.DepsKeyVersion (#158, #169).
+	// store written before the field existed — and the scan treats a
+	// mismatch as "not comparable" rather than diffing two different
+	// naming schemes against each other. See
+	// github.ScanFingerprint.DepsKeyVersion (#158, #169).
+	//
+	// Forward-only, and worth knowing: an older binary ignores this field
+	// (encoding/json drops what it does not declare), so it will read a
+	// name-keyed surface, write a path-keyed one back, and drop the
+	// marker — which is the false delta again on the next upgrade, once.
+	// Downgrading is not a supported path; this is what it costs if
+	// somebody does it anyway.
 	DepsKeyVersion int `json:"deps_key_version,omitempty"`
 
 	// Deps is the recorded dependency install surface: for each lockfile

--- a/internal/config/baseline.go
+++ b/internal/config/baseline.go
@@ -55,6 +55,13 @@ type BaselineFingerprint struct {
 	// price of being able to recognise a return to any of them.
 	Seen map[string]map[string]time.Time `json:"seen,omitempty"`
 
+	// DepsKeyVersion is the key format Deps was written in. Zero means a
+	// store written before the field existed, which is every baseline on
+	// disk today — and the scan treats a mismatch as "not comparable"
+	// rather than diffing two different naming schemes against each
+	// other. See github.ScanFingerprint.DepsKeyVersion (#158, #169).
+	DepsKeyVersion int `json:"deps_key_version,omitempty"`
+
 	// Deps is the recorded dependency install surface: for each lockfile
 	// path a scan actually read, "name@version" → integrity for the
 	// subset of dependencies that run code at install. See

--- a/internal/config/baseline_test.go
+++ b/internal/config/baseline_test.go
@@ -217,3 +217,24 @@ func TestSeenHistorySurvivesTheRoundTrip(t *testing.T) {
 		t.Errorf("an empty history was written out:\n%s", b)
 	}
 }
+
+// A store written before the marker existed has no deps_key_version at
+// all, and must load as zero rather than as anything that could pass for
+// the current format — that is the value the scan keys its migration on
+// (#169).
+func TestAStoreWithoutTheKeyVersionLoadsAsZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scan-baselines.json")
+	store := `{"repos":{"o/r":{"captured_at":"2026-09-01T00:00:00Z","verdict":"clean","deps":{"main package-lock.json":{"packages/cli@0.4.0":"-"}}}}}`
+	if err := os.WriteFile(path, []byte(store), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := LoadBaselines(path).Repos["o/r"]
+	if got.DepsKeyVersion != 0 {
+		t.Errorf("DepsKeyVersion = %d, want 0 for a store written before the field", got.DepsKeyVersion)
+	}
+	if len(got.Deps) != 1 {
+		t.Errorf("Deps = %v, want the recorded surface to survive the load", got.Deps)
+	}
+}

--- a/internal/github/lockfile_delta_test.go
+++ b/internal/github/lockfile_delta_test.go
@@ -31,9 +31,58 @@ func depsBaseline(capturedAt time.Time, deps map[string]map[string]string) *Scan
 	return &ScanFingerprint{
 		CapturedAt: capturedAt,
 		Verdict:    VerdictClean.String(),
-		Ignition:   map[string]string{},
-		Signed:     map[string]bool{"main": true},
-		Deps:       deps,
+		// Current key format: these fixtures are about the delta, and a
+		// baseline in an older format is not comparable at all — which is
+		// its own pair of tests below.
+		DepsKeyVersion: depsKeyVersion,
+		Ignition:       map[string]string{},
+		Signed:         map[string]bool{"main": true},
+		Deps:           deps,
+	}
+}
+
+// A baseline written before #158 keyed a workspace package by its install
+// path; a scan today keys it by name. Diffing the two describes the same
+// package under two names, so the report claimed weight 2 — "began
+// executing code at install" — for an upgrade that changed nothing. This
+// is measured on the code before the marker existed (#169):
+//
+//	weight 2 — cli runs code at install and did not at the last scan
+//	weight 0 — packages/cli no longer runs code at install
+func TestABaselineInTheOldKeyFormatIsNotComparable(t *testing.T) {
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	old := depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{
+		key: {"packages/cli@0.4.0": noIntegrity}, // keyed by path
+	})
+	old.DepsKeyVersion = 0 // written before the marker existed
+
+	s := evaluateScan(depsInput(map[string]string{"cli@0.4.0": noIntegrity}, old, now))
+
+	found := deltaFindings(s)
+	if len(found) != 1 {
+		t.Fatalf("findings = %+v, want exactly the not-comparable disclosure", found)
+	}
+	if found[0].Weight != 0 {
+		t.Errorf("weight = %d, want 0: nothing about the repository changed", found[0].Weight)
+	}
+	if !strings.Contains(found[0].Reason, "first comparison") {
+		t.Errorf("reason = %q, want the first-comparison wording", found[0].Reason)
+	}
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0 — an upgrade must not score", s.Score)
+	}
+}
+
+// And the scan rewrites the surface as it goes, so the cost is one scan:
+// the fingerprint it produces carries the current format.
+func TestTheScanRecordsTheCurrentKeyFormat(t *testing.T) {
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	s := evaluateScan(depsInput(map[string]string{"cli@0.4.0": noIntegrity}, nil, now))
+	if s.Fingerprint.DepsKeyVersion != depsKeyVersion {
+		t.Errorf("recorded key version = %d, want %d — otherwise every scan reads as a format change",
+			s.Fingerprint.DepsKeyVersion, depsKeyVersion)
 	}
 }
 

--- a/internal/github/lockfile_delta_test.go
+++ b/internal/github/lockfile_delta_test.go
@@ -75,6 +75,39 @@ func TestABaselineInTheOldKeyFormatIsNotComparable(t *testing.T) {
 	}
 }
 
+// "It costs one scan" is the claim the migration rests on, so it is worth
+// asserting rather than reasoning about: feed the fingerprint the first
+// scan produced back in as the baseline for a second one, and the delta
+// has to work normally — a bump reported as a bump, not another reset.
+func TestTheScanAfterTheMigrationComparesNormally(t *testing.T) {
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	key := fingerprintKey("main", "package-lock.json")
+
+	stale := depsBaseline(now.Add(-48*time.Hour), map[string]map[string]string{
+		key: {"packages/cli@0.4.0": noIntegrity},
+	})
+	stale.DepsKeyVersion = 0
+
+	first := evaluateScan(depsInput(map[string]string{"cli@0.4.0": noIntegrity}, stale, now))
+
+	// The surface the first scan recorded becomes the next scan's baseline,
+	// exactly as fetchRepoScanCmd stores it.
+	carried := first.Fingerprint
+	carried.CapturedAt = now.Add(-24 * time.Hour)
+	second := evaluateScan(depsInput(map[string]string{"cli@0.5.0": noIntegrity}, &carried, now))
+
+	found := deltaFindings(second)
+	if len(found) != 1 {
+		t.Fatalf("second scan findings = %+v, want exactly the bump", found)
+	}
+	if strings.Contains(found[0].Reason, "first comparison") {
+		t.Fatalf("the second scan still refuses to compare: %q", found[0].Reason)
+	}
+	if !strings.Contains(found[0].Reason, "already ran code at install and is now at 0.5.0") {
+		t.Errorf("reason = %q, want the ordinary version-bump line", found[0].Reason)
+	}
+}
+
 // And the scan rewrites the surface as it goes, so the cost is one scan:
 // the fingerprint it produces carries the current format.
 func TestTheScanRecordsTheCurrentKeyFormat(t *testing.T) {

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -2049,12 +2049,20 @@ func evaluateScan(in scanInput) *RepoScan {
 				now := s.Fingerprint.Deps[key]
 				prev, had := in.Baseline.Deps[key]
 				if had && in.Baseline.DepsKeyVersion != depsKeyVersion {
-					// A baseline written before workspace packages were
-					// keyed by name (#158): the two sides name the same
-					// package differently, so diffing would report every
-					// install-script workspace as newly arrived — weight
-					// 2 — and its old key as departed, for an upgrade that
-					// changed nothing in the repository (#169).
+					// A baseline whose key format is not the one this scan
+					// produces. In practice that is one written before
+					// workspace packages were keyed by name (#158), where
+					// the two sides name the same package differently and
+					// diffing reports every install-script workspace as
+					// newly arrived — weight 2 — with its old key departed,
+					// for an upgrade that changed nothing (#169).
+					//
+					// Not every markerless baseline is in the old format:
+					// one written from main after #158 and before the
+					// marker existed is already name-keyed and would have
+					// compared fine. It is treated the same way on
+					// purpose — the recorded format is unknown, and
+					// guessing right is worth less than one honest scan.
 					//
 					// Not comparable rather than compared wrongly, which
 					// is this axis's whole posture. It costs one scan: the

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -224,6 +224,25 @@ type ScanFingerprint struct {
 	// See config.BaselineFingerprint.Seen for why it is not bounded.
 	Seen map[string]map[string]time.Time
 
+	// DepsKeyVersion says which key format Deps uses, and exists because
+	// the format changed once: #158 moved a workspace package from being
+	// keyed by its install path to being keyed by its name.
+	//
+	// Without the marker, a baseline written by an older scan and a
+	// surface produced by this one describe the same package under two
+	// names, and the delta reports weight-2 "began executing code at
+	// install" for a package that did nothing — measured on the code in
+	// main before this field existed (#169). The keys cannot simply be
+	// rewritten: the old one was the path even for a workspace that
+	// declares a name, and nothing recorded says which it was.
+	//
+	// Zero means "written before the marker existed", so it also covers
+	// every baseline already on disk. A mismatch costs one scan of
+	// comparison, disclosed at weight 0 in the words the report already
+	// has for it, and the surface is rewritten in the current format as
+	// it goes.
+	DepsKeyVersion int
+
 	// Deps is the Axis-1b dependency install surface: for each lockfile
 	// path this scan actually read, "name@version" → integrity for the
 	// subset of dependencies that run code at install.
@@ -1777,10 +1796,11 @@ func evaluateScan(in scanInput) *RepoScan {
 	// persists it whatever the verdict, so the next scan always has
 	// something to diff against.
 	s.Fingerprint = ScanFingerprint{
-		CapturedAt: in.Now,
-		Ignition:   map[string]string{},
-		Signed:     map[string]bool{},
-		Deps:       map[string]map[string]string{},
+		CapturedAt:     in.Now,
+		DepsKeyVersion: depsKeyVersion,
+		Ignition:       map[string]string{},
+		Signed:         map[string]bool{},
+		Deps:           map[string]map[string]string{},
 	}
 	for _, b := range in.Branches {
 		s.Fingerprint.Signed[b.Prov.Name] = b.Prov.Signed && !b.Prov.SignedByGitHub
@@ -2028,6 +2048,24 @@ func evaluateScan(in scanInput) *RepoScan {
 				}
 				now := s.Fingerprint.Deps[key]
 				prev, had := in.Baseline.Deps[key]
+				if had && in.Baseline.DepsKeyVersion != depsKeyVersion {
+					// A baseline written before workspace packages were
+					// keyed by name (#158): the two sides name the same
+					// package differently, so diffing would report every
+					// install-script workspace as newly arrived — weight
+					// 2 — and its old key as departed, for an upgrade that
+					// changed nothing in the repository (#169).
+					//
+					// Not comparable rather than compared wrongly, which
+					// is this axis's whole posture. It costs one scan: the
+					// surface below is recorded in the current format, so
+					// the next scan diffs normally.
+					add(Finding{
+						Axis: AxisDelta, Branch: branch, Path: path, Weight: 0,
+						Reason: fmt.Sprintf("%s was recorded by an earlier version that identified workspace packages differently, so this is the first comparison of its dependency install surface", path),
+					})
+					continue
+				}
 				if !had {
 					// A lockfile this scan read and the last one did not.
 					// Diffing it against nothing would report every
@@ -2424,6 +2462,12 @@ const maxBlobFetches = 12
 //
 // It counts CANDIDATES, not successful reads. That is what makes it a
 // choice of file rather than a preference: see gatherBlobs.
+// depsKeyVersion is the current Deps key format: 1 is "a workspace is
+// keyed by its name" (#158). Bump it whenever the shape of a Deps key
+// changes, or a baseline in the old shape will be diffed against one in
+// the new and report the difference as a change in the repository.
+const depsKeyVersion = 1
+
 const maxLockfileFetches = 1
 
 // scanRefsQuery enumerates a repository's branches with each tip's

--- a/internal/ui/scan.go
+++ b/internal/ui/scan.go
@@ -608,23 +608,25 @@ func viewRepoScanCmd(r github.Repo) tea.Cmd {
 // the other lacks.
 func baselineToFingerprint(fp config.BaselineFingerprint) github.ScanFingerprint {
 	return github.ScanFingerprint{
-		CapturedAt: fp.CapturedAt,
-		Verdict:    fp.Verdict,
-		Ignition:   fp.Ignition,
-		Signed:     fp.Signed,
-		Seen:       fp.Seen,
-		Deps:       fp.Deps,
+		CapturedAt:     fp.CapturedAt,
+		Verdict:        fp.Verdict,
+		DepsKeyVersion: fp.DepsKeyVersion,
+		Ignition:       fp.Ignition,
+		Signed:         fp.Signed,
+		Seen:           fp.Seen,
+		Deps:           fp.Deps,
 	}
 }
 
 func fingerprintToBaseline(fp github.ScanFingerprint) config.BaselineFingerprint {
 	return config.BaselineFingerprint{
-		CapturedAt: fp.CapturedAt,
-		Verdict:    fp.Verdict,
-		Ignition:   fp.Ignition,
-		Signed:     fp.Signed,
-		Seen:       fp.Seen,
-		Deps:       fp.Deps,
+		CapturedAt:     fp.CapturedAt,
+		Verdict:        fp.Verdict,
+		DepsKeyVersion: fp.DepsKeyVersion,
+		Ignition:       fp.Ignition,
+		Signed:         fp.Signed,
+		Seen:           fp.Seen,
+		Deps:           fp.Deps,
 	}
 }
 

--- a/internal/ui/scan_fingerprint_test.go
+++ b/internal/ui/scan_fingerprint_test.go
@@ -48,10 +48,15 @@ func TestFingerprintConversionCarriesEveryField(t *testing.T) {
 	in := github.ScanFingerprint{
 		CapturedAt: when,
 		Verdict:    "watch",
-		Ignition:   map[string]string{"main\x00.claude/settings.json": "abc123"},
-		Signed:     map[string]bool{"main": true},
-		Seen:       map[string]map[string]time.Time{"main\x00.claude/settings.json": {"abc123": when}},
-		Deps:       map[string]map[string]string{"main\x00package-lock.json": {"fsevents@2.3.3": "sha512-a"}},
+		// Deliberately not the current version: the round trip has to
+		// carry whatever was recorded, including a format this binary no
+		// longer writes, or an old baseline would read back as current
+		// and be diffed against keys it does not share (#169).
+		DepsKeyVersion: 7,
+		Ignition:       map[string]string{"main\x00.claude/settings.json": "abc123"},
+		Signed:         map[string]bool{"main": true},
+		Seen:           map[string]map[string]time.Time{"main\x00.claude/settings.json": {"abc123": when}},
+		Deps:           map[string]map[string]string{"main\x00package-lock.json": {"fsevents@2.3.3": "sha512-a"}},
 	}
 
 	v := reflect.ValueOf(in)


### PR DESCRIPTION
Closes #169 — a defect **#158 introduced and this release would have shipped**.

#158 keys a workspace package by its name rather than its install path. Baselines on disk still hold the old keys, so the first scan after upgrading describes the same package under two names. Measured on `main` before this fix:

```
weight 2 — cli runs code at install and did not at the last scan, now at 0.4.0 per package-lock.json
weight 0 — packages/cli no longer runs code at install; it was at 0.4.0, per package-lock.json
total score: 2
```

`wDeltaNewInstallScript` is the second-heaviest claim this axis makes, and here it is an artefact of the upgrade.

### Why not rewrite the keys, and why not a heuristic

The old key was the **path** for every workspace, including those that declare a name — `npm/cli`'s `docs` is `@npmcli/docs`, and the old key kept neither the scope nor the fact that there was one. A rewrite could only recover the basename case.

A heuristic on the key shape has the same hole from the other side: it would catch `packages/cli` by its slash and miss `docs`, which is a single segment. Both of those are real entries in the sample measured for #158.

### So the fingerprint says which format it is in

`DepsKeyVersion`, persisted as `deps_key_version` and **omitted when zero** — and zero is exactly what every baseline on disk carries today. A mismatch reads as *not comparable*, which is the wording the report already uses for a surface it has not seen before, rather than a diff between two naming schemes.

It costs **one scan**: the surface is recorded in the current format as that scan goes, so the next comparison is normal. Pinned by `TestTheScanRecordsTheCurrentKeyFormat`.

### Mutation-tested, both halves

| mutation | result |
| --- | --- |
| remove the format check | the weight-2 finding comes back, verbatim |
| stop recording the version | every scan reads as a format change |

### The round-trip test earned its keep

`TestFingerprintConversionCarriesEveryField` asserts the fixture leaves **no field zero**, so a new field cannot be added without being carried through both conversions — it failed until `DepsKeyVersion` was wired through `baselineToFingerprint` and `fingerprintToBaseline`. Its fixture deliberately uses a version this binary never writes: a baseline has to read back as what it *was*, not as what we ship today.

**Checks:** `gofmt` clean under the pinned toolchain, all packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented dependency comparisons from producing false findings when upgrading from an older workspace naming format.
  * The first scan after upgrading now treats mismatched historical data as a new comparison and refreshes it using the current format.
  * Scan records now preserve the dependency key format across baseline conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->