### PR TITLE
perf(scan): read blobs raw, and bound the read itself

### DIFF
--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -317,15 +317,27 @@ now shares its key, which is correct: npm links it at that same name.
   pathological file where *every* entry does costs about 4.4×: 17.7 MiB at
   4 MiB of input, 35 at 8, 71 at 16.
 
-  Fetch and parse **together**, measured end to end through this code on a
-  3.94 MiB pathological lockfile (2026-09-12): **44.5 MiB before
-  [#167](https://github.com/gfazioli/octoscope/issues/167), 32.8 MiB
-  after** — the difference being the base64 field and its newline-stripped
-  copy, which the raw body removes. Not the 2.7× the arithmetic suggests:
-  `io.ReadAll` grows by doubling and the parse dominates, which is exactly
-  why the figure is measured rather than derived. Once per scan, since
-  `maxLockfileFetches` is 1; 8 MiB would roughly double it to serve nothing
-  any measured repository needs.
+  Fetch and parse **together**, on a 3.94 MiB pathological lockfile: about
+  **29 MiB**, and re-derivable rather than quoted —
+  `BenchmarkLockfileFetchAndParse` builds that fixture and reports it as
+  `B/op`:
+
+  ```sh
+  go test ./internal/github/ -run '^$' -bench LockfileFetchAndParse -benchmem
+  ```
+
+  Once per scan, since `maxLockfileFetches` is 1; 8 MiB would roughly double
+  it to serve nothing any measured repository needs.
+
+  Dropping the base64 envelope in
+  [#167](https://github.com/gfazioli/octoscope/issues/167) took roughly
+  **12 MiB** off that figure — measured once on 2026-09-12 against the same
+  fixture by reconstructing the old path's steps, 44.5 MiB of allocation
+  against 32.8 as `TotalAlloc` deltas. That one is a dated one-off and
+  cannot be re-run from this repository, because the path it compares
+  against is gone. The saving is real and much smaller than the 2.7× the
+  copies suggest: `io.ReadAll` grows by doubling, and the parse dominates
+  both sides.
 
   **The cap is enforced on the read itself**, not on a size the response
   reports — raw has no envelope to declare one. The reader takes at most

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -315,17 +315,20 @@ now shares its key, which is correct: npm links it at that same name.
   this code: the real gutenberg file costs 2.3 MiB of allocation — 1.3× its
   size, because only 12 of its packages carry an install script — while a
   pathological file where *every* entry does costs about 4.4×: 17.7 MiB at
-  4 MiB of input, 35 at 8, 71 at 16. The fetch used to add 2.7× of its own
-  on top — the blobs API answered in base64 (2,567,507 bytes of response for
-  gutenberg's 1,894,061-byte file, 1.36×) plus the newline-stripped copy and
-  the decoded bytes. Since
-  [#167](https://github.com/gfazioli/octoscope/issues/167) it asks for the
-  raw body and adds one. So 4 MiB is roughly 22 MiB of transient allocation
-  in the worst case, once per scan (`maxLockfileFetches` is 1). 8 MiB would
-  double that to serve nothing any measured repository needs.
+  4 MiB of input, 35 at 8, 71 at 16.
+
+  Fetch and parse **together**, measured end to end through this code on a
+  3.94 MiB pathological lockfile (2026-09-12): **44.5 MiB before
+  [#167](https://github.com/gfazioli/octoscope/issues/167), 32.8 MiB
+  after** — the difference being the base64 field and its newline-stripped
+  copy, which the raw body removes. Not the 2.7× the arithmetic suggests:
+  `io.ReadAll` grows by doubling and the parse dominates, which is exactly
+  why the figure is measured rather than derived. Once per scan, since
+  `maxLockfileFetches` is 1; 8 MiB would roughly double it to serve nothing
+  any measured repository needs.
 
   **The cap is enforced on the read itself**, not on a size the response
-  reports: raw has no envelope to declare one, and the reader takes at most
+  reports — raw has no envelope to declare one. The reader takes at most
   the cap plus one byte — the extra byte being how a file *at* the cap is
   told from one over it. That is stronger than what it replaced, and it is
   pinned by a test that counts the bytes actually read rather than the

--- a/docs/design/supply-chain-scan.md
+++ b/docs/design/supply-chain-scan.md
@@ -315,11 +315,24 @@ now shares its key, which is correct: npm links it at that same name.
   this code: the real gutenberg file costs 2.3 MiB of allocation — 1.3× its
   size, because only 12 of its packages carry an install script — while a
   pathological file where *every* entry does costs about 4.4×: 17.7 MiB at
-  4 MiB of input, 35 at 8, 71 at 16. The fetch adds its own, because the
-  blobs API answers in base64: 2,567,507 bytes of response for gutenberg's
-  1,894,061-byte file, 1.36×. So 4 MiB is roughly 33 MiB of transient
-  allocation in the worst case, once per scan (`maxLockfileFetches` is 1).
-  8 MiB would double that to serve nothing any measured repository needs.
+  4 MiB of input, 35 at 8, 71 at 16. The fetch used to add 2.7× of its own
+  on top — the blobs API answered in base64 (2,567,507 bytes of response for
+  gutenberg's 1,894,061-byte file, 1.36×) plus the newline-stripped copy and
+  the decoded bytes. Since
+  [#167](https://github.com/gfazioli/octoscope/issues/167) it asks for the
+  raw body and adds one. So 4 MiB is roughly 22 MiB of transient allocation
+  in the worst case, once per scan (`maxLockfileFetches` is 1). 8 MiB would
+  double that to serve nothing any measured repository needs.
+
+  **The cap is enforced on the read itself**, not on a size the response
+  reports: raw has no envelope to declare one, and the reader takes at most
+  the cap plus one byte — the extra byte being how a file *at* the cap is
+  told from one over it. That is stronger than what it replaced, and it is
+  pinned by a test that counts the bytes actually read rather than the
+  outcome. The first version of that test passed with the bound removed,
+  because the length check after the read caught the same case — by which
+  point the whole body had been allocated, which is the one thing the cap
+  exists to prevent.
 
 A lockfile is exempt from Axis 2 entirely. It is hundreds of kilobytes of
 base64 integrity hashes, which is precisely the shape that axis scores — without

--- a/internal/github/lockfile_bench_test.go
+++ b/internal/github/lockfile_bench_test.go
@@ -1,0 +1,55 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// syntheticLockfile builds a pathological lockfile of roughly n bytes:
+// every entry carries an install script, which is the shape that costs the
+// most to parse and the one the cap has to be defensible against. A real
+// lockfile is far cheaper — WordPress/gutenberg's 1.81 MiB has 12 such
+// entries out of thousands.
+func syntheticLockfile(n int) string {
+	var b strings.Builder
+	b.WriteString(`{"lockfileVersion":3,"packages":{"":{"name":"x","version":"1.0.0"},`)
+	for i := 0; b.Len() < n; i++ {
+		fmt.Fprintf(&b, `"node_modules/pkg%d":{"version":"1.0.%d","integrity":"sha512-%s","hasInstallScript":true},`,
+			i, i, strings.Repeat("A", 64))
+	}
+	return strings.TrimSuffix(b.String(), ",") + "}}"
+}
+
+// BenchmarkLockfileFetchAndParse is where the allocation figures in
+// maxLockfileScanBytes's comment come from, so they can be re-derived
+// rather than believed:
+//
+//	go test ./internal/github/ -run '^$' -bench LockfileFetchAndParse -benchmem
+//
+// It exercises the real path — fetchBlob over an httptest server, then
+// parseLockfile — at just under the cap, which is the worst case the cap
+// admits. B/op is the number the comment quotes.
+func BenchmarkLockfileFetchAndParse(b *testing.B) {
+	body := syntheticLockfile(maxLockfileScanBytes - (64 << 10))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+	c := &Client{rest: &http.Client{Transport: &rewriteHost{host: srv.URL}}}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		content, err := c.fetchBlob(context.Background(), "o", "r", "sha", maxLockfileScanBytes)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if f := parseLockfile(content); len(f.Packages) == 0 {
+			b.Fatal("fixture parsed to nothing; the benchmark would measure the wrong path")
+		}
+	}
+}

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -2,10 +2,9 @@ package github
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -53,12 +52,10 @@ func newBlobClient(t *testing.T, content map[string]string) (*Client, *blobServe
 			http.NotFound(w, r)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(restBlob{
-			Content:  base64.StdEncoding.EncodeToString([]byte(body)),
-			Encoding: "base64",
-			Size:     len(body),
-		})
+		// Raw, as the blobs API answers `Accept: application/vnd.github.raw`
+		// since #167 — the file itself, not base64 inside an envelope.
+		w.Header().Set("Content-Type", "application/vnd.github.raw")
+		_, _ = io.WriteString(w, body)
 	}))
 	t.Cleanup(srv.Close)
 	return &Client{rest: &http.Client{Transport: &rewriteHost{host: srv.URL}}, authenticated: true}, bs
@@ -251,26 +248,25 @@ func TestALockfileAboveTheBlobCapIsStillRead(t *testing.T) {
 }
 
 // The cap is an argument about memory, so it is enforced where the memory
-// is actually allocated — not only on the tree entry that decided whether
-// to ask. A blob whose own reported size is past the caller's limit is
-// treated as content that did not arrive, which the report already knows
-// how to say. The two sizes come from the same git object and should never
-// disagree; this is what happens if they ever do.
-func TestABlobLargerThanItsTreeEntryClaimsIsNotDecoded(t *testing.T) {
-	// The server answers with a blob whose `size` is past the lockfile cap
-	// while the tree entry advertised a small file.
+// is actually allocated: on the READ. The tree entry decided whether to
+// ask at all — it costs no request — but a server that sends more than it
+// advertised would otherwise be allocated in full before anyone noticed.
+// Since #167 the body arrives raw, so there is no self-reported size to
+// trust and the bytes themselves are the bound.
+func TestABlobLargerThanItsTreeEntryClaimsIsNotRead(t *testing.T) {
+	// The tree entry advertised a small file; the server sends one byte
+	// past the cap.
+	oversized := strings.Repeat("x", maxLockfileScanBytes+1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"content":%q,"encoding":"base64","size":%d}`,
-			base64.StdEncoding.EncodeToString([]byte(lockfileV3)), maxLockfileScanBytes+1)
+		_, _ = io.WriteString(w, oversized)
 	}))
 	t.Cleanup(srv.Close)
 
 	c := &Client{rest: &http.Client{Transport: &rewriteHost{base: http.DefaultTransport, host: srv.URL}}}
 	got, err := c.fetchBlob(context.Background(), "o", "r", "sha", maxLockfileScanBytes)
 	if got != nil {
-		t.Errorf("decoded %d bytes, want none — the blob declares %d, past the %d-byte cap",
-			len(got), maxLockfileScanBytes+1, maxLockfileScanBytes)
+		t.Errorf("read %d bytes, want none — the body is %d, past the %d-byte cap",
+			len(got), len(oversized), maxLockfileScanBytes)
 	}
 	// An error, not a quiet nil. Both callers read (nil, nil) as a
 	// successful fetch of an empty file, which turns "we did not read it"
@@ -282,7 +278,73 @@ func TestABlobLargerThanItsTreeEntryClaimsIsNotDecoded(t *testing.T) {
 		t.Fatalf("err = %v, want a *FetchError so the callers take their did-not-arrive paths", err)
 	}
 	if fe.Reason != ReasonServer {
-		t.Errorf("reason = %v, want ReasonServer: the tree and the blob contradicted each other", fe.Reason)
+		t.Errorf("reason = %v, want ReasonServer: the blob outgrew what the tree entry cleared", fe.Reason)
+	}
+}
+
+// The previous test proves the OUTCOME — an over-limit blob errors — and
+// a mutation showed it proves nothing about the bound: remove the
+// io.LimitReader and it still passes, because the length check after
+// ReadAll catches the same case. But by then the whole body has been
+// allocated, which is the one thing the cap exists to prevent.
+//
+// So this one counts what was actually read. A body of 10 MiB behind a
+// 64-byte cap must yield at most 65 bytes off the wire: the cap, plus the
+// one byte that tells "exactly at the limit" from "over it".
+type countingBody struct {
+	data []byte
+	read int
+}
+
+func (c *countingBody) Read(p []byte) (int, error) {
+	if c.read >= len(c.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, c.data[c.read:])
+	c.read += n
+	return n, nil
+}
+
+func (c *countingBody) Close() error { return nil }
+
+type bodyTransport struct{ body *countingBody }
+
+func (t *bodyTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: t.body, Header: http.Header{}}, nil
+}
+
+func TestAnOverLimitBlobIsNotReadPastTheCap(t *testing.T) {
+	const limit = 64
+	body := &countingBody{data: []byte(strings.Repeat("z", 10<<20))}
+
+	c := &Client{rest: &http.Client{Transport: &bodyTransport{body: body}}}
+	if _, err := c.fetchBlob(context.Background(), "o", "r", "sha", limit); err == nil {
+		t.Fatal("fetchBlob returned no error for a body far past the cap")
+	}
+	if body.read > limit+1 {
+		t.Errorf("read %d bytes of a %d-byte body; the cap is %d, so at most %d may be read — "+
+			"without the bound the whole file is allocated before being rejected",
+			body.read, len(body.data), limit, limit+1)
+	}
+}
+
+// A file exactly AT the cap is not over it, and the one extra byte the
+// reader takes is what tells the two apart.
+func TestABlobExactlyAtTheCapIsRead(t *testing.T) {
+	const limit = 64
+	body := strings.Repeat("y", limit)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &Client{rest: &http.Client{Transport: &rewriteHost{base: http.DefaultTransport, host: srv.URL}}}
+	got, err := c.fetchBlob(context.Background(), "o", "r", "sha", limit)
+	if err != nil {
+		t.Fatalf("fetchBlob: %v", err)
+	}
+	if len(got) != limit {
+		t.Errorf("read %d bytes, want %d — a file at the cap is inside it", len(got), limit)
 	}
 }
 
@@ -290,9 +352,7 @@ func TestABlobLargerThanItsTreeEntryClaimsIsNotDecoded(t *testing.T) {
 // the content could not be fetched, never that it could not be parsed.
 func TestAnOverLimitLockfileBlobIsDisclosedAsUnfetched(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"content":%q,"encoding":"base64","size":%d}`,
-			base64.StdEncoding.EncodeToString([]byte(lockfileV3)), maxLockfileScanBytes+1)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxLockfileScanBytes+1))
 	}))
 	t.Cleanup(srv.Close)
 	c := &Client{rest: &http.Client{Transport: &rewriteHost{host: srv.URL}}, authenticated: true}

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -52,8 +53,17 @@ func newBlobClient(t *testing.T, content map[string]string) (*Client, *blobServe
 			http.NotFound(w, r)
 			return
 		}
