### PR TITLE
docs: the install line is a cask now

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,15 @@ brew install gfazioli/tap/octoscope
 `brew upgrade gfazioli/tap/octoscope` picks up newer versions as they
 ship.
 
+Since v0.34.0 the tap ships a **cask** rather than a formula — the command
+above is unchanged, and it serves Linux Homebrew as well as macOS. If you
+installed before that, the one-time move is:
+
+```bash
+brew uninstall octoscope
+brew install --cask gfazioli/tap/octoscope
+```
+
 ### From source
 
 ```bash

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -28,6 +28,7 @@
           <button class="copy">copy</button>
           <pre><span class="prompt">$ </span>brew install gfazioli/tap/octoscope</pre>
         </div>
+        <p>Since v0.34.0 the tap ships a <b>cask</b> rather than a formula: the command above is unchanged and now serves Linux Homebrew as well as macOS. Installed before that? The one-time move is <code>brew uninstall octoscope</code>, then <code>brew install --cask gfazioli/tap/octoscope</code>.</p>
         <p>Or build from source with a Go 1.25+ toolchain — <code>go install github.com/gfazioli/octoscope@latest</code>.</p>
 
         <p>Since v0.31.0 there are two more ways in. From inside the GitHub CLI:</p>


### PR DESCRIPTION
Step 3 of #165 — and the last one. It could not happen earlier: the order is release → remove the formula from the tap → update the docs.

- v0.34.0 published `Casks/octoscope.rb` ✅
- `Formula/octoscope.rb` removed from `gfazioli/homebrew-tap` ✅ — it had stopped at 0.33.0, and it was what `brew install gfazioli/tap/octoscope` resolved while both files existed
- this PR: the docs

**The command does not change**, which is the part worth stating rather than glossing over: `brew install gfazioli/tap/octoscope` now resolves the cask — verified against the live tap, where `brew install --dry-run` answers `Would install 1 cask`. What changes is that it serves Linux Homebrew as well as macOS, and that anyone already installed through the formula needs the one-time `brew uninstall octoscope` + `brew install --cask …`, because a cask cannot upgrade a formula and cannot even declare a conflict with one — Homebrew removed that in [Homebrew/brew#20499](https://github.com/Homebrew/brew/pull/20499).

Closes #165.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Homebrew installation guidance to note that v0.34.0 uses a cask.
  - Clarified that the existing install command supports both macOS and Linux Homebrew.
  - Added migration steps for installations created before v0.34.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->