### PR TITLE
chore(release): prep 0.34.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,14 @@ direct shortcut you can press from inside the menu to skip selection.
   file because the file churns and the subset does not — measured over
   57 lockfile revisions of `axios/axios`, `npm/cli` and `nodejs/undici`,
   the subset moved twice and the same version was never republished.
+  A workspace package is identified by its **name** rather than its
+  location (v0.34.0+), so moving `packages/cli` to `apps/cli` is not a
+  dependency that started running code at install; the recorded baseline
+  says which naming it holds, so upgrading to that version costs one
+  comparison rather than inventing a burst of findings. The read has its
+  own **4 MiB** ceiling (v0.34.0+) instead of sharing the obfuscation
+  analysis's — measured against thirteen real lockfiles, two of them above
+  the old one.
   npm only, and the report says so: pnpm dropped its build declaration
   at lockfileVersion 9 and Yarn never had one, so a repository whose
   only lockfile is theirs gets an explicit line saying its dependency
@@ -593,7 +601,7 @@ Each release also carries the bare executables next to the archives, named
 `octoscope_<version>_<os>-<arch>`, for when unpacking is the awkward part:
 
 ```bash
-VERSION=0.33.0   # or whatever the latest release says
+VERSION=0.34.0   # or whatever the latest release says
 curl -fsSL -o octoscope \
   "https://github.com/gfazioli/octoscope/releases/download/v${VERSION}/octoscope_${VERSION}_linux-amd64" \
   && chmod +x octoscope

--- a/docs/guide/docs.js
+++ b/docs/guide/docs.js
@@ -46,7 +46,7 @@
     var html = '' +
       '<a class="brand" href="../index.html" title="Back to octoscope.dev">' +
       '<span class="glyph">⌖</span><b>octoscope</b>' +
-      '<span class="ver" id="guide-ver">v0.33.0</span></a><nav class="side">';
+      '<span class="ver" id="guide-ver">v0.34.0</span></a><nav class="side">';
     NAV.forEach(function (g) {
       html += '<div class="navgroup"><div class="label">' + g.group + '</div>';
       g.items.forEach(function (it) {

--- a/docs/guide/drill-ins.html
+++ b/docs/guide/drill-ins.html
@@ -98,7 +98,8 @@
         <p>It records the subset rather than the file because the file churns and the subset does not. Measured over the last 20 lockfile revisions of <code>axios/axios</code>, <code>npm/cli</code> and <code>nodejs/undici</code> — 57 in all — the subset moved twice, and the same version was never republished once. That measured base rate is what lets the sharp case carry weight instead of teaching you to skip it.</p>
         <ul>
           <li><b>npm only, and it says so.</b> pnpm dropped its build declaration at lockfileVersion 9 and Yarn never had one, so building on them would ship a rule that decays. A repository whose only lockfile is theirs gets an explicit line saying its dependency surface was <b>not</b> compared.</li>
-          <li>The same goes for no lockfile at all, one too large to read, and a schema octoscope has not measured. Silence would look exactly like nothing running code at install.</li>
+          <li>The same goes for no lockfile at all, one too large to read, and a schema octoscope has not measured. Silence would look exactly like nothing running code at install. <i>Since 0.34.0 "too large" means past <b>4 MiB</b>, the lockfile's own ceiling — measured against thirteen real lockfiles, two of which were above the 1.5 MiB it used to share with the obfuscation analysis.</i></li>
+          <li><b>A workspace package is identified by its name, not its location</b> (0.34.0). Moving <code>packages/cli</code> to <code>apps/cli</code> used to read as one dependency beginning to execute code at install and another stopping — a monorepo reorganisation could produce a burst of them. The first scan after upgrading says it cannot compare the recorded surface, once, rather than inventing that burst.</li>
           <li>octoscope never looks at the registry. The claim is that your dependencies' auto-execute surface <i>changed</i> — never that a dependency is malicious.</li>
         </ul>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1298,7 +1298,7 @@
                      keeps #version-pill, which the release-API fetch
                      below writes its text into. -->
                 <a class="version-link" href="guide/releases.html">
-                    <span class="version-tag" id="version-pill">0.33.0</span>
+                    <span class="version-tag" id="version-pill">0.34.0</span>
                     <span class="version-more">what&rsquo;s new &rarr;</span>
                 </a>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1573,6 +1573,7 @@
                     <div class="feature-label">Integrity over time</div>
                     <h3>Notices what changed, not just what's there</h3>
                     <p>The supply-chain scan records a fingerprint of what auto-executes in a repo, then reports what moved since: a file that appeared, one whose contents changed, a branch tip that stopped being signed, a dependency that started running code at <code class="inline">npm install</code> &mdash; or the same version of one shipping different content. It also maps what a compromise could reach — workflow permissions and triggers, self-hosted runners, deploy keys, off-platform webhooks — and says which checks your token couldn't run.</p>
+                    <p>Since v0.34.0 it is also <strong style="color: var(--text);">quieter about what you did yourself</strong>: a workspace package is identified by its name rather than its location, so moving <code class="inline">packages/cli</code> to <code class="inline">apps/cli</code> is no longer a dependency that started executing code — and the lockfile read has its own 4 MiB budget, measured against real monorepos, two of which were larger than it used to read.</p>
                 </div>
                 <div class="feature w-l">
                     <div class="feature-label">Workflow chains</div>

--- a/internal/ui/whatsnew.go
+++ b/internal/ui/whatsnew.go
@@ -102,7 +102,30 @@ var whatsNew033 = whatsNewEntry{
 	},
 }
 
+var whatsNew034 = whatsNewEntry{
+	headline: "The scan stops reporting things you did not do.",
+	items: []whatsNewItem{
+		{
+			title: "Moving a package is not a package that started running code",
+			desc:  "A workspace was keyed by where it lives, so renaming packages/cli to apps/cli read as one dependency beginning to execute code at install and another stopping. It is keyed by its name now — and the baseline records which key format it holds, so upgrading to this version is not itself reported as a change. That costs one scan.",
+		},
+		{
+			title: "Big monorepo lockfiles are compared again",
+			desc:  "The lockfile read shared the 1.5 MiB cap that bounds obfuscation analysis — a different question. It has its own 4 MiB ceiling now, measured against thirteen real lockfiles: two were above the old one. The axis was weakest exactly where it would have paid most.",
+		},
+		{
+			title: "The same scan reads the same twice",
+			desc:  "Two findings of equal weight on one path came out in whatever order Go's map iteration produced. The report is meant to be run twice and compared by eye, so that order is decided now rather than inherited.",
+		},
+		{
+			title: "Homebrew installs a cask",
+			desc:  "goreleaser deprecated the formula generator, and a cask serves Linux Homebrew as well as macOS. Coming from the formula, the one-time move is: brew uninstall octoscope, then brew install --cask gfazioli/tap/octoscope.",
+		},
+	},
+}
+
 var whatsNew = map[string]whatsNewEntry{
+	"0.34.0": whatsNew034,
 	"0.33.0": whatsNew033,
 	"0.32.0": whatsNew032,
 	// 0.31.1 shows 0.31.0's highlights, on the 0.30.1 precedent below.

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 // showing up only in local builds. Measured before the change:
 // `go build -ldflags "-X main.version=9.9.9-fromtag"` still printed
 // 0.31.0.
-var version = "0.33.0"
+var version = "0.34.0"
 
 // cliOverrides tracks settings the user passed on the command line.
 // Pointers carry "was set" semantics: a nil field means "no CLI


### PR DESCRIPTION
Version surfaces, the what's-new entry, and the two documentation surfaces this cycle earns. **No behaviour changes.**

`main` is not taggable without it: `main.go` and `whatsnew.go` both still said 0.33.0, because none of the seven PRs in this cycle carried release-prep — they were fixes and docs, merged as items rather than as a release. Same situation as v0.22.0, and the same answer: a dedicated prep PR.

### What 0.34.0 is

| | |
| --- | --- |
| #158, #169 | a workspace is identified by its **name**, not its location — and upgrading to this version is not itself reported as a change |
| #159 | the lockfile read gets its own **4 MiB** ceiling, measured against thirteen real lockfiles |
| #157 | equal-weight findings stop shuffling between runs |
| #161 | the baseline's write semantics are documented where a user meets them |
| #142 | Homebrew ships a **cask** instead of a formula |
| #167 | every blob read drops the base64 envelope |
| #122 | a failed Pages deploy stops being invisible (the alarm half) |

### Two gates named what I had missed

Which is exactly what they are for:

- `TestVersionSurfacesAgree` — the README's copy-pasteable `curl` snippet still said `VERSION=0.33.0`. That is the test from #121, and it named the surface rather than just failing.
- `TestWhatsNewEntriesStayShort` — the first entry had five items and rendered 55 lines against a 48-line budget. The two that told the same story (the key change and its migration) are now one item.

### The install instructions deliberately do not change

Until `Formula/octoscope.rb` is removed from the tap — which can only happen **after** the release that first publishes the cask — `brew install gfazioli/tap/octoscope` still resolves to the formula. #165 holds that order, and the what's-new entry carries the one-time move for anyone already installed through it.

**Checks:** `gofmt` clean under the pinned toolchain, all packages pass, `drill-ins.html` parses with no unbalanced tags.