-		// Raw, as the blobs API answers `Accept: application/vnd.github.raw`
-		// since #167 — the file itself, not base64 inside an envelope.
+		// The media type is part of the contract, so the fake enforces it:
+		// ask for anything but raw and you get the envelope back, exactly
+		// as GitHub would — which is what makes a regression to
+		// `+json` fail here instead of silently handing the scan a JSON
+		// object to analyse as if it were file bytes (#167).
+		if !strings.HasPrefix(r.Header.Get("Accept"), "application/vnd.github.raw") {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"content":%q,"encoding":"base64","size":%d}`,
+				base64.StdEncoding.EncodeToString([]byte(body)), len(body))
+			return
+		}
 		w.Header().Set("Content-Type", "application/vnd.github.raw")
 		_, _ = io.WriteString(w, body)
 	}))

--- a/internal/github/lockfile_fetch_test.go
+++ b/internal/github/lockfile_fetch_test.go
@@ -58,7 +58,10 @@ func newBlobClient(t *testing.T, content map[string]string) (*Client, *blobServe
 		// as GitHub would — which is what makes a regression to
 		// `+json` fail here instead of silently handing the scan a JSON
 		// object to analyse as if it were file bytes (#167).
-		if !strings.HasPrefix(r.Header.Get("Accept"), "application/vnd.github.raw") {
+		// Exact, not a prefix: a prefix accepts the legacy
+		// `application/vnd.github.raw` this code deliberately moved off,
+		// and `…raw-anything` besides.
+		if r.Header.Get("Accept") != "application/vnd.github.raw+json" {
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprintf(w, `{"content":%q,"encoding":"base64","size":%d}`,
 				base64.StdEncoding.EncodeToString([]byte(body)), len(body))

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -911,14 +911,21 @@ const maxBlobScanBytes = 1536 * 1024 // 1.5 MiB
 // pathological file where EVERY entry does costs about 4.4x, i.e. 17.7 MiB
 // at 4 MiB of input, 35 at 8, 71 at 16.
 //
-// End to end, fetch and parse together on a 3.94 MiB pathological lockfile,
-// measured through this code on 2026-09-12: 44.5 MiB before #167 and
-// 32.8 MiB after, the difference being the base64 field and its
-// newline-stripped copy. Not the 2.7x of arithmetic — io.ReadAll grows by
-// doubling and the parse dominates — which is why the number is measured
-// rather than derived. Once per scan, since maxLockfileFetches is 1;
-// 8 MiB would roughly double it to serve nothing any measured repository
-// needs.
+// End to end, fetch and parse together on a 3.94 MiB pathological lockfile:
+// about 29 MiB, and re-derivable rather than quoted —
+// BenchmarkLockfileFetchAndParse builds that fixture and reports it as
+// B/op (go test ./internal/github/ -run '^$' -bench LockfileFetchAndParse
+// -benchmem). Once per scan, since maxLockfileFetches is 1; 8 MiB would
+// roughly double it to serve nothing any measured repository needs.
+//
+// Dropping the base64 envelope in #167 took roughly 12 MiB off that,
+// measured once on 2026-09-12 against the same fixture by reconstructing
+// the old path's steps (44.5 MiB of allocation versus 32.8 as TotalAlloc
+// deltas). That one is a dated one-off and cannot be re-run from this
+// repository, since the path it compares against is gone. Worth knowing
+// and not worth trusting further than that: the saving is real but far
+// smaller than the 2.7x the copies suggest, because io.ReadAll grows by
+// doubling and the parse dominates both sides.
 const maxLockfileScanBytes = 4 * 1024 * 1024 // 4 MiB
 
 // shannonEntropy returns the Shannon entropy of b in bits per byte

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -905,16 +904,15 @@ const maxBlobScanBytes = 1536 * 1024 // 1.5 MiB
 // claim is true rather than trusting: on the size the tree reports for the
 // blob, which costs no request, and again inside fetchBlob on the size the
 // blob itself reports, which is where the memory is about to be spent.
-// parseLockfile hands the whole body to encoding/json. Measured against this code: the real
-// gutenberg file costs 2.3 MiB of allocation, 1.3x its size, since only 12
-// of its packages carry an install script — while a pathological file
-// where EVERY entry does costs about 4.4x, i.e. 17.7 MiB at 4 MiB of
-// input, 35 at 8, 71 at 16. The fetch adds its own: the blobs API answers
-// in base64, so the response body is 1.36x the file before decoding
-// (measured on gutenberg: 2,567,507 bytes for 1,894,061). So 4 MiB is
-// roughly 33 MiB of transient allocation in the worst case, once per scan
-// since maxLockfileFetches is 1. 8 MiB would double that to serve nothing
-// any measured repository needs.
+// parseLockfile hands the whole body to encoding/json. Measured against
+// this code: the real gutenberg file costs 2.3 MiB of allocation, 1.3x its
+// size, since only 12 of its packages carry an install script — while a
+// pathological file where EVERY entry does costs about 4.4x, i.e. 17.7 MiB
+// at 4 MiB of input, 35 at 8, 71 at 16. The fetch used to add 2.7x of its
+// own on top, in base64 and its stripped copy; since #167 it reads the raw
+// body and adds one. So 4 MiB is roughly 22 MiB of transient allocation in
+// the worst case, once per scan since maxLockfileFetches is 1. 8 MiB would
+// double that to serve nothing any measured repository needs.
 const maxLockfileScanBytes = 4 * 1024 * 1024 // 4 MiB
 
 // shannonEntropy returns the Shannon entropy of b in bits per byte
@@ -2936,16 +2934,9 @@ func (c *Client) fetchTree(ctx context.Context, owner, name, treeSHA string) ([]
 	return entries, tree.Truncated, nil
 }
 
-// restBlob mirrors the get-a-blob response (base64-encoded content).
-type restBlob struct {
-	Content  string `json:"content"`
-	Encoding string `json:"encoding"`
-	Size     int    `json:"size"`
-}
-
-// fetchBlob pulls one blob's content by SHA and returns the decoded
-// bytes. Only called for matched ignition files within the size cap,
-// so the payload stays bounded.
+// fetchBlob pulls one blob's content by SHA, bounded by limit. Only
+// called for matched files the tree already said were within the cap, so
+// the payload stays bounded twice over.
 func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string, limit int) ([]byte, error) {
 	reqURL := fmt.Sprintf(
 		"https://api.github.com/repos/%s/%s/git/blobs/%s",
@@ -2955,7 +2946,14 @@ func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string, limit i
 	if err != nil {
 		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
+	// RAW, not the JSON envelope. Asked as JSON, GitHub answers with the
+	// file base64-encoded inside an object, and this function then held
+	// three copies of a file it wants once: the encoded field, the
+	// newline-stripped copy, and the decoded bytes. Measured on
+	// WordPress/gutenberg's package-lock.json — 1,894,061 bytes — the
+	// `content` field came back at 2,567,507, and the same blob requested
+	// raw returns the file verbatim (#167).
+	req.Header.Set("Accept", "application/vnd.github.raw")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
 	resp, err := c.rest.Do(req)
@@ -2967,42 +2965,34 @@ func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string, limit i
 		return nil, err
 	}
 
-	var blob restBlob
-	if err := json.NewDecoder(resp.Body).Decode(&blob); err != nil {
-		return nil, &FetchError{Reason: ReasonServer, Err: err}
+	// The cap is enforced on the READ, which is stronger than what it
+	// replaces. The envelope carried a `size` field and #159 checked it —
+	// but that is a number the server reports about bytes it is about to
+	// send, while this bounds the bytes themselves. One byte past the
+	// limit is read on purpose: it is how a file exactly at the cap is
+	// told from one over it.
+	r := io.Reader(resp.Body)
+	if limit > 0 {
+		r = io.LimitReader(resp.Body, int64(limit)+1)
 	}
-	// The caller gated on the size the TREE reported for this SHA, which
-	// is where the decision belongs — it costs no request. This re-checks
-	// the size the BLOB reports, because the cap is an argument about
-	// memory and the tree entry is not what gets allocated. The two come
-	// from the same git object and should never disagree; if they ever do,
-	// this is a server that contradicted itself (#159).
-	//
-	// An ERROR, not (nil, nil). The first version returned no content and
-	// no error, which both callers read as a successful fetch of an empty
-	// file: the lockfile branch set Fetched and disclosed "could not be
-	// decoded" — a claim about the file's contents, made about bytes that
-	// were never read — and Axis 2 spent a fetch from its budget to record
-	// zero entropy and no markers, which can only ever remove findings.
-	// A FetchError lands in the paths both branches already have for a
-	// read that did not happen.
-	if limit > 0 && blob.Size > limit {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, &FetchError{Reason: classifyErr(ctx, err), Err: err}
+	}
+	if limit > 0 && len(body) > limit {
+		// An ERROR, not (nil, nil). Both callers read "no content, no
+		// error" as a successful fetch of an empty file: the lockfile
+		// branch would disclose "could not be decoded" about bytes nobody
+		// read, and Axis 2 would spend a fetch from its budget to record
+		// zero entropy and no markers, which can only ever remove
+		// findings (#159).
 		return nil, &FetchError{
 			Reason: ReasonServer,
-			Err: fmt.Errorf("blob %s reports %d bytes, past the %d-byte cap the tree entry cleared",
-				sha, blob.Size, limit),
+			Err: fmt.Errorf("blob %s is larger than the %d-byte cap the tree entry cleared",
+				sha, limit),
 		}
 	}
-	if blob.Encoding != "base64" {
-		// Unexpected encoding — treat as empty rather than guessing.
-		return nil, nil
-	}
-	// GitHub wraps the base64 in newlines; strip them before decoding.
-	decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(blob.Content, "\n", ""))
-	if err != nil {
-		return nil, &FetchError{Reason: ReasonServer, Err: err}
-	}
-	return decoded, nil
+	return body, nil
 }
 
 // restStatusError classifies a non-2xx REST response into the shared

--- a/internal/github/scan.go
+++ b/internal/github/scan.go
@@ -902,17 +902,23 @@ const maxBlobScanBytes = 1536 * 1024 // 1.5 MiB
 //
 // The number is also an allocation bound, and enforced twice so that the
 // claim is true rather than trusting: on the size the tree reports for the
-// blob, which costs no request, and again inside fetchBlob on the size the
-// blob itself reports, which is where the memory is about to be spent.
+// blob, which costs no request, and again inside fetchBlob on the bytes it
+// actually reads — there is no size field to trust since the body arrives
+// raw (#167), and the read is where the memory is spent anyway.
 // parseLockfile hands the whole body to encoding/json. Measured against
 // this code: the real gutenberg file costs 2.3 MiB of allocation, 1.3x its
 // size, since only 12 of its packages carry an install script — while a
 // pathological file where EVERY entry does costs about 4.4x, i.e. 17.7 MiB
-// at 4 MiB of input, 35 at 8, 71 at 16. The fetch used to add 2.7x of its
-// own on top, in base64 and its stripped copy; since #167 it reads the raw
-// body and adds one. So 4 MiB is roughly 22 MiB of transient allocation in
-// the worst case, once per scan since maxLockfileFetches is 1. 8 MiB would
-// double that to serve nothing any measured repository needs.
+// at 4 MiB of input, 35 at 8, 71 at 16.
+//
+// End to end, fetch and parse together on a 3.94 MiB pathological lockfile,
+// measured through this code on 2026-09-12: 44.5 MiB before #167 and
+// 32.8 MiB after, the difference being the base64 field and its
+// newline-stripped copy. Not the 2.7x of arithmetic — io.ReadAll grows by
+// doubling and the parse dominates — which is why the number is measured
+// rather than derived. Once per scan, since maxLockfileFetches is 1;
+// 8 MiB would roughly double it to serve nothing any measured repository
+// needs.
 const maxLockfileScanBytes = 4 * 1024 * 1024 // 4 MiB
 
 // shannonEntropy returns the Shannon entropy of b in bits per byte
@@ -2953,7 +2959,14 @@ func (c *Client) fetchBlob(ctx context.Context, owner, name, sha string, limit i
 	// WordPress/gutenberg's package-lock.json — 1,894,061 bytes — the
 	// `content` field came back at 2,567,507, and the same blob requested
 	// raw returns the file verbatim (#167).
-	req.Header.Set("Accept", "application/vnd.github.raw")
+	//
+	// `raw+json` rather than the older `raw`: both answer with the file
+	// today — measured against this endpoint on 2026-09-12, while plain
+	// `+json` returns the envelope — but only the suffixed form is in the
+	// current Get-a-Blob reference, and a legacy alias that stops being
+	// negotiated would silently hand this code an envelope to analyse as
+	// if it were file bytes.
+	req.Header.Set("Accept", "application/vnd.github.raw+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
 	resp, err := c.rest.Do(req)


### PR DESCRIPTION
Closes #167.

`fetchBlob` asked for `application/vnd.github+json`, so GitHub answered with the file **base64-encoded inside an object** and the function held three copies of a file it wants once: the encoded field, the newline-stripped copy, and the decoded bytes. Measured on `WordPress/gutenberg`'s `package-lock.json` — 1,894,061 bytes — the `content` field came back at **2,567,507, 1.36×**, before any of the rest.

With `application/vnd.github.raw` the body *is* the file. Every blob read gets cheaper — Axis 2's twelve as well as the lockfile's one — and #159's memory argument drops from ~33 MiB of transient allocation at 4 MiB of input to **~22**.

### The bound moved, and got stronger

The envelope was also where #159's size re-check lived, and raw has no self-reported size to check. So the cap is now enforced on the **read**: `io.LimitReader` takes at most the cap plus one byte — the extra byte being how a file *exactly at* the cap is told from one past it.

That is better than what it replaced. The old check trusted a number the server reported about bytes it was about to send; this bounds the bytes themselves.

### Why three tests and not one

The obvious test — an over-limit body must error — **passes with the bound removed**. The length check after the read catches the same case, so the outcome is identical; by then the whole body has been allocated, which is exactly what the cap exists to prevent. The mutation is what surfaced it:

| test | mutation: drop the `io.LimitReader` |
| --- | --- |
| over-limit body errors | still passes — proves the outcome, not the bound |
| a body exactly at the cap is read | still passes |
| **bytes actually read ≤ cap + 1** | **fails: `read 10485760 bytes of a 10485760-byte body`** |

The third uses a counting reader behind a stub transport, so it measures the read rather than the HTTP server's behaviour.

### Verified live, through this client

Not only through `curl`: a real blob came back verbatim at its exact size (3,024 bytes, first line `.PHONY: build install test race tapes tape tapes-clean fmt vet help`), and a 10-byte cap refused it. Build-tag-gated smoke test, deleted before committing, per the repo's rule.

`restBlob` and the `encoding/base64` import are gone with the envelope, and the test server serves raw bodies now.

**Checks:** `gofmt` clean under the pinned toolchain, `go vet` clean, all packages pass.