### PR TITLE
ci(pages): a failed publish stops looking like an unchanged site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,3 +392,58 @@ jobs:
             n=$(jq --arg p "$want" '[.[] | select(.type == "Docker Image" and (.extra.Platforms // []) == [$p])] | length' dist/artifacts.json)
             [ "$n" -ge 1 ] || { echo "no image built for $want"; exit 1; }
           done
+
+  # The site is published by a build nobody configured. Pages runs Jekyll
+  # over docs/ on every push to main — `build_type: legacy`, measured
+  # 2026-09-12, which is also why a markdown code sample containing Liquid
+  # braces could take the whole site down. When that build fails the live
+  # site keeps serving the previous one, so the failure looks exactly like
+  # a site that has not changed.
+  #
+  # It happened: seven consecutive failures over twenty-two hours in August
+  # 2026, spanning two release-prep commits, and the only reason anyone
+  # noticed was a post-tag check that read the served bytes (#122).
+  #
+  # This job asks. It is a detector rather than a cure — the cure is
+  # publishing without Jekyll, which needs the repository's Pages source
+  # switched to "GitHub Actions" and is the second half of #122.
+  pages:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: read
+    steps:
+      - name: Did the site publish this commit?
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Pages starts within seconds of the push and this site builds in
+          # well under a minute; five minutes is a ceiling for a slow queue,
+          # not an expectation.
+          for _ in $(seq 1 30); do
+            latest=$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest")
+            status=$(printf '%s' "$latest" | jq -r '.status')
+            commit=$(printf '%s' "$latest" | jq -r '.commit')
+            echo "pages build: status=${status} commit=${commit:0:7} (want ${GITHUB_SHA:0:7})"
+
+            # An errored build is the alarm, whichever commit it was for:
+            # the site is stale from this moment until somebody fixes it.
+            if [ "$status" = "errored" ]; then
+              msg=$(printf '%s' "$latest" | jq -r '.error.message // "no message"')
+              echo "::error title=GitHub Pages build failed::The published site is now stale — it keeps serving the last build that succeeded. Commit ${commit}: ${msg}"
+              exit 1
+            fi
+
+            if [ "$status" = "built" ] && [ "$commit" = "$GITHUB_SHA" ]; then
+              echo "the site serves this commit"
+              exit 0
+            fi
+            sleep 10
+          done
+
+          # Not a failure. A newer push supersedes this one and its build is
+          # the one that matters, and a slow queue is not a broken site — so
+          # the honest outcome here is "not established", said out loud,
+          # rather than a red run that teaches people to ignore this job.
+          echo "::warning title=Pages build not confirmed::No completed Pages build for ${GITHUB_SHA:0:7} within five minutes. Not necessarily a failure — a later push supersedes this one — but nothing here has confirmed the site was published."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,27 +417,46 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-          # Pages starts within seconds of the push and this site builds in
-          # well under a minute; five minutes is a ceiling for a slow queue,
-          # not an expectation.
+          set -uo pipefail
+          # NOT `set -e`. Every failure mode below is a reason to keep
+          # polling or to warn — a 404 because Pages is unconfigured, a 403
+          # or 429 from the rate limiter, a network blip, a malformed body.
+          # With -e the first of those would turn this job red and teach
+          # everyone that a red `pages` means nothing, which is the habit
+          # this job exists to break.
+          #
+          # Pages starts within seconds of the push; five minutes is a
+          # ceiling for a slow queue rather than a claim about build time.
           for _ in $(seq 1 30); do
-            latest=$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest")
-            status=$(printf '%s' "$latest" | jq -r '.status')
-            commit=$(printf '%s' "$latest" | jq -r '.commit')
+            if ! latest=$(gh api "repos/${GITHUB_REPOSITORY}/pages/builds/latest" 2>&1); then
+              echo "pages API did not answer: ${latest}"
+              sleep 10
+              continue
+            fi
+            status=$(printf '%s' "$latest" | jq -r '.status' 2>/dev/null || echo "unreadable")
+            commit=$(printf '%s' "$latest" | jq -r '.commit' 2>/dev/null || echo "")
             echo "pages build: status=${status} commit=${commit:0:7} (want ${GITHUB_SHA:0:7})"
 
-            # An errored build is the alarm, whichever commit it was for:
-            # the site is stale from this moment until somebody fixes it.
-            if [ "$status" = "errored" ]; then
-              msg=$(printf '%s' "$latest" | jq -r '.error.message // "no message"')
-              echo "::error title=GitHub Pages build failed::The published site is now stale — it keeps serving the last build that succeeded. Commit ${commit}: ${msg}"
-              exit 1
-            fi
-
-            if [ "$status" = "built" ] && [ "$commit" = "$GITHUB_SHA" ]; then
-              echo "the site serves this commit"
-              exit 0
+            # Only THIS commit's build fails the run. An errored build for
+            # someone else's commit means the site is stale — which matters,
+            # and is why the warning below says so — but failing the run
+            # that FIXES it would be the worst possible aim: the recovery
+            # push goes red while the broken one went green, because its own
+            # build had not finished yet when its CI looked.
+            if [ "$commit" = "$GITHUB_SHA" ]; then
+              if [ "$status" = "errored" ]; then
+                msg=$(printf '%s' "$latest" | jq -r '.error.message // "no message"' 2>/dev/null || echo "no message")
+                echo "::error title=GitHub Pages build failed::The published site is now stale — it keeps serving the last build that succeeded. Commit ${commit}: ${msg}"
+                exit 1
+              fi
+              if [ "$status" = "built" ]; then
+                echo "the site serves this commit"
+                exit 0
+              fi
+            elif [ "$status" = "errored" ]; then
+              # Not ours, so not our failure — but worth saying while it is
+              # true, because this is exactly the state nobody could see.
+              echo "::warning title=GitHub Pages is currently failing::The most recent Pages build (${commit:0:7}) errored, so the live site is stale until it succeeds again."
             fi
             sleep 10
           done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,10 +416,27 @@ separate is the point:
 - **`docs/guide/` — the documentation.** Ten pages: eight under
   *Guide*, plus a *Reference* pair (CLI flags, keyboard shortcuts).
 
-**Hand-authored static HTML — no generator, no build step.** Pages
-serves `docs/` verbatim, so what is in the repo is what ships. Don't
-introduce a toolchain without a reason bigger than "it would be
-tidier".
+**Hand-authored static HTML — no generator of ours, and no build step we
+wrote.** Don't introduce a toolchain without a reason bigger than "it
+would be tidier".
+
+But *"Pages serves `docs/` verbatim"*, which this file claimed until
+2026-09-12, **is not true** and the difference has already cost twenty-two
+hours of a stale site. Pages is configured as `build_type: legacy`
+(measured), so it runs **Jekyll** over `docs/` on every push to `main`:
+Liquid is evaluated before anything is served. That is how a markdown
+sample containing `{{` in `docs/design/` failed the whole publish seven
+times in a row in August 2026, and how `${{ secrets.NAME }}` in prose
+renders as empty text rather than as itself. `docs/_config.yml` excludes
+`design/` as a patch on a build the project does not want.
+
+Two things follow. The CI `pages` job now **alarms** when a build errors,
+so a stale site stops being invisible; and the real fix — publishing
+through `upload-pages-artifact` + `deploy-pages`, which removes Jekyll
+from the path and makes this paragraph true again — is a repository
+settings change and is tracked in
+[#122](https://github.com/gfazioli/octoscope/issues/122). Until then,
+assume markdown under `docs/` passes through Liquid.
 
 **The README stays canonical.** The guide is the narrative version;
 the README is the reference an outside reader hits first on GitHub.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,12 +423,23 @@ would be tidier".
 But *"Pages serves `docs/` verbatim"*, which this file claimed until
 2026-09-12, **is not true** and the difference has already cost twenty-two
 hours of a stale site. Pages is configured as `build_type: legacy`
-(measured), so it runs **Jekyll** over `docs/` on every push to `main`:
-Liquid is evaluated before anything is served. That is how a markdown
-sample containing `{{` in `docs/design/` failed the whole publish seven
-times in a row in August 2026, and how `${{ secrets.NAME }}` in prose
-renders as empty text rather than as itself. `docs/_config.yml` excludes
-`design/` as a patch on a build the project does not want.
+(measured), so it runs **Jekyll** over `docs/` on every push to `main`.
+
+The mechanism is worth having right, because the obvious reading of Jekyll
+says it cannot happen: a file without front matter is a static file, and
+nothing under `docs/` has front matter. GitHub Pages is not vanilla Jekyll
+— it loads **`jekyll-optional-front-matter`** by default (0.3.2 against
+Jekyll 3.10.0, read from <https://pages.github.com/versions.json> on
+2026-09-12), and that plugin turns a front-matter-less markdown file into a
+page. So Liquid *does* run over the markdown here, which is how a sample
+containing `{{` in `docs/design/` failed the whole publish seven times in a
+row in August 2026. `docs/_config.yml` excludes `design/` as a patch on a
+build the project does not want.
+
+The HTML under `docs/` and `docs/guide/` is unaffected — that plugin only
+touches markdown — but a `${{ … }}` written in any markdown served from
+here is Liquid, not text (it renders as a bare `$`, the braces being
+consumed).
 
 Two things follow. The CI `pages` job now **alarms** when a build errors,
 so a stale site stops being invisible; and the real fix — publishing
@@ -436,7 +447,7 @@ through `upload-pages-artifact` + `deploy-pages`, which removes Jekyll
 from the path and makes this paragraph true again — is a repository
 settings change and is tracked in
 [#122](https://github.com/gfazioli/octoscope/issues/122). Until then,
-assume markdown under `docs/` passes through Liquid.
+markdown under `docs/` passes through Liquid — HTML does not.
 
 **The README stays canonical.** The guide is the narrative version;
 the README is the reference an outside reader hits first on GitHub.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,15 @@
 # on GitHub (the guide links it at blob/main/...), never served as a page.
 # It is also full of GitHub Actions expressions — `${{ secrets.NAME }}`,
 # `toJSON(secrets)` — and Jekyll runs Liquid over markdown *before*
-# rendering it, so `{{` opens a Liquid variable. Most of those merely
+# rendering it, so `{{` opens a Liquid variable.
+#
+# Which should not happen to a file with no front matter, and does here
+# because GitHub Pages is not vanilla Jekyll: it loads
+# jekyll-optional-front-matter by default (0.3.2, per
+# https://pages.github.com/versions.json), and that plugin makes a
+# front-matter-less markdown file a page. Worth writing down — reading
+# Jekyll's own documentation would say this document is copied through
+# untouched. Most of those merely
 # render empty, silently corrupting the text. One does worse:
 #
 #     format('{{Hello {0}!}}', secrets.TOKEN)


### PR DESCRIPTION
Part of #122, which asks for two things. This is the first; the second is a settings change and stays on the issue.

Pages publishes this site by running **Jekyll** over `docs/` on every push to `main` — `build_type: legacy`, measured today — and when that build fails the live site keeps serving the last one that worked. The failure looks exactly like a site that has not changed, which is why seven consecutive failures ran for **twenty-two hours** in August 2026, across two release-prep commits, and were found only by a post-tag check that happened to read the served bytes.

### The job

It polls the Pages build for the pushed commit and has three outcomes, deliberately:

| what it sees | what it does |
| --- | --- |
| `errored` | **fails**, with the API's own message and a line saying the site is stale from now until someone fixes it |
| `built`, this commit | passes |
| nothing resolved in five minutes | **warns**, and passes |

The third row is the one worth arguing about. A later push supersedes this one, and a slow queue is not a broken site — a job that goes red for either is a job people learn to ignore, which is the failure this is supposed to fix, one level up.

### All three paths were exercised before pushing

None of them can be seen until the job runs on `main`, so the script was extracted and driven against a stubbed API:

```
=== built, this commit ===    pages build: status=built commit=4b2c46c (want 4b2c46c)
                              the site serves this commit                       exit=0
=== errored ===               ::error title=GitHub Pages build failed::… Commit deadbeef: Liquid syntax error
                                                                                exit=1
=== unresolved ===            ::warning title=Pages build not confirmed::…      exit=0
```

`actionlint` is clean on both workflows.

### A correction this issue forces

`CLAUDE.md` said *"Pages serves `docs/` verbatim"*. That is what the project believes and **not what happens**: Liquid is evaluated before anything is served, which is how `{{` inside a markdown code sample took the whole site down, and why `${{ secrets.NAME }}` written in prose renders as empty text. `docs/_config.yml` excluding `design/` is a patch on a build step the project does not want.

The file now says what was measured, and names the real fix.

### What is left on #122

Publishing through `upload-pages-artifact` + `deploy-pages` removes Jekyll from the path and makes that paragraph true again — the whole failure class disappears instead of being monitored. It needs the repository's Pages source switched from a branch to "GitHub Actions", which is a settings change on a live site and the maintainer's call, so it is not riding along in this PR